### PR TITLE
Remove incorrect Combine Strategies section from blog

### DIFF
--- a/docs/blog/blog-execution-strategies-en.md
+++ b/docs/blog/blog-execution-strategies-en.md
@@ -415,20 +415,6 @@ group(takeLatest()) {
 }
 ```
 
-### 4. Combine Strategies When Needed
-
-```kotlin
-// Debounce input, then takeLatest for the API call
-on<SearchInputChanged>(debounce(300.milliseconds)) { state, action ->
-    emit(SearchAction(action.query))  // Triggers takeLatest search
-}
-
-on<SearchAction>(takeLatest()) { state, action ->
-    val results = api.search(action.query)
-    emit(SearchResults(results))
-}
-```
-
 ---
 
 ## Conclusion

--- a/docs/blog/blog-execution-strategies-ko.md
+++ b/docs/blog/blog-execution-strategies-ko.md
@@ -415,20 +415,6 @@ group(takeLatest()) {
 }
 ```
 
-### 4. 필요시 전략 조합하기
-
-```kotlin
-// 입력은 debounce하고, API 호출은 takeLatest
-on<SearchInputChanged>(debounce(300.milliseconds)) { state, action ->
-    emit(SearchAction(action.query))  // takeLatest 검색을 트리거
-}
-
-on<SearchAction>(takeLatest()) { state, action ->
-    val results = api.search(action.query)
-    emit(SearchResults(results))
-}
-```
-
 ---
 
 ## 결론


### PR DESCRIPTION
## Summary
Remove the "Combine Strategies When Needed" section from both blog posts.

The example was incorrect - `emit()` sends actions to remaining middlewares, not back to the beginning of the middleware chain. The shown pattern wouldn't work as described.

🤖 Generated with [Claude Code](https://claude.com/claude-code)