### PR TITLE
Split createTimeTravelStore into two overloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,8 +277,7 @@ val store = createTimeTravelStore(
     initialState = CounterState(),
     reducer = counterReducer,
     middlewares = listOf(LoggingMiddleware()),
-    maxHistorySize = 100,       // Optional: limit history size (default: 100)
-    initialHistory = null       // Optional: restore from saved history
+    maxHistorySize = 100        // Optional: limit history size (default: 100)
 )
 
 // Use like a regular store
@@ -316,7 +315,7 @@ store.clear()
 
 **Restoring History:**
 
-You can restore a previous session's history using `initialHistory`:
+You can restore a previous session's history using a separate overload:
 
 ```kotlin
 // Save history (e.g., to JSON)
@@ -324,9 +323,8 @@ val savedHistory = store.history
 
 // Later, restore from saved history
 val restoredStore = createTimeTravelStore(
-    initialState = CounterState(),  // Fallback if history is empty
-    reducer = counterReducer,
-    initialHistory = savedHistory   // Restores state and history
+    initialHistory = savedHistory,  // Restores state and history
+    reducer = counterReducer
 )
 // restoredStore starts at the last state in savedHistory
 ```

--- a/flowdux-timetravel/src/commonMain/kotlin/io/flowdux/timetravel/TimeTravelStore.kt
+++ b/flowdux-timetravel/src/commonMain/kotlin/io/flowdux/timetravel/TimeTravelStore.kt
@@ -21,8 +21,8 @@ import kotlinx.datetime.Clock
 
 class TimeTravelStore<S : State, A : Action> internal constructor(
     private val innerStore: Store<S, A>,
-    initialState: S,
     private val maxHistorySize: Int,
+    initialState: S?,
     initialHistory: List<StateSnapshot<S, A>>?,
 ) {
     private val mutex = Mutex()
@@ -44,23 +44,27 @@ class TimeTravelStore<S : State, A : Action> internal constructor(
     val canRedo: Boolean get() = _currentIndex < _history.size - 1
 
     init {
-        if (initialHistory.isNullOrEmpty()) {
-            _history.add(
-                StateSnapshot(
-                    index = 0,
-                    action = null,
-                    previousState = null,
-                    currentState = initialState,
-                    timestamp = currentTimeMillis()
+        when {
+            !initialHistory.isNullOrEmpty() -> {
+                _history.addAll(initialHistory.mapIndexed { idx, snapshot ->
+                    snapshot.copy(index = idx)
+                })
+                _currentIndex = _history.size - 1
+                _state = MutableStateFlow(_history.last().currentState)
+            }
+            initialState != null -> {
+                _history.add(
+                    StateSnapshot(
+                        index = 0,
+                        action = null,
+                        previousState = null,
+                        currentState = initialState,
+                        timestamp = currentTimeMillis()
+                    )
                 )
-            )
-            _state = MutableStateFlow(initialState)
-        } else {
-            _history.addAll(initialHistory.mapIndexed { idx, snapshot ->
-                snapshot.copy(index = idx)
-            })
-            _currentIndex = _history.size - 1
-            _state = MutableStateFlow(_history.last().currentState)
+                _state = MutableStateFlow(initialState)
+            }
+            else -> error("Either initialState or initialHistory must be provided")
         }
     }
 
@@ -148,8 +152,45 @@ fun <S : State, A : Action> createTimeTravelStore(
     middlewares: List<Middleware<S, A>> = emptyList(),
     errorProcessor: ErrorProcessor<A> = DefaultErrorProcessor(),
     maxHistorySize: Int = 100,
-    initialHistory: List<StateSnapshot<S, A>>? = null,
     scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+): TimeTravelStore<S, A> = createTimeTravelStoreInternal(
+    initialState = initialState,
+    initialHistory = null,
+    reducer = reducer,
+    middlewares = middlewares,
+    errorProcessor = errorProcessor,
+    maxHistorySize = maxHistorySize,
+    scope = scope,
+)
+
+fun <S : State, A : Action> createTimeTravelStore(
+    initialHistory: List<StateSnapshot<S, A>>,
+    reducer: Reducer<S, A>,
+    middlewares: List<Middleware<S, A>> = emptyList(),
+    errorProcessor: ErrorProcessor<A> = DefaultErrorProcessor(),
+    maxHistorySize: Int = 100,
+    scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+): TimeTravelStore<S, A> {
+    require(initialHistory.isNotEmpty()) { "initialHistory must not be empty" }
+    return createTimeTravelStoreInternal(
+        initialState = null,
+        initialHistory = initialHistory,
+        reducer = reducer,
+        middlewares = middlewares,
+        errorProcessor = errorProcessor,
+        maxHistorySize = maxHistorySize,
+        scope = scope,
+    )
+}
+
+private fun <S : State, A : Action> createTimeTravelStoreInternal(
+    initialState: S?,
+    initialHistory: List<StateSnapshot<S, A>>?,
+    reducer: Reducer<S, A>,
+    middlewares: List<Middleware<S, A>>,
+    errorProcessor: ErrorProcessor<A>,
+    maxHistorySize: Int,
+    scope: CoroutineScope,
 ): TimeTravelStore<S, A> {
     lateinit var timeTravelStore: TimeTravelStore<S, A>
 
@@ -163,7 +204,7 @@ fun <S : State, A : Action> createTimeTravelStore(
         }
     }
 
-    val effectiveInitialState = initialHistory?.lastOrNull()?.currentState ?: initialState
+    val effectiveInitialState = initialHistory?.lastOrNull()?.currentState ?: initialState!!
 
     val innerStore = createStore(
         initialState = effectiveInitialState,
@@ -176,8 +217,8 @@ fun <S : State, A : Action> createTimeTravelStore(
 
     timeTravelStore = TimeTravelStore(
         innerStore = innerStore,
-        initialState = initialState,
         maxHistorySize = maxHistorySize,
+        initialState = initialState,
         initialHistory = initialHistory,
     )
 

--- a/flowdux-timetravel/src/jvmTest/kotlin/io/flowdux/timetravel/TimeTravelStoreTest.kt
+++ b/flowdux-timetravel/src/jvmTest/kotlin/io/flowdux/timetravel/TimeTravelStoreTest.kt
@@ -406,10 +406,9 @@ class TimeTravelStoreTest {
         )
 
         val store = createTimeTravelStore(
-            initialState = CounterState(),
+            initialHistory = savedHistory,
             reducer = counterReducer,
             errorProcessor = testErrorProcessor,
-            initialHistory = savedHistory,
             scope = backgroundScope,
         )
 
@@ -440,10 +439,9 @@ class TimeTravelStoreTest {
         )
 
         val store = createTimeTravelStore(
-            initialState = CounterState(),
+            initialHistory = savedHistory,
             reducer = counterReducer,
             errorProcessor = testErrorProcessor,
-            initialHistory = savedHistory,
             scope = backgroundScope,
         )
 
@@ -462,16 +460,15 @@ class TimeTravelStoreTest {
     }
 
     @Test
-    fun `empty initialHistory uses initialState`() = runTest {
-        val store = createTimeTravelStore(
-            initialState = CounterState(42),
-            reducer = counterReducer,
-            errorProcessor = testErrorProcessor,
-            initialHistory = emptyList(),
-            scope = backgroundScope,
-        )
-
-        assertEquals(1, store.history.size)
-        assertEquals(42, store.currentState.count)
+    fun `empty initialHistory throws exception`() = runTest {
+        val exception = org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
+            createTimeTravelStore(
+                initialHistory = emptyList<StateSnapshot<CounterState, CounterAction>>(),
+                reducer = counterReducer,
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
+        }
+        assertEquals("initialHistory must not be empty", exception.message)
     }
 }


### PR DESCRIPTION
## Summary

- Split `createTimeTravelStore` into two separate overloads:
  - `createTimeTravelStore(initialState, ...)` - for fresh start
  - `createTimeTravelStore(initialHistory, ...)` - for restoring from history
- Remove unnecessary `initialState` parameter when restoring from history
- Add validation: `initialHistory` must not be empty

## Usage

```kotlin
// Fresh start
val store = createTimeTravelStore(
    initialState = MyState(),
    reducer = myReducer
)

// Restore from history
val store = createTimeTravelStore(
    initialHistory = savedHistory,
    reducer = myReducer
)
```

## Test plan

- [x] All 16 timetravel tests pass
- [x] Empty history throws IllegalArgumentException

🤖 Generated with [Claude Code](https://claude.ai/code)