### PR TITLE
Fix JitPack build by skipping JS/WASM npm tasks

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -3,3 +3,6 @@ jdk:
 
 before_install:
   - chmod +x gradlew
+
+install:
+  - ./gradlew :flowdux:publishToMavenLocal :flowdux-timetravel:publishToMavenLocal -x kotlinNpmInstall -x kotlinStoreYarnLock -x jsTest -x wasmJsTest


### PR DESCRIPTION
## Summary
- Fix JitPack build failure caused by outdated GLIBC in JitPack environment
- Skip npm-related tasks (`kotlinNpmInstall`, `kotlinStoreYarnLock`, `jsTest`, `wasmJsTest`) during JitPack build

## Problem
JitPack's build environment has GLIBC 2.17 which is incompatible with Node.js 18 required for Kotlin/JS and WASM targets.

## Solution
Configure `jitpack.yml` to explicitly run publish tasks while excluding npm-related tasks. This allows JVM and iOS artifacts to be published successfully.

## Test Plan
- [ ] JitPack build succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)