### PR TITLE
Add StoreLogger for debugging support

### DIFF
--- a/flowdux/src/commonMain/kotlin/io/flowdux/Middleware.kt
+++ b/flowdux/src/commonMain/kotlin/io/flowdux/Middleware.kt
@@ -9,6 +9,7 @@ typealias ActionProcessor<S, A> = suspend FlowCollector<A>.(S, A) -> Unit
 typealias ActionProcessorMap<S, A> = Map<KClass<*>, ActionProcessor<S, A>>
 
 interface Middleware<S : State, A : Action> {
+    val name: String get() = this::class.simpleName ?: "Unknown"
     val processors: ActionProcessorMap<S, A>
 
     fun process(

--- a/flowdux/src/commonMain/kotlin/io/flowdux/StoreLogger.kt
+++ b/flowdux/src/commonMain/kotlin/io/flowdux/StoreLogger.kt
@@ -1,0 +1,21 @@
+package io.flowdux
+
+interface StoreLogger<S : State, A : Action> {
+    fun onActionDispatched(action: A)
+    fun onMiddlewareProcessing(middlewareName: String, action: A)
+    fun onMiddlewaresCompleted(action: A)
+    fun onFlowHolderActionEmitted(action: A)
+    fun onErrorOccurred(throwable: Throwable)
+    fun onErrorHandled(action: A)
+    fun onStateReduced(action: A, previousState: S, newState: S)
+}
+
+class NoOpStoreLogger<S : State, A : Action> : StoreLogger<S, A> {
+    override fun onActionDispatched(action: A) {}
+    override fun onMiddlewareProcessing(middlewareName: String, action: A) {}
+    override fun onMiddlewaresCompleted(action: A) {}
+    override fun onFlowHolderActionEmitted(action: A) {}
+    override fun onErrorOccurred(throwable: Throwable) {}
+    override fun onErrorHandled(action: A) {}
+    override fun onStateReduced(action: A, previousState: S, newState: S) {}
+}

--- a/sample-android/src/main/java/io/flowdux/sample/android/CounterViewModel.kt
+++ b/sample-android/src/main/java/io/flowdux/sample/android/CounterViewModel.kt
@@ -1,14 +1,56 @@
 package io.flowdux.sample.android
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import io.flowdux.StoreLogger
 import io.flowdux.createStore
 
 class CounterViewModel : ViewModel() {
+    companion object {
+        private const val TAG = "CounterStore"
+    }
+
     private val store = createStore(
         initialState = CounterState(),
         reducer = counterReducer,
-        scope = viewModelScope
+        scope = viewModelScope,
+        logger = object : StoreLogger<CounterState, CounterAction> {
+            override fun onActionDispatched(action: CounterAction) {
+                Log.d(TAG, "[DISPATCH] $action")
+            }
+
+            override fun onMiddlewareProcessing(
+                middlewareName: String,
+                action: CounterAction
+            ) {
+                Log.d(TAG, "[MIDDLEWARE] $middlewareName processing $action")
+            }
+
+            override fun onMiddlewaresCompleted(action: CounterAction) {
+                Log.d(TAG, "[MIDDLEWARE_CHAIN] completed with $action")
+            }
+
+            override fun onFlowHolderActionEmitted(action: CounterAction) {
+                Log.d(TAG, "[FLOW_ACTION] emitted $action")
+            }
+
+            override fun onErrorOccurred(throwable: Throwable) {
+                Log.e(TAG, "[ERROR] ${throwable.message}", throwable)
+            }
+
+            override fun onErrorHandled(action: CounterAction) {
+                Log.d(TAG, "[ERROR_HANDLED] $action")
+            }
+
+            override fun onStateReduced(
+                action: CounterAction,
+                previousState: CounterState,
+                newState: CounterState
+            ) {
+                Log.d(TAG, "[REDUCE] $action: $previousState -> $newState")
+            }
+        }
     )
 
     val state = store.state


### PR DESCRIPTION
## Summary
- Add `StoreLogger` interface for external logging injection into Store
- Add `name` property to `Middleware` interface for identification in logs
- Integrate logging hooks throughout Store's action processing pipeline
- Add sample logging implementation in `CounterViewModel`

## Logging Events
| Event | Description |
|-------|-------------|
| `onActionDispatched` | When action is dispatched |
| `onMiddlewareProcessing` | Before each middleware processes action |
| `onMiddlewaresCompleted` | After middleware chain completes |
| `onFlowHolderActionEmitted` | When FlowHolderAction emits action |
| `onErrorOccurred` | When error is caught |
| `onErrorHandled` | When errorProcessor emits recovery action |
| `onStateReduced` | After state is reduced |

## Test plan
- [x] Existing tests pass
- [ ] Verify logging output in sample-android app

🤖 Generated with [Claude Code](https://claude.com/claude-code)