### PR TITLE
Release 0.2.1: Fix LICENSE format for pub.dev

### DIFF
--- a/dart/flowdux/CHANGELOG.md
+++ b/dart/flowdux/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.1
+
+- Fix LICENSE file format to standard Apache 2.0 template for pub.dev recognition
+
 ## 0.2.0
 
 - Fix LICENSE format for pub.dev OSI license recognition

--- a/dart/flowdux/LICENSE
+++ b/dart/flowdux/LICENSE
@@ -1,17 +1,3 @@
-Copyright 2024 Flowdux Contributors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -188,3 +174,28 @@ limitations under the License.
       of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2024 Flowdux Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/dart/flowdux/pubspec.yaml
+++ b/dart/flowdux/pubspec.yaml
@@ -2,7 +2,7 @@ name: flowdux
 description: >
   A predictable state management library with execution strategies.
   Supports takeLatest, takeLeading, debounce, throttle, retry, and strategy chaining.
-version: 0.2.0
+version: 0.2.1
 homepage: https://github.com/chibimoons/flowdux
 repository: https://github.com/chibimoons/flowdux
 issue_tracker: https://github.com/chibimoons/flowdux/issues

--- a/dart/flowdux_flutter/CHANGELOG.md
+++ b/dart/flowdux_flutter/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2026-01-23
+
+### Changed
+
+- Fix LICENSE file format to standard Apache 2.0 template for pub.dev recognition
+- Update flowdux dependency to ^0.2.1
+
 ## [0.2.0] - 2026-01-23
 
 ### Changed

--- a/dart/flowdux_flutter/LICENSE
+++ b/dart/flowdux_flutter/LICENSE
@@ -1,17 +1,3 @@
-Copyright 2024 Flowdux Contributors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -188,3 +174,28 @@ limitations under the License.
       of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2024 Flowdux Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/dart/flowdux_flutter/pubspec.yaml
+++ b/dart/flowdux_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: flowdux_flutter
 description: >
   Flutter bindings for FlowDux state management library.
   Provides StoreProvider, StoreBuilder, and StoreConsumer widgets.
-version: 0.2.0
+version: 0.2.1
 homepage: https://github.com/chibimoons/flowdux
 repository: https://github.com/chibimoons/flowdux
 issue_tracker: https://github.com/chibimoons/flowdux/issues


### PR DESCRIPTION
## Summary
Fix LICENSE file format to standard Apache 2.0 template for proper pub.dev license detection.

## Changes
- Use standard Apache 2.0 format (header first, APPENDIX with copyright at end)
- Update both flowdux and flowdux_flutter packages

## Expected Result
- pub.dev score: 150/160 → 160/160 (full 30/30 for file conventions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)