### PR TITLE
Refactor: Reorganize project structure (kotlin/, dart/ folders)

### DIFF
--- a/README.md
+++ b/README.md
@@ -813,6 +813,8 @@ Opens browser at `http://localhost:8080` with an interactive Counter app (WASM v
 
 ## Platform Support
 
+### Kotlin Multiplatform
+
 | Platform | Status | Sample |
 |----------|--------|--------|
 | JVM | ✅ | `kotlin/sample-jvm` |
@@ -820,6 +822,13 @@ Opens browser at `http://localhost:8080` with an interactive Counter app (WASM v
 | iOS | ✅ | `kotlin/sample-shared/iosApp` |
 | JavaScript | ✅ | `kotlin/sample-web` |
 | WebAssembly | ✅ | `kotlin/sample-wasm` |
+
+### Dart / Flutter
+
+| Platform | Status | Sample |
+|----------|--------|--------|
+| Dart | ✅ | `dart/flowdux` |
+| Flutter | ✅ | `dart/flowdux_flutter` |
 
 ## License
 


### PR DESCRIPTION
## Summary
- Reorganize project structure: move Kotlin modules to `kotlin/` folder, Dart stays in `dart/`
- Add path-filtered GitHub Actions CI (kotlin.yml, dart.yml)
- Update all Gradle paths with `:kotlin:` prefix
- Update JitPack configuration for new paths
- Update README with new paths and add Dart/Flutter documentation
- Remove flaky sequential test with real dispatcher
- Fix Dart FlowHolderAction example to match Kotlin pattern

## Test plan
- [x] Local Kotlin build passes (`./gradlew :kotlin:flowdux:check`)
- [x] Local Dart tests pass (`dart test`)
- [x] CI workflows trigger correctly on path changes
- [x] JitPack deployment compatibility verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)