### PR TITLE
Add strategy group DSL and duplicate processor validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ A lightweight Redux-style state management library for Kotlin Multiplatform with
 
 - Redux-style state management with Reducer pattern
 - Middleware support for side effects
+- Execution strategies (takeLatest, takeLeading, debounce, throttle)
+- Strategy groups for cross-action coordination
 - Error handling with ErrorProcessor
 - Built on Kotlin Coroutines and Flow
 - Kotlin Multiplatform support (JVM, iOS)
@@ -56,6 +58,7 @@ flowchart TB
 | Component | Role |
 |-----------|------|
 | **Middleware** | Side effects (API calls, logging), action transformation |
+| **ExecutionStrategy** | Control concurrent action processing (takeLatest, debounce, etc.) |
 | **FlowHolderAction** | Convert existing Flow to Action stream |
 | **ErrorProcessor** | Catch errors and convert to Actions |
 | **Reducer** | Pure function: (State, Action) → NewState |
@@ -266,6 +269,41 @@ on<FetchProduct>(takeLatest("product")) { state, action ->
 }
 ```
 
+### Strategy Groups
+
+Use `group` to share a strategy instance across multiple action types. Actions within the same group will coordinate their execution (e.g., one action can cancel another):
+
+```kotlin
+class SearchMiddleware : Middleware<AppState, AppAction> {
+    override val processors = buildProcessors {
+        // SearchAction and RefreshAction share the same takeLatest instance
+        // Dispatching RefreshAction will cancel an in-progress SearchAction
+        group(takeLatest("search")) {
+            on<SearchAction> { state, action ->
+                val results = searchApi.search(action.query)
+                emit(SearchResults(results))
+            }
+            on<RefreshAction> { state, action ->
+                val results = searchApi.refresh()
+                emit(SearchResults(results))
+            }
+        }
+
+        // Debounce across multiple input types
+        group(debounce(300.milliseconds)) {
+            on<TextChanged> { state, action ->
+                emit(ValidateInput(action.text))
+            }
+            on<FilterChanged> { state, action ->
+                emit(ApplyFilter(action.filter))
+            }
+        }
+    }
+}
+```
+
+**Important:** Each action type can only be registered once per middleware. Duplicate registrations will throw `DuplicateProcessorException`.
+
 ## Sample Apps
 
 ### Run JVM Console Sample
@@ -310,6 +348,13 @@ State: count = 42 [api]
     [takeLeading] Processing form submission...
     [takeLeading] Form submitted!
   Result: Only first submission processed, others ignored!
+
+> Strategy Group: LoadUser and RefreshUser share takeLatest
+  Dispatching LoadUser, then RefreshUser (cancels LoadUser)...
+    [group] Loading user: 123
+    [group] Refreshing user...
+    [group] User refreshed!
+  Result: LoadUser was canceled, only RefreshUser completed!
 ```
 
 ### Build Android Sample

--- a/flowdux/src/commonMain/kotlin/io/flowdux/Middleware.kt
+++ b/flowdux/src/commonMain/kotlin/io/flowdux/Middleware.kt
@@ -24,12 +24,29 @@ interface Middleware<S : State, A : Action> {
         }
     }
 
+    /**
+     * Exception thrown when attempting to register a duplicate action processor.
+     */
+    class DuplicateProcessorException(actionClass: KClass<*>) : IllegalArgumentException(
+        "Processor for action type '${actionClass.simpleName}' is already registered. " +
+            "Each action type can only have one processor per middleware."
+    )
+
     class ActionProcessorBuilder<S, A> {
-        val processors = mutableMapOf<KClass<*>, ActionProcessor<S, A>>()
+        @PublishedApi
+        internal val processors = mutableMapOf<KClass<*>, ActionProcessor<S, A>>()
+
+        @PublishedApi
+        internal fun checkDuplicate(actionClass: KClass<*>) {
+            if (actionClass in processors) {
+                throw DuplicateProcessorException(actionClass)
+            }
+        }
 
         inline fun <reified T : A> on(
             noinline processor: suspend FlowCollector<A>.(state: S, action: T) -> Unit
         ) {
+            checkDuplicate(T::class)
             @Suppress("UNCHECKED_CAST")
             processors[T::class] = processor as ActionProcessor<S, A>
         }
@@ -37,6 +54,7 @@ interface Middleware<S : State, A : Action> {
         inline fun <reified T : A> on(
             noinline processor: suspend FlowCollector<A>.() -> Unit
         ) {
+            checkDuplicate(T::class)
             processors[T::class] = { _, _ -> processor() }
         }
 
@@ -50,6 +68,7 @@ interface Middleware<S : State, A : Action> {
             strategy: ExecutionStrategy,
             noinline processor: suspend FlowCollector<A>.(state: S, action: T) -> Unit
         ) {
+            checkDuplicate(T::class)
             val wrappedProcessor = strategy.wrap(processor)
             @Suppress("UNCHECKED_CAST")
             processors[T::class] = wrappedProcessor as ActionProcessor<S, A>
@@ -65,13 +84,74 @@ interface Middleware<S : State, A : Action> {
             strategy: ExecutionStrategy,
             noinline processor: suspend FlowCollector<A>.() -> Unit
         ) {
+            checkDuplicate(T::class)
             val baseProcessor: suspend FlowCollector<A>.(S, T) -> Unit = { _, _ -> processor() }
             val wrappedProcessor = strategy.wrap(baseProcessor)
             @Suppress("UNCHECKED_CAST")
             processors[T::class] = wrappedProcessor as ActionProcessor<S, A>
         }
 
+        /**
+         * Groups multiple action processors under a shared execution strategy.
+         * Actions within the same group share the strategy's state (e.g., cancellation, throttling).
+         *
+         * Example:
+         * ```
+         * group(takeLatest("search")) {
+         *     on<SearchAction> { state, action -> ... }
+         *     on<RefreshAction> { state, action -> ... }
+         * }
+         * ```
+         *
+         * @param strategy The shared execution strategy for all processors in this group
+         * @param block The builder block to register processors
+         */
+        fun group(strategy: ExecutionStrategy, block: StrategyGroupBuilder<S, A>.() -> Unit) {
+            StrategyGroupBuilder(strategy, processors).apply(block)
+        }
+
         fun build() = processors.toMap()
+    }
+
+    /**
+     * Builder for registering action processors within a strategy group.
+     * All processors registered here share the same strategy instance.
+     */
+    class StrategyGroupBuilder<S, A>(
+        @PublishedApi internal val strategy: ExecutionStrategy,
+        @PublishedApi internal val processors: MutableMap<KClass<*>, ActionProcessor<S, A>>
+    ) {
+        @PublishedApi
+        internal fun checkDuplicate(actionClass: KClass<*>) {
+            if (actionClass in processors) {
+                throw DuplicateProcessorException(actionClass)
+            }
+        }
+
+        /**
+         * Registers an action processor that shares this group's execution strategy.
+         */
+        inline fun <reified T : A> on(
+            noinline processor: suspend FlowCollector<A>.(state: S, action: T) -> Unit
+        ) {
+            checkDuplicate(T::class)
+            val wrappedProcessor = strategy.wrap(processor)
+            @Suppress("UNCHECKED_CAST")
+            processors[T::class] = wrappedProcessor as ActionProcessor<S, A>
+        }
+
+        /**
+         * Registers an action processor (no parameters) that shares this group's execution strategy.
+         */
+        inline fun <reified T : A> on(
+            noinline processor: suspend FlowCollector<A>.() -> Unit
+        ) {
+            checkDuplicate(T::class)
+            val baseProcessor: suspend FlowCollector<A>.(S, T) -> Unit = { _, _ -> processor() }
+            val wrappedProcessor = strategy.wrap(baseProcessor)
+            @Suppress("UNCHECKED_CAST")
+            processors[T::class] = wrappedProcessor as ActionProcessor<S, A>
+        }
     }
 
     fun buildProcessors(

--- a/flowdux/src/jvmTest/kotlin/io/flowdux/ExecutionStrategyTest.kt
+++ b/flowdux/src/jvmTest/kotlin/io/flowdux/ExecutionStrategyTest.kt
@@ -476,4 +476,267 @@ class ExecutionStrategyTest {
             }
         }
     }
+
+    @Nested
+    inner class StrategyGroupTests {
+
+        @Test
+        fun `group shares strategy instance across different action types`() = runTest {
+            val executionOrder = mutableListOf<String>()
+
+            val middleware = object : Middleware<TestState, TestAction> {
+                override val processors = buildProcessors {
+                    // Both Fetch and Search share the same takeLatest instance
+                    group(takeLatest("shared")) {
+                        on<TestAction.Fetch> { _, action ->
+                            executionOrder.add("fetch-start-${action.id}")
+                            delay(100)
+                            executionOrder.add("fetch-end-${action.id}")
+                            emit(TestAction.FetchSuccess(action.id, "result-${action.id}"))
+                        }
+                        on<TestAction.Search> { _, action ->
+                            executionOrder.add("search-start-${action.query}")
+                            delay(100)
+                            executionOrder.add("search-end-${action.query}")
+                            emit(TestAction.SearchResult(action.query, listOf(action.query)))
+                        }
+                    }
+                }
+            }
+
+            val store = createStore(
+                initialState = TestState(),
+                reducer = testReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
+
+            store.state.test {
+                assertEquals(emptyList<String>(), awaitItem().values)
+
+                // Dispatch Fetch, then Search should cancel Fetch
+                store.dispatch(TestAction.Fetch("1"))
+                advanceTimeBy(50) // Let Fetch start
+
+                store.dispatch(TestAction.Search("query"))
+                advanceTimeBy(150) // Let Search complete
+
+                // Only Search should complete
+                val result = awaitItem()
+                assertEquals(listOf("query"), result.values)
+
+                // Verify Fetch was started but canceled
+                assertTrue(executionOrder.contains("fetch-start-1"))
+                assertFalse(executionOrder.contains("fetch-end-1"))
+                assertTrue(executionOrder.contains("search-end-query"))
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+        @Test
+        fun `group with takeLeading blocks across different action types`() = runTest {
+            val executionOrder = mutableListOf<String>()
+
+            val middleware = object : Middleware<TestState, TestAction> {
+                override val processors = buildProcessors {
+                    group(takeLeading("shared")) {
+                        on<TestAction.Fetch> { _, action ->
+                            executionOrder.add("fetch-${action.id}")
+                            delay(100)
+                            emit(TestAction.FetchSuccess(action.id, action.id))
+                        }
+                        on<TestAction.Search> { _, action ->
+                            executionOrder.add("search-${action.query}")
+                            delay(100)
+                            emit(TestAction.SearchResult(action.query, listOf(action.query)))
+                        }
+                    }
+                }
+            }
+
+            val store = createStore(
+                initialState = TestState(),
+                reducer = testReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
+
+            store.state.test {
+                assertEquals(emptyList<String>(), awaitItem().values)
+
+                // Dispatch Fetch, then Search should be ignored
+                store.dispatch(TestAction.Fetch("1"))
+                advanceTimeBy(50)
+                store.dispatch(TestAction.Search("query")) // Should be ignored
+
+                advanceTimeBy(100)
+                awaitItem()
+
+                // Only Fetch should execute
+                assertEquals(listOf("fetch-1"), executionOrder)
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+        @Test
+        fun `separate groups have independent strategies`() = runTest {
+            val groupAExecutions = mutableListOf<String>()
+            val groupBExecutions = mutableListOf<String>()
+
+            val middleware = object : Middleware<TestState, TestAction> {
+                override val processors = buildProcessors {
+                    group(takeLatest("groupA")) {
+                        on<TestAction.Fetch> { _, action ->
+                            delay(50)
+                            groupAExecutions.add(action.id)
+                            emit(TestAction.FetchSuccess(action.id, action.id))
+                        }
+                    }
+                    group(takeLatest("groupB")) {
+                        on<TestAction.Search> { _, action ->
+                            delay(50)
+                            groupBExecutions.add(action.query)
+                            emit(TestAction.SearchResult(action.query, listOf(action.query)))
+                        }
+                    }
+                }
+            }
+
+            val store = createStore(
+                initialState = TestState(),
+                reducer = testReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
+
+            store.state.test {
+                assertEquals(emptyList<String>(), awaitItem().values)
+
+                // Dispatch to both groups - they should not affect each other
+                store.dispatch(TestAction.Fetch("f1"))
+                store.dispatch(TestAction.Search("s1"))
+
+                // Cancel within each group
+                advanceTimeBy(25)
+                store.dispatch(TestAction.Fetch("f2"))
+                store.dispatch(TestAction.Search("s2"))
+
+                advanceTimeBy(100)
+                awaitItem()
+                awaitItem()
+
+                // Only latest from each group
+                assertEquals(listOf("f2"), groupAExecutions)
+                assertEquals(listOf("s2"), groupBExecutions)
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+        @Test
+        fun `group with debounce resets timer across different action types`() = runTest {
+            val executionOrder = mutableListOf<String>()
+
+            val middleware = object : Middleware<TestState, TestAction> {
+                override val processors = buildProcessors {
+                    group(debounce(100.milliseconds)) {
+                        on<TestAction.Fetch> { _, action ->
+                            executionOrder.add("fetch-${action.id}")
+                            emit(TestAction.FetchSuccess(action.id, action.id))
+                        }
+                        on<TestAction.Search> { _, action ->
+                            executionOrder.add("search-${action.query}")
+                            emit(TestAction.SearchResult(action.query, listOf(action.query)))
+                        }
+                    }
+                }
+            }
+
+            val store = createStore(
+                initialState = TestState(),
+                reducer = testReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
+
+            store.state.test {
+                assertEquals(emptyList<String>(), awaitItem().values)
+
+                // Dispatch Fetch, then Search before debounce completes
+                // Search should reset the debounce timer, canceling Fetch
+                store.dispatch(TestAction.Fetch("1"))
+                advanceTimeBy(50)
+                store.dispatch(TestAction.Search("query")) // Resets debounce
+
+                advanceTimeBy(150) // Wait for debounce to complete
+                awaitItem()
+
+                // Only Search should execute (Fetch was canceled by debounce reset)
+                assertEquals(listOf("search-query"), executionOrder)
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+        @Test
+        fun `group with throttle limits rate across different action types`() = runBlocking {
+            val executionOrder = mutableListOf<String>()
+            val storeScope = CoroutineScope(Dispatchers.Default + Job())
+
+            val middleware = object : Middleware<TestState, TestAction> {
+                override val processors = buildProcessors {
+                    group(throttle(100.milliseconds)) {
+                        on<TestAction.Fetch> { _, action ->
+                            executionOrder.add("fetch-${action.id}")
+                            emit(TestAction.FetchSuccess(action.id, action.id))
+                        }
+                        on<TestAction.Search> { _, action ->
+                            executionOrder.add("search-${action.query}")
+                            emit(TestAction.SearchResult(action.query, listOf(action.query)))
+                        }
+                    }
+                }
+            }
+
+            val store = createStore(
+                initialState = TestState(),
+                reducer = testReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = testErrorProcessor,
+                scope = storeScope,
+            )
+
+            try {
+                store.state.test {
+                    assertEquals(emptyList<String>(), awaitItem().values)
+
+                    // First action executes immediately
+                    store.dispatch(TestAction.Fetch("1"))
+                    awaitItem()
+
+                    // Second action (different type) within throttle window - should be ignored
+                    delay(30)
+                    store.dispatch(TestAction.Search("query"))
+
+                    // Third action after throttle window - should execute
+                    delay(100)
+                    store.dispatch(TestAction.Search("query2"))
+                    awaitItem()
+
+                    // Only first and third should execute
+                    assertEquals(listOf("fetch-1", "search-query2"), executionOrder)
+
+                    cancelAndIgnoreRemainingEvents()
+                }
+            } finally {
+                storeScope.cancel()
+            }
+        }
+    }
 }

--- a/flowdux/src/jvmTest/kotlin/io/flowdux/MiddlewareTest.kt
+++ b/flowdux/src/jvmTest/kotlin/io/flowdux/MiddlewareTest.kt
@@ -308,4 +308,46 @@ class MiddlewareTest {
                 cancelAndIgnoreRemainingEvents()
             }
         }
+
+    @Test
+    fun `duplicate processor registration throws exception`() {
+        org.junit.jupiter.api.assertThrows<Middleware.DuplicateProcessorException> {
+            object : Middleware<CounterState, CounterAction> {
+                override val processors = buildProcessors {
+                    on<CounterAction.Increment> { _, _ -> emit(CounterAction.Increment) }
+                    on<CounterAction.Increment> { _, _ -> emit(CounterAction.Increment) } // Duplicate!
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `duplicate processor in group throws exception`() {
+        org.junit.jupiter.api.assertThrows<Middleware.DuplicateProcessorException> {
+            object : Middleware<CounterState, CounterAction> {
+                override val processors = buildProcessors {
+                    on<CounterAction.Increment> { _, _ -> emit(CounterAction.Increment) }
+                    group(takeLatest("test")) {
+                        on<CounterAction.Increment> { _, _ -> emit(CounterAction.Increment) } // Duplicate!
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `duplicate processor across groups throws exception`() {
+        org.junit.jupiter.api.assertThrows<Middleware.DuplicateProcessorException> {
+            object : Middleware<CounterState, CounterAction> {
+                override val processors = buildProcessors {
+                    group(takeLatest("group1")) {
+                        on<CounterAction.Increment> { _, _ -> emit(CounterAction.Increment) }
+                    }
+                    group(takeLatest("group2")) {
+                        on<CounterAction.Increment> { _, _ -> emit(CounterAction.Increment) } // Duplicate!
+                    }
+                }
+            }
+        }
+    }
 }

--- a/sample-jvm/src/main/kotlin/io/flowdux/sample/Main.kt
+++ b/sample-jvm/src/main/kotlin/io/flowdux/sample/Main.kt
@@ -49,6 +49,11 @@ sealed interface CounterAction : Action {
     data class FetchSuccess(val id: String, val value: Int) : CounterAction
     object SubmitForm : CounterAction
     object SubmitSuccess : CounterAction
+
+    // Strategy Group Examples
+    data class LoadUser(val userId: String) : CounterAction
+    object RefreshUser : CounterAction
+    data class UserLoaded(val userName: String) : CounterAction
 }
 
 // Simulated Search API
@@ -84,6 +89,23 @@ class ExecutionStrategyMiddleware : Middleware<CounterState, CounterAction> {
             println("    [takeLeading] Form submitted!")
             emit(CounterAction.SubmitSuccess)
         }
+
+        // Strategy Group: Different action types share the same strategy instance
+        // LoadUser and RefreshUser will cancel each other
+        group(takeLatest("user-data")) {
+            on<CounterAction.LoadUser> { _, action ->
+                println("    [group] Loading user: ${action.userId}")
+                delay(300) // Simulate API call
+                println("    [group] User loaded: ${action.userId}")
+                emit(CounterAction.UserLoaded("User-${action.userId}"))
+            }
+            on<CounterAction.RefreshUser> { _, _ ->
+                println("    [group] Refreshing user...")
+                delay(300) // Simulate API call
+                println("    [group] User refreshed!")
+                emit(CounterAction.UserLoaded("RefreshedUser"))
+            }
+        }
     }
 }
 
@@ -112,6 +134,9 @@ val counterReducer = buildReducer<CounterState, CounterAction> {
     }
     on<CounterAction.SubmitSuccess> { state, _ ->
         state.copy(source = "submitted")
+    }
+    on<CounterAction.UserLoaded> { state, action ->
+        state.copy(source = action.userName)
     }
 }
 
@@ -202,6 +227,15 @@ fun main() {
         store.dispatch(CounterAction.SubmitForm) // ignored
         delay(600) // Wait for submission to complete
         println("  Result: Only first submission processed, others ignored!")
+
+        // Strategy Group Example: Different action types share same strategy
+        println("\n> Strategy Group: LoadUser and RefreshUser share takeLatest")
+        println("  Dispatching LoadUser, then RefreshUser (cancels LoadUser)...")
+        store.dispatch(CounterAction.LoadUser("123"))
+        delay(100) // Let LoadUser start
+        store.dispatch(CounterAction.RefreshUser) // Cancels LoadUser
+        delay(400) // Wait for RefreshUser to complete
+        println("  Result: LoadUser was canceled, only RefreshUser completed!")
 
         println("\n" + "=".repeat(50))
         println("=== Done ===")


### PR DESCRIPTION
## Summary
- Add `group()` DSL for sharing execution strategy across different action types
- Add `DuplicateProcessorException` for duplicate action type registration
- Update Features and Component table in README

## Strategy Group DSL
```kotlin
buildProcessors {
    group(takeLatest("user-data")) {
        on<LoadUser> { ... }
        on<RefreshUser> { ... }  // Cancels LoadUser if in progress
    }
}
```

## Tests Added
- Strategy group tests (takeLatest, takeLeading, debounce, throttle)
- Duplicate processor validation tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)