### PR TITLE
Add StoreListener to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,6 +687,15 @@ StoreSelector<AppState, Action, int>(
     return Text('Count: $count');
   },
 )
+
+// Listen to state changes for side effects (navigation, snackbar, etc.)
+StoreListener<AppState, Action>(
+  listenWhen: (previous, current) => current.navigateTo != null,
+  listener: (context, store, state) {
+    Navigator.of(context).pushNamed(state.navigateTo!);
+  },
+  child: MyWidget(),
+)
 ```
 
 ### Run Dart Tests


### PR DESCRIPTION
## Summary
Add `StoreListener` widget documentation to Flutter Integration section.

`StoreListener` is used for side effects like navigation, snackbars, etc. without rebuilding the widget tree.

```dart
StoreListener<AppState, Action>(
  listenWhen: (previous, current) => current.navigateTo != null,
  listener: (context, store, state) {
    Navigator.of(context).pushNamed(state.navigateTo!);
  },
  child: MyWidget(),
)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)