### PR TITLE
Fix middleware to pass through unregistered actions

### DIFF
--- a/flowdux/src/commonMain/kotlin/io/flowdux/Middleware.kt
+++ b/flowdux/src/commonMain/kotlin/io/flowdux/Middleware.kt
@@ -16,7 +16,12 @@ interface Middleware<S : State, A : Action> {
         getState: () -> S,
         action: A,
     ): Flow<A> = flow {
-        processors[action::class]?.invoke(this, getState(), action)
+        val processor = processors[action::class]
+        if (processor != null) {
+            processor.invoke(this, getState(), action)
+        } else {
+            emit(action)
+        }
     }
 
     class ActionProcessorBuilder<S, A> {


### PR DESCRIPTION
## Summary
Fix bug where actions not registered with `on` in middleware were dropped and never reached the reducer.

## Problem
```kotlin
// Before: unregistered actions were silently dropped
fun process(...): Flow<A> = flow {
    processors[action::class]?.invoke(this, getState(), action)
    // If no processor found → nothing emitted → action lost!
}
```

## Solution
```kotlin
// After: unregistered actions pass through
fun process(...): Flow<A> = flow {
    val processor = processors[action::class]
    if (processor != null) {
        processor.invoke(this, getState(), action)
    } else {
        emit(action)  // passthrough
    }
}
```

## Test plan
- [x] `middleware passes through unregistered actions to reducer`
- [x] `multiple middlewares pass through unregistered actions`
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)