### PR TITLE
Add close() method to Store

### DIFF
--- a/flowdux/src/commonMain/kotlin/io/flowdux/Store.kt
+++ b/flowdux/src/commonMain/kotlin/io/flowdux/Store.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
@@ -77,6 +78,11 @@ class Store<S : State, A : Action>(
         scope.launch {
             actionFlow.send(action)
         }
+    }
+
+    fun close() {
+        actionFlow.close()
+        scope.cancel()
     }
 
     private suspend fun reduceAction(currentState: S, action: A): S {


### PR DESCRIPTION
## Summary
- Add `close()` method to Store for explicit scope cancellation
- Closes action channel and cancels coroutine scope

## Usage
```kotlin
val store = createStore(...)

// When done
store.close()
```

## Test plan
- [x] `close cancels scope and stops processing actions`
- [x] `close stops FlowHolderAction stream collection`
- [x] `close can be called multiple times safely`

🤖 Generated with [Claude Code](https://claude.com/claude-code)