### PR TITLE
Fix LICENSE format for pub.dev OSI license detection

### DIFF
--- a/dart/flowdux/LICENSE
+++ b/dart/flowdux/LICENSE
@@ -1,3 +1,17 @@
+Copyright 2024 Flowdux Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -174,17 +188,3 @@
       of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
-
-   Copyright 2024 Flowdux Contributors
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.

--- a/dart/flowdux_flutter/LICENSE
+++ b/dart/flowdux_flutter/LICENSE
@@ -1,3 +1,17 @@
+Copyright 2024 Flowdux Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -174,17 +188,3 @@
       of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
-
-   Copyright 2024 Flowdux Contributors
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.


### PR DESCRIPTION
## Summary
- Move copyright notice to the top of LICENSE files in both `dart/flowdux` and `dart/flowdux_flutter`
- This fixes the "0/10 points: Use an OSI-approved license" penalty on pub.dev
- pub.dev's pana tool requires the copyright notice at the beginning of the file to properly recognize Apache 2.0 as an OSI-approved license

## Test plan
- [ ] Merge PR and create new release tag `dart-v0.2.0`
- [ ] Republish packages to pub.dev
- [ ] Verify pub points show 10/10 for license

🤖 Generated with [Claude Code](https://claude.com/claude-code)