### PR TITLE
Release 0.2.0

### DIFF
--- a/dart/flowdux/CHANGELOG.md
+++ b/dart/flowdux/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.2.0
+
+- Fix LICENSE format for pub.dev OSI license recognition
+- Add dartdoc comments to all public API elements
+- Add example file demonstrating Store, Actions, FlowHolderAction, and strategies
+
 ## 0.1.0
 
 - Initial release

--- a/dart/flowdux/pubspec.yaml
+++ b/dart/flowdux/pubspec.yaml
@@ -2,7 +2,7 @@ name: flowdux
 description: >
   A predictable state management library with execution strategies.
   Supports takeLatest, takeLeading, debounce, throttle, retry, and strategy chaining.
-version: 0.1.0
+version: 0.2.0
 homepage: https://github.com/chibimoons/flowdux
 repository: https://github.com/chibimoons/flowdux
 issue_tracker: https://github.com/chibimoons/flowdux/issues

--- a/dart/flowdux_flutter/CHANGELOG.md
+++ b/dart/flowdux_flutter/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-01-23
+
+### Changed
+
+- Fix LICENSE format for pub.dev OSI license recognition
+- Update flowdux dependency to ^0.2.0
+
 ## [0.1.0] - 2024-01-21
 
 ### Added

--- a/dart/flowdux_flutter/pubspec.yaml
+++ b/dart/flowdux_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: flowdux_flutter
 description: >
   Flutter bindings for FlowDux state management library.
   Provides StoreProvider, StoreBuilder, and StoreConsumer widgets.
-version: 0.1.0
+version: 0.2.0
 homepage: https://github.com/chibimoons/flowdux
 repository: https://github.com/chibimoons/flowdux
 issue_tracker: https://github.com/chibimoons/flowdux/issues


### PR DESCRIPTION
## Summary
Bump version to 0.2.0 for pub.dev release.

## Changes in 0.2.0
- Fix LICENSE format for pub.dev OSI license recognition (+10 points)
- Add dartdoc comments to all public API elements (+10 points)
- Add example file demonstrating Store, Actions, FlowHolderAction, and strategies (+10 points)

## After merge
Create tag `dart-v0.2.0` to trigger pub.dev publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)