### PR TITLE
Fix architecture diagram: wrap processAction scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,15 +24,16 @@ flowchart TB
     subgraph Store["Store"]
         channel["Channel〈Action〉"]
 
-        subgraph Pipeline["Action Pipeline"]
+        subgraph processAction["processAction()"]
             middleware["Middleware Chain"]
             flowHolder{"FlowHolderAction?"}
             toFlow["toFlowAction()"]
             pass["Pass Through"]
-            reducer["Reducer"]
+            catchBlock[".catch { }"]
+            errorProc["ErrorProcessor"]
         end
 
-        errorProc["ErrorProcessor"]
+        reducer["Reducer"]
         stateFlow["StateFlow〈State〉"]
     end
 
@@ -43,8 +44,10 @@ flowchart TB
     flowHolder -->|No| pass
     toFlow --> reducer
     pass --> reducer
-    toFlow -.->|Error| errorProc
-    pass -.->|Error| errorProc
+    middleware -.->|Error| catchBlock
+    toFlow -.->|Error| catchBlock
+    pass -.->|Error| catchBlock
+    catchBlock --> errorProc
     errorProc -.-> reducer
     reducer --> stateFlow
     stateFlow --> observe


### PR DESCRIPTION
## Summary
- Add `processAction()` subgraph containing middleware, flowHolder, errorProcessor
- Reducer is outside processAction (matches code structure)
- Show `.catch {}` block explicitly catching errors from entire chain

## Changes
- **Normal flow** (solid lines): Middleware → FlowHolder → toFlow/Pass → Reducer
- **Error flow** (dotted lines): Any error → `.catch {}` → ErrorProcessor → Reducer

🤖 Generated with [Claude Code](https://claude.com/claude-code)