### PR TITLE
chore: Update flowdux_flutter dependency to use hosted package

### DIFF
--- a/dart/flowdux_flutter/pubspec.yaml
+++ b/dart/flowdux_flutter/pubspec.yaml
@@ -15,8 +15,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flowdux:
-    path: ../flowdux
+  flowdux: ^0.2.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- Change flowdux dependency from path to pub.dev hosted version (^0.2.2)
- Required for pub.dev publishing compatibility

## Context
This change was made during the 0.2.2 publish process. The path dependency prevents publishing to pub.dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)