### PR TITLE
Fix inconsistent variable naming in Middleware.kt

### DIFF
--- a/flowdux/src/commonMain/kotlin/io/flowdux/Middleware.kt
+++ b/flowdux/src/commonMain/kotlin/io/flowdux/Middleware.kt
@@ -65,10 +65,10 @@ interface Middleware<S : State, A : Action> {
             strategy: ExecutionStrategy,
             noinline processor: suspend FlowCollector<A>.() -> Unit
         ) {
-            val wrappedProcessor: suspend FlowCollector<A>.(S, T) -> Unit = { _, _ -> processor() }
-            val wrapped = strategy.wrap(wrappedProcessor)
+            val baseProcessor: suspend FlowCollector<A>.(S, T) -> Unit = { _, _ -> processor() }
+            val wrappedProcessor = strategy.wrap(baseProcessor)
             @Suppress("UNCHECKED_CAST")
-            processors[T::class] = wrapped as ActionProcessor<S, A>
+            processors[T::class] = wrappedProcessor as ActionProcessor<S, A>
         }
 
         fun build() = processors.toMap()


### PR DESCRIPTION
## Summary
- Fix inconsistent variable naming in the strategy-based `on()` overload

## Changes
```kotlin
// Before
val wrappedProcessor: suspend FlowCollector<A>.(S, T) -> Unit = { _, _ -> processor() }
val wrapped = strategy.wrap(wrappedProcessor)
processors[T::class] = wrapped as ActionProcessor<S, A>

// After
val baseProcessor: suspend FlowCollector<A>.(S, T) -> Unit = { _, _ -> processor() }
val wrappedProcessor = strategy.wrap(baseProcessor)
processors[T::class] = wrappedProcessor as ActionProcessor<S, A>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)