### PR TITLE
Remove key parameter from takeLatest and takeLeading

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,14 +285,14 @@ store.dispatch(ObserveUser(repositoryFlow))       // Store collects it
 
 FlowDux provides execution strategies to control how concurrent actions are processed in middleware.
 
-### takeLatest(key)
+### takeLatest()
 
-Cancels previous processing when a new action with the same key arrives. Only the latest action's result is emitted.
+Cancels previous processing when a new action arrives. Only the latest action's result is emitted.
 
 ```kotlin
 class SearchMiddleware : Middleware<AppState, AppAction> {
     override val processors = buildProcessors {
-        on<AppAction.Search>(takeLatest("search")) { state, action ->
+        on<AppAction.Search>(takeLatest()) { state, action ->
             val results = searchApi.search(action.query)
             emit(AppAction.SearchResults(results))
         }
@@ -302,14 +302,14 @@ class SearchMiddleware : Middleware<AppState, AppAction> {
 
 Use cases: Search, API refresh, pagination with pull-to-refresh
 
-### takeLeading(key)
+### takeLeading()
 
-Ignores new actions while one with the same key is still processing. Only the first action in a series executes.
+Ignores new actions while one is still processing. Only the first action in a series executes.
 
 ```kotlin
 class SubmitMiddleware : Middleware<AppState, AppAction> {
     override val processors = buildProcessors {
-        on<AppAction.Submit>(takeLeading("submit")) { state, action ->
+        on<AppAction.Submit>(takeLeading()) { state, action ->
             // Prevents duplicate submissions
             val result = api.submit(action.data)
             emit(AppAction.SubmitSuccess(result))
@@ -365,7 +365,7 @@ class SearchMiddleware : Middleware<AppState, AppAction> {
     override val processors = buildProcessors {
         // SearchAction and RefreshAction share the same takeLatest instance
         // Dispatching RefreshAction will cancel an in-progress SearchAction
-        group(takeLatest("search")) {
+        group(takeLatest()) {
             on<SearchAction> { state, action ->
                 val results = searchApi.search(action.query)
                 emit(SearchResults(results))

--- a/flowdux/src/commonMain/kotlin/io/flowdux/ExecutionStrategy.kt
+++ b/flowdux/src/commonMain/kotlin/io/flowdux/ExecutionStrategy.kt
@@ -25,23 +25,23 @@ sealed interface ExecutionStrategy {
 }
 
 /**
- * Cancels any previous execution with the same key when a new action arrives.
+ * Cancels any previous execution when a new action arrives.
  * Only the latest action's result will be emitted.
  *
- * @param key Grouping key - actions with the same key cancel each other
+ * Use [group] in middleware to coordinate cancellation across different action types.
  */
-class TakeLatest(private val key: Any) : ExecutionStrategy {
+class TakeLatest : ExecutionStrategy {
     private val mutex = Mutex()
-    private val jobs = mutableMapOf<Any, Job>()
+    private var currentJob: Job? = null
 
     override fun <S, A, T : A> wrap(
         processor: suspend FlowCollector<A>.(state: S, action: T) -> Unit
     ): suspend FlowCollector<A>.(state: S, action: T) -> Unit = { state, action ->
-        val currentJob = currentCoroutineContext()[Job]!!
+        val job = currentCoroutineContext()[Job]!!
 
         mutex.withLock {
-            jobs[key]?.cancel()
-            jobs[key] = currentJob
+            currentJob?.cancel()
+            currentJob = job
         }
 
         try {
@@ -50,8 +50,8 @@ class TakeLatest(private val key: Any) : ExecutionStrategy {
             throw e
         } finally {
             mutex.withLock {
-                if (jobs[key] === currentJob) {
-                    jobs.remove(key)
+                if (currentJob === job) {
+                    currentJob = null
                 }
             }
         }
@@ -59,23 +59,23 @@ class TakeLatest(private val key: Any) : ExecutionStrategy {
 }
 
 /**
- * Ignores new actions while one with the same key is still processing.
+ * Ignores new actions while one is still processing.
  * Only the first action in a series will execute.
  *
- * @param key Grouping key - actions with the same key are deduplicated
+ * Use [group] in middleware to coordinate across different action types.
  */
-class TakeLeading(private val key: Any) : ExecutionStrategy {
+class TakeLeading : ExecutionStrategy {
     private val mutex = Mutex()
-    private val activeKeys = mutableSetOf<Any>()
+    private var isActive = false
 
     override fun <S, A, T : A> wrap(
         processor: suspend FlowCollector<A>.(state: S, action: T) -> Unit
     ): suspend FlowCollector<A>.(state: S, action: T) -> Unit = { state, action ->
         val shouldExecute = mutex.withLock {
-            if (key in activeKeys) {
+            if (isActive) {
                 false
             } else {
-                activeKeys.add(key)
+                isActive = true
                 true
             }
         }
@@ -85,7 +85,7 @@ class TakeLeading(private val key: Any) : ExecutionStrategy {
                 processor(state, action)
             } finally {
                 mutex.withLock {
-                    activeKeys.remove(key)
+                    isActive = false
                 }
             }
         }
@@ -161,16 +161,16 @@ class Throttle(private val duration: Duration) : ExecutionStrategy {
 /**
  * Creates a [TakeLatest] strategy that cancels previous executions when a new action arrives.
  *
- * @param key Grouping key - actions with the same key cancel each other. Defaults to Unit.
+ * Use [group] in middleware to share a strategy instance across different action types.
  */
-fun takeLatest(key: Any = Unit): ExecutionStrategy = TakeLatest(key)
+fun takeLatest(): ExecutionStrategy = TakeLatest()
 
 /**
  * Creates a [TakeLeading] strategy that ignores new actions while one is processing.
  *
- * @param key Grouping key - actions with the same key are deduplicated. Defaults to Unit.
+ * Use [group] in middleware to share a strategy instance across different action types.
  */
-fun takeLeading(key: Any = Unit): ExecutionStrategy = TakeLeading(key)
+fun takeLeading(): ExecutionStrategy = TakeLeading()
 
 /**
  * Creates a [Debounce] strategy that delays execution until no new actions arrive.

--- a/flowdux/src/commonMain/kotlin/io/flowdux/Middleware.kt
+++ b/flowdux/src/commonMain/kotlin/io/flowdux/Middleware.kt
@@ -97,7 +97,7 @@ interface Middleware<S : State, A : Action> {
          *
          * Example:
          * ```
-         * group(takeLatest("search")) {
+         * group(takeLatest()) {
          *     on<SearchAction> { state, action -> ... }
          *     on<RefreshAction> { state, action -> ... }
          * }

--- a/flowdux/src/jvmTest/kotlin/io/flowdux/ExecutionStrategyTest.kt
+++ b/flowdux/src/jvmTest/kotlin/io/flowdux/ExecutionStrategyTest.kt
@@ -56,7 +56,7 @@ class ExecutionStrategyTest {
 
             val middleware = object : Middleware<TestState, TestAction> {
                 override val processors = buildProcessors {
-                    on<TestAction.Fetch>(takeLatest("fetch")) { state, action ->
+                    on<TestAction.Fetch>(takeLatest()) { state, action ->
                         executionOrder.add("start-${action.id}")
                         delay(100)
                         executionOrder.add("end-${action.id}")
@@ -107,12 +107,12 @@ class ExecutionStrategyTest {
             val middleware = object : Middleware<TestState, TestAction> {
                 override val processors = buildProcessors {
                     // Use separate takeLatest instances for different key groups
-                    on<TestAction.Fetch>(takeLatest("fetch")) { state, action ->
+                    on<TestAction.Fetch>(takeLatest()) { state, action ->
                         delay(100)
                         completedActionsA.add(action.id)
                         emit(TestAction.FetchSuccess(action.id, "result-${action.id}"))
                     }
-                    on<TestAction.Search>(takeLatest("search")) { state, action ->
+                    on<TestAction.Search>(takeLatest()) { state, action ->
                         delay(100)
                         completedActionsB.add(action.query)
                         emit(TestAction.SearchResult(action.query, listOf(action.query)))
@@ -163,7 +163,7 @@ class ExecutionStrategyTest {
 
             val middleware = object : Middleware<TestState, TestAction> {
                 override val processors = buildProcessors {
-                    on<TestAction.Fetch>(takeLeading("fetch")) { state, action ->
+                    on<TestAction.Fetch>(takeLeading()) { state, action ->
                         executionCount.add(action.id)
                         delay(100)
                         emit(TestAction.FetchSuccess(action.id, "result-${action.id}"))
@@ -204,7 +204,7 @@ class ExecutionStrategyTest {
 
             val middleware = object : Middleware<TestState, TestAction> {
                 override val processors = buildProcessors {
-                    on<TestAction.Click>(takeLeading("click")) { state, action ->
+                    on<TestAction.Click>(takeLeading()) { state, action ->
                         executionOrder.add(action.buttonId)
                         delay(50)
                         emit(TestAction.ClickProcessed(action.buttonId))
@@ -433,12 +433,12 @@ class ExecutionStrategyTest {
 
             val middleware = object : Middleware<TestState, TestAction> {
                 override val processors = buildProcessors {
-                    on<TestAction.Fetch>(takeLatest("fetch")) { state, action ->
+                    on<TestAction.Fetch>(takeLatest()) { state, action ->
                         delay(50)
                         fetchExecutions.add(action.id)
                         emit(TestAction.FetchSuccess(action.id, action.id))
                     }
-                    on<TestAction.Click>(takeLeading("click")) { state, action ->
+                    on<TestAction.Click>(takeLeading()) { state, action ->
                         delay(50)
                         clickExecutions.add(action.buttonId)
                         emit(TestAction.ClickProcessed(action.buttonId))
@@ -487,7 +487,7 @@ class ExecutionStrategyTest {
             val middleware = object : Middleware<TestState, TestAction> {
                 override val processors = buildProcessors {
                     // Both Fetch and Search share the same takeLatest instance
-                    group(takeLatest("shared")) {
+                    group(takeLatest()) {
                         on<TestAction.Fetch> { _, action ->
                             executionOrder.add("fetch-start-${action.id}")
                             delay(100)
@@ -541,7 +541,7 @@ class ExecutionStrategyTest {
 
             val middleware = object : Middleware<TestState, TestAction> {
                 override val processors = buildProcessors {
-                    group(takeLeading("shared")) {
+                    group(takeLeading()) {
                         on<TestAction.Fetch> { _, action ->
                             executionOrder.add("fetch-${action.id}")
                             delay(100)
@@ -589,14 +589,14 @@ class ExecutionStrategyTest {
 
             val middleware = object : Middleware<TestState, TestAction> {
                 override val processors = buildProcessors {
-                    group(takeLatest("groupA")) {
+                    group(takeLatest()) {
                         on<TestAction.Fetch> { _, action ->
                             delay(50)
                             groupAExecutions.add(action.id)
                             emit(TestAction.FetchSuccess(action.id, action.id))
                         }
                     }
-                    group(takeLatest("groupB")) {
+                    group(takeLatest()) {
                         on<TestAction.Search> { _, action ->
                             delay(50)
                             groupBExecutions.add(action.query)

--- a/flowdux/src/jvmTest/kotlin/io/flowdux/MiddlewareTest.kt
+++ b/flowdux/src/jvmTest/kotlin/io/flowdux/MiddlewareTest.kt
@@ -327,7 +327,7 @@ class MiddlewareTest {
             object : Middleware<CounterState, CounterAction> {
                 override val processors = buildProcessors {
                     on<CounterAction.Increment> { _, _ -> emit(CounterAction.Increment) }
-                    group(takeLatest("test")) {
+                    group(takeLatest()) {
                         on<CounterAction.Increment> { _, _ -> emit(CounterAction.Increment) } // Duplicate!
                     }
                 }
@@ -340,10 +340,10 @@ class MiddlewareTest {
         org.junit.jupiter.api.assertThrows<Middleware.DuplicateProcessorException> {
             object : Middleware<CounterState, CounterAction> {
                 override val processors = buildProcessors {
-                    group(takeLatest("group1")) {
+                    group(takeLatest()) {
                         on<CounterAction.Increment> { _, _ -> emit(CounterAction.Increment) }
                     }
-                    group(takeLatest("group2")) {
+                    group(takeLatest()) {
                         on<CounterAction.Increment> { _, _ -> emit(CounterAction.Increment) } // Duplicate!
                     }
                 }

--- a/sample-jvm/src/main/kotlin/io/flowdux/sample/Main.kt
+++ b/sample-jvm/src/main/kotlin/io/flowdux/sample/Main.kt
@@ -68,7 +68,7 @@ object SearchApi {
 class ExecutionStrategyMiddleware : Middleware<CounterState, CounterAction> {
     override val processors = buildProcessors {
         // takeLatest: Only the latest search executes, previous ones are canceled
-        on<CounterAction.Search>(takeLatest("search")) { _, action ->
+        on<CounterAction.Search>(takeLatest()) { _, action ->
             println("    [takeLatest] Searching for: ${action.query}")
             val results = SearchApi.search(action.query)
             println("    [takeLatest] Search completed: ${action.query}")
@@ -83,7 +83,7 @@ class ExecutionStrategyMiddleware : Middleware<CounterState, CounterAction> {
         }
 
         // takeLeading: Ignore subsequent submissions while one is processing
-        on<CounterAction.SubmitForm>(takeLeading("submit")) { _, _ ->
+        on<CounterAction.SubmitForm>(takeLeading()) { _, _ ->
             println("    [takeLeading] Processing form submission...")
             delay(500) // Simulate slow API
             println("    [takeLeading] Form submitted!")
@@ -92,7 +92,7 @@ class ExecutionStrategyMiddleware : Middleware<CounterState, CounterAction> {
 
         // Strategy Group: Different action types share the same strategy instance
         // LoadUser and RefreshUser will cancel each other
-        group(takeLatest("user-data")) {
+        group(takeLatest()) {
             on<CounterAction.LoadUser> { _, action ->
                 println("    [group] Loading user: ${action.userId}")
                 delay(300) // Simulate API call


### PR DESCRIPTION
## Summary
- Remove unused `key` parameter from `takeLatest()` and `takeLeading()`
- Simplify internal implementation (Map → single variable, Set → boolean)
- Cross-action coordination should use `group()` instead

## Why
The `key` parameter was not functional - each strategy instance has its own internal state, so the key served no purpose. The actual grouping happens through instance sharing via `group()`.

## Before
```kotlin
on<SearchAction>(takeLatest("search")) { ... }
on<RefreshAction>(takeLatest("search")) { ... }  // Different instances!
```

## After
```kotlin
group(takeLatest()) {
    on<SearchAction> { ... }
    on<RefreshAction> { ... }  // Same instance - can cancel each other
}
```

## Test plan
- [x] All existing tests pass
- [x] `./gradlew :sample-jvm:run` works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)