### PR TITLE
Release 1.2.1.1

### DIFF
--- a/flowdux/build.gradle.kts
+++ b/flowdux/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "io.flowdux"
-version = "1.2.1"
+version = "1.2.1.1"
 
 kotlin {
     jvm()


### PR DESCRIPTION
## Summary
- Bump version to 1.2.1.1
- Retry JitPack build (1.2.1 had timeout issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)