### PR TITLE
Release 1.8.1 - Fix JitPack KMP variant resolution

### DIFF
--- a/kotlin/flowdux-timetravel/build.gradle.kts
+++ b/kotlin/flowdux-timetravel/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "io.flowdux"
-version = "1.8.0"
+version = "1.8.1"
 
 // JitPack only publishes JVM artifacts to avoid variant resolution issues for JVM/Android consumers
 val isJitPack = System.getenv("JITPACK") == "true"

--- a/kotlin/flowdux/build.gradle.kts
+++ b/kotlin/flowdux/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "io.flowdux"
-version = "1.8.0"
+version = "1.8.1"
 
 // JitPack only publishes JVM artifacts to avoid variant resolution issues for JVM/Android consumers
 val isJitPack = System.getenv("JITPACK") == "true"


### PR DESCRIPTION
## Summary
- Bump version to 1.8.1
- Fix JitPack KMP variant resolution for JVM/Android consumers
- Only publish JVM targets when building on JitPack, avoiding JS/WASM/iOS variant conflicts

## Changes
- JVM/Android consumers can now use `com.github.chibimoons:flowdux:1.8.1` without `-jvm` suffix

🤖 Generated with [Claude Code](https://claude.com/claude-code)