### PR TITLE
Fix sed command for pub.dev publish workflow

### DIFF
--- a/.github/workflows/publish-dart.yml
+++ b/.github/workflows/publish-dart.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Update flowdux_flutter dependency to published version
         run: |
-          sed -i 's|path: ../flowdux|^${{ steps.version.outputs.VERSION }}|' pubspec.yaml
+          sed -i '/flowdux:/{N;s|  flowdux:\n    path: ../flowdux|  flowdux: ^${{ steps.version.outputs.VERSION }}|}' pubspec.yaml
         working-directory: dart/flowdux_flutter
 
       - name: Publish flowdux_flutter


### PR DESCRIPTION
## Summary
Fix multiline YAML replacement in publish-dart.yml workflow.

The previous sed command:
```bash
sed -i 's|path: ../flowdux|^VERSION|' pubspec.yaml
```

Would produce invalid YAML:
```yaml
flowdux:
    ^0.1.0
```

Fixed to properly handle two-line structure:
```bash
sed -i '/flowdux:/{N;s|flowdux:\n    path: ../flowdux|flowdux: ^VERSION|}' pubspec.yaml
```

Produces valid YAML:
```yaml
flowdux: ^0.1.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)