### PR TITLE
Fix middleware blocking when emitting FlowHolderAction

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Add the dependency to your `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("com.github.chibimoons:flowdux:1.8.0")
+    implementation("com.github.chibimoons:flowdux:1.8.2")
 }
 ```
 
@@ -182,7 +182,7 @@ Add to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  flowdux: ^1.0.0
+  flowdux: ^0.2.2
 ```
 
 ### Flutter
@@ -191,8 +191,8 @@ Add to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  flowdux: ^1.0.0
-  flowdux_flutter: ^1.0.0
+  flowdux: ^0.2.2
+  flowdux_flutter: ^0.2.2
 ```
 
 ## Usage (Kotlin)
@@ -503,7 +503,7 @@ Time travel debugging is available as a separate module:
 
 ```kotlin
 // build.gradle.kts
-implementation("com.github.chibimoons.flowdux:flowdux-timetravel:1.8.0")
+implementation("com.github.chibimoons.flowdux:flowdux-timetravel:1.8.2")
 ```
 
 ```kotlin

--- a/dart/flowdux/CHANGELOG.md
+++ b/dart/flowdux/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.2
+
+- Fix middleware blocking when emitting FlowHolderAction with infinite streams
+- Change middleware chain from asyncExpand to flatMap for concurrent processing
+
 ## 0.2.1
 
 - Fix LICENSE file format to standard Apache 2.0 template for pub.dev recognition

--- a/dart/flowdux/lib/src/store.dart
+++ b/dart/flowdux/lib/src/store.dart
@@ -88,13 +88,17 @@ class Store<S, A extends Action> {
         });
   }
 
-  /// Processes an action through all middlewares sequentially.
+  /// Processes an action through all middlewares concurrently.
   /// FlowHolderMiddleware is included at the end of the chain.
+  ///
+  /// Uses flatMap instead of asyncExpand to allow concurrent processing
+  /// of emitted actions. This prevents blocking when a middleware emits
+  /// FlowHolderActions with infinite streams.
   Stream<A> _processMiddlewares(A action) {
     Stream<A> currentStream = Stream.value(action);
 
     for (final middleware in _allMiddlewares) {
-      currentStream = currentStream.asyncExpand((currentAction) {
+      currentStream = currentStream.flatMap((currentAction) {
         _logger.onMiddlewareProcessing(middleware.name, currentAction);
         return middleware.process(() => currentState, currentAction);
       });

--- a/dart/flowdux/pubspec.yaml
+++ b/dart/flowdux/pubspec.yaml
@@ -2,7 +2,7 @@ name: flowdux
 description: >
   A predictable state management library with execution strategies.
   Supports takeLatest, takeLeading, debounce, throttle, retry, and strategy chaining.
-version: 0.2.1
+version: 0.2.2
 homepage: https://github.com/chibimoons/flowdux
 repository: https://github.com/chibimoons/flowdux
 issue_tracker: https://github.com/chibimoons/flowdux/issues

--- a/dart/flowdux/test/middleware_emit_flow_holder_action_test.dart
+++ b/dart/flowdux/test/middleware_emit_flow_holder_action_test.dart
@@ -1,0 +1,172 @@
+import 'dart:async';
+
+import 'package:flowdux/flowdux.dart';
+import 'package:test/test.dart';
+
+/// Tests for emitting multiple FlowHolderActions from within a middleware processor.
+///
+/// These tests verify that the middleware chain uses flatMap (not asyncExpand)
+/// to allow concurrent processing of emitted actions. This prevents blocking when
+/// a middleware emits FlowHolderActions with infinite streams.
+
+// Test Actions
+class StartMultipleObserversAction implements Action {}
+
+class SetupCompleteAction implements Action {
+  final DateTime timestamp;
+  SetupCompleteAction(this.timestamp);
+}
+
+class IncrementAction implements Action {}
+
+class AddAction implements Action {
+  final int value;
+  AddAction(this.value);
+}
+
+// FlowHolderAction that emits increment actions infinitely
+class InfiniteObserverFlowAction with FlowHolderAction {
+  final String id;
+  final Duration emitInterval;
+
+  InfiniteObserverFlowAction(this.id, {this.emitInterval = const Duration(milliseconds: 50)});
+
+  @override
+  Stream<Action> toStreamAction() async* {
+    while (true) {
+      await Future.delayed(emitInterval);
+      yield IncrementAction();
+    }
+  }
+}
+
+// FlowHolderAction that emits add(10) actions infinitely
+class SecondaryObserverFlowAction with FlowHolderAction {
+  final String id;
+  final Duration emitInterval;
+
+  SecondaryObserverFlowAction(this.id, {this.emitInterval = const Duration(milliseconds: 50)});
+
+  @override
+  Stream<Action> toStreamAction() async* {
+    while (true) {
+      await Future.delayed(emitInterval);
+      yield AddAction(10);
+    }
+  }
+}
+
+// Test State
+class AppState {
+  final int count;
+
+  AppState({this.count = 0});
+
+  AppState copyWith({int? count}) => AppState(count: count ?? this.count);
+
+  @override
+  String toString() => 'AppState(count: $count)';
+}
+
+// Test Reducer
+class AppReducer extends ReducerBase<AppState, Action> {
+  bool setupCompleteReceived = false;
+
+  AppReducer() {
+    on<IncrementAction>((state, _) => state.copyWith(count: state.count + 1));
+    on<AddAction>((state, action) => state.copyWith(count: state.count + action.value));
+    on<SetupCompleteAction>((state, action) {
+      setupCompleteReceived = true;
+      return state;
+    });
+  }
+}
+
+/// Middleware that emits multiple FlowHolderActions when StartMultipleObserversAction is dispatched.
+/// This simulates the real-world scenario where an app starts observing multiple data streams.
+class MultiObserverMiddleware extends Middleware<AppState, Action> {
+  MultiObserverMiddleware() {
+    on<StartMultipleObserversAction>((state, action) async* {
+      // Emit first infinite FlowHolderAction
+      yield InfiniteObserverFlowAction('observer1', emitInterval: Duration(milliseconds: 50));
+
+      // Emit second infinite FlowHolderAction
+      // With flatMap, this executes concurrently (not blocked by first yield)
+      yield SecondaryObserverFlowAction('observer2', emitInterval: Duration(milliseconds: 50));
+
+      // Emit a marker action to indicate setup is complete
+      // With flatMap, this also executes without blocking
+      yield SetupCompleteAction(DateTime.now());
+    });
+  }
+}
+
+void main() {
+  group('Middleware Emit FlowHolderAction Tests', () {
+    test('emitting multiple FlowHolderActions from middleware should not block', () async {
+      final appReducer = AppReducer();
+      final store = createStore<AppState, Action>(
+        initialState: AppState(),
+        reducer: appReducer.reducer,
+        middlewares: [MultiObserverMiddleware()],
+      );
+
+      // Dispatch action that triggers multiple FlowHolderAction emissions
+      store.dispatch(StartMultipleObserversAction());
+
+      // We should see emissions from BOTH streams
+      // InfiniteObserverFlowAction adds 1 per emission
+      // SecondaryObserverFlowAction adds 10 per emission
+      // If both are running, we should see both +1 and +10 increments
+
+      var sawIncrementByOne = false;
+      var sawIncrementByTen = false;
+      var previousCount = 0;
+
+      // Listen to state changes
+      final subscription = store.state.listen((state) {
+        final increment = state.count - previousCount;
+        if (increment == 1) sawIncrementByOne = true;
+        if (increment == 10) sawIncrementByTen = true;
+        previousCount = state.count;
+      });
+
+      // Wait for some emissions (with timeout to detect blocking)
+      await Future.delayed(Duration(milliseconds: 500));
+
+      await subscription.cancel();
+      await store.close();
+
+      expect(
+        sawIncrementByOne && sawIncrementByTen,
+        isTrue,
+        reason: 'Expected both FlowHolderActions to run concurrently. '
+            'sawIncrementByOne=$sawIncrementByOne, sawIncrementByTen=$sawIncrementByTen. '
+            'If only sawIncrementByOne=true, the second yield was blocked.',
+      );
+    });
+
+    test('code after yielding FlowHolderAction should execute', () async {
+      final appReducer = AppReducer();
+      final store = createStore<AppState, Action>(
+        initialState: AppState(),
+        reducer: appReducer.reducer,
+        middlewares: [MultiObserverMiddleware()],
+      );
+
+      store.dispatch(StartMultipleObserversAction());
+
+      // Wait for some emissions
+      await Future.delayed(Duration(milliseconds: 500));
+
+      await store.close();
+
+      expect(
+        appReducer.setupCompleteReceived,
+        isTrue,
+        reason: 'SetupCompleteAction should have been yielded after the FlowHolderActions, '
+            'but the code after yield was blocked.',
+      );
+    });
+  });
+}

--- a/dart/flowdux_flutter/CHANGELOG.md
+++ b/dart/flowdux_flutter/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] - 2026-01-23
+
+### Changed
+
+- Update flowdux dependency to ^0.2.2 (includes middleware blocking fix)
+
 ## [0.2.1] - 2026-01-23
 
 ### Changed

--- a/dart/flowdux_flutter/pubspec.yaml
+++ b/dart/flowdux_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: flowdux_flutter
 description: >
   Flutter bindings for FlowDux state management library.
   Provides StoreProvider, StoreBuilder, and StoreConsumer widgets.
-version: 0.2.1
+version: 0.2.2
 homepage: https://github.com/chibimoons/flowdux
 repository: https://github.com/chibimoons/flowdux
 issue_tracker: https://github.com/chibimoons/flowdux/issues

--- a/kotlin/flowdux-timetravel/build.gradle.kts
+++ b/kotlin/flowdux-timetravel/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "io.flowdux"
-version = "1.8.1"
+version = "1.8.2"
 
 // JitPack only publishes JVM artifacts to avoid variant resolution issues for JVM/Android consumers
 val isJitPack = System.getenv("JITPACK") == "true"

--- a/kotlin/flowdux/build.gradle.kts
+++ b/kotlin/flowdux/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "io.flowdux"
-version = "1.8.1"
+version = "1.8.2"
 
 // JitPack only publishes JVM artifacts to avoid variant resolution issues for JVM/Android consumers
 val isJitPack = System.getenv("JITPACK") == "true"

--- a/kotlin/flowdux/src/commonMain/kotlin/io/flowdux/Store.kt
+++ b/kotlin/flowdux/src/commonMain/kotlin/io/flowdux/Store.kt
@@ -47,7 +47,7 @@ class Store<S : State, A : Action>(
 
     private fun processAction(a: A): Flow<A> = allMiddlewares
         .fold(flowOf(a)) { flow, middleware ->
-            flow.flatMapConcat { currentAction ->
+            flow.flatMapMerge { currentAction ->
                 logger.onMiddlewareProcessing(middleware.name, currentAction)
                 middleware.process(
                     getState = { currentState },

--- a/kotlin/flowdux/src/jvmTest/kotlin/io/flowdux/MiddlewareEmitFlowHolderActionTest.kt
+++ b/kotlin/flowdux/src/jvmTest/kotlin/io/flowdux/MiddlewareEmitFlowHolderActionTest.kt
@@ -1,0 +1,141 @@
+package io.flowdux
+
+import app.cash.turbine.test
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for emitting multiple FlowHolderActions from within a middleware processor.
+ *
+ * These tests verify that the middleware chain uses flatMapMerge (not flatMapConcat)
+ * to allow concurrent processing of emitted actions. This prevents blocking when
+ * a middleware emits FlowHolderActions with infinite flows.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class MiddlewareEmitFlowHolderActionTest {
+
+    /**
+     * Middleware that emits multiple FlowHolderActions when StartMultipleObservers is dispatched.
+     * This simulates the real-world scenario where an app starts observing multiple data streams.
+     */
+    private class MultiObserverMiddleware : Middleware<CounterState, CounterAction> {
+        override val processors: ActionProcessorMap<CounterState, CounterAction> = buildProcessors {
+            on<CounterAction.StartMultipleObservers> { _, _ ->
+                // Emit first infinite FlowHolderAction
+                emit(CounterAction.InfiniteStreamAction("observer1", emitInterval = 50L))
+
+                // Emit second infinite FlowHolderAction
+                // With flatMapMerge, this executes concurrently (not blocked by first emit)
+                emit(CounterAction.SecondaryStreamAction("observer2", emitInterval = 50L))
+
+                // Emit a marker action to indicate setup is complete
+                // With flatMapMerge, this also executes without blocking
+                emit(CounterAction.SetupComplete(System.currentTimeMillis()))
+            }
+        }
+    }
+
+    @Test
+    fun `emitting multiple FlowHolderActions from middleware should not block`() = runTest {
+        val store = createStore(
+            initialState = CounterState(),
+            middlewares = listOf(MultiObserverMiddleware()),
+            reducer = counterReducer,
+            errorProcessor = testErrorProcessor,
+            scope = backgroundScope,
+        )
+
+        store.state.test {
+            assertEquals(0, awaitItem().count)
+
+            // Dispatch action that triggers multiple FlowHolderAction emissions
+            store.dispatch(CounterAction.StartMultipleObservers)
+
+            // We should see emissions from BOTH streams
+            // InfiniteStreamAction adds 1 per emission
+            // SecondaryStreamAction adds 10 per emission
+            // If both are running, we should see both +1 and +10 increments
+
+            var sawIncrementByOne = false
+            var sawIncrementByTen = false
+            var previousCount = 0
+
+            // Use timeout to detect if we're stuck
+            withTimeout(2000) {
+                repeat(10) {
+                    val currentCount = awaitItem().count
+                    val increment = currentCount - previousCount
+
+                    if (increment == 1) sawIncrementByOne = true
+                    if (increment == 10) sawIncrementByTen = true
+
+                    previousCount = currentCount
+
+                    // Early exit if we've seen both
+                    if (sawIncrementByOne && sawIncrementByTen) return@withTimeout
+                }
+            }
+
+            assertTrue(sawIncrementByOne && sawIncrementByTen) {
+                "Expected both FlowHolderActions to run concurrently. " +
+                    "sawIncrementByOne=$sawIncrementByOne, sawIncrementByTen=$sawIncrementByTen. " +
+                    "If only sawIncrementByOne=true, the second emit was blocked."
+            }
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `code after emitting FlowHolderAction should execute`() = runTest {
+        var setupCompleteReceived = false
+
+        val testReducer = Reducer<CounterState, CounterAction> { state, action ->
+            when (action) {
+                is CounterAction.SetupComplete -> {
+                    setupCompleteReceived = true
+                    state
+                }
+                is CounterAction.Add -> state.copy(count = state.count + action.value)
+                else -> state
+            }
+        }
+
+        val store = createStore(
+            initialState = CounterState(),
+            middlewares = listOf(MultiObserverMiddleware()),
+            reducer = testReducer,
+            errorProcessor = testErrorProcessor,
+            scope = backgroundScope,
+        )
+
+        store.state.test {
+            assertEquals(0, awaitItem().count)
+
+            store.dispatch(CounterAction.StartMultipleObservers)
+
+            // Wait for some emissions and check if SetupComplete was received
+            withTimeout(2000) {
+                repeat(10) {
+                    awaitItem()
+                    if (setupCompleteReceived) return@withTimeout
+                }
+            }
+
+            assertTrue(setupCompleteReceived) {
+                "SetupComplete action should have been emitted after the FlowHolderActions, " +
+                    "but the code after emit() was blocked."
+            }
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    private fun assertEquals(expected: Int, actual: Int) {
+        org.junit.jupiter.api.Assertions.assertEquals(expected, actual)
+    }
+}

--- a/kotlin/flowdux/src/jvmTest/kotlin/io/flowdux/TestFixtures.kt
+++ b/kotlin/flowdux/src/jvmTest/kotlin/io/flowdux/TestFixtures.kt
@@ -157,6 +157,18 @@ sealed interface CounterAction : Action {
             emit(innerAction) // Then emit another FlowHolderAction
         }
     }
+
+    /**
+     * Action that triggers the middleware to emit multiple FlowHolderActions.
+     * Used to test concurrent emission of FlowHolderActions from middleware.
+     */
+    object StartMultipleObservers : CounterAction
+
+    /**
+     * Marker action emitted after all FlowHolderActions are emitted.
+     * Used to verify that middleware code after emit() is executed.
+     */
+    data class SetupComplete(val timestamp: Long) : CounterAction
 }
 
 val counterReducer =
@@ -179,6 +191,8 @@ val counterReducer =
             is CounterAction.DebouncedStreamAction -> state
             is CounterAction.ThrottledStreamAction -> state
             is CounterAction.NestedFlowHolderAction -> state
+            is CounterAction.StartMultipleObservers -> state
+            is CounterAction.SetupComplete -> state
         }
     }
 


### PR DESCRIPTION
## Summary
- Fix blocking issue when middleware emits FlowHolderActions with infinite flows
- Change middleware chain from `flatMapConcat` to `flatMapMerge`
- Bump version to 1.8.2

## Problem
When a middleware emits a `FlowHolderAction` (e.g., observing a state flow), subsequent code in the processor was blocked because `flatMapConcat` waits for each emission to complete.

```kotlin
on<AppAction.Start> {
    emit(AppAction.ObserveMusicState(flow))  // ❌ Blocks here forever
    emit(AppAction.ObservePermissionState(flow))  // Never reached
    appUseCase.start()  // Never reached
}
```

## Solution
Change to `flatMapMerge` allowing concurrent processing of emitted actions.

## Test plan
- [x] Added tests that reproduce the blocking issue
- [x] All existing tests pass
- [x] New tests pass with `flatMapMerge`

🤖 Generated with [Claude Code](https://claude.com/claude-code)