### PR TITLE
chore: add GitHub Pages landing page for SEO

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Flowdux - Lightweight Redux-style State Management for Kotlin Multiplatform &amp; Dart/Flutter</title>
+    <meta name="description" content="Flowdux is a lightweight Redux-style state management library for Kotlin Multiplatform and Dart/Flutter with middleware, execution strategies, time travel debugging, and real-time remote state sync over WebSocket.">
+    <meta name="keywords" content="flowdux, kotlin, kotlin multiplatform, dart, flutter, redux, state management, middleware, coroutines, flow, mvi, websocket, remote state sync, time travel debugging">
+    <meta name="author" content="chibimoons">
+    <link rel="canonical" href="https://chibimoons.github.io/flowdux/">
+
+    <!-- Open Graph -->
+    <meta property="og:title" content="Flowdux - State Management for Kotlin Multiplatform &amp; Dart/Flutter">
+    <meta property="og:description" content="Lightweight Redux-style state management with middleware, execution strategies, time travel debugging, and real-time WebSocket sync.">
+    <meta property="og:url" content="https://chibimoons.github.io/flowdux/">
+    <meta property="og:type" content="website">
+
+    <style>
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            line-height: 1.6;
+            color: #24292e;
+            background: #fff;
+        }
+        .hero {
+            text-align: center;
+            padding: 80px 20px 60px;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+        }
+        .hero h1 { font-size: 48px; margin-bottom: 16px; }
+        .hero p { font-size: 20px; max-width: 700px; margin: 0 auto 32px; opacity: 0.9; }
+        .badges { display: flex; justify-content: center; gap: 8px; flex-wrap: wrap; margin-bottom: 32px; }
+        .badges img { height: 24px; }
+        .cta { display: inline-flex; gap: 12px; flex-wrap: wrap; justify-content: center; }
+        .cta a {
+            padding: 12px 28px;
+            border-radius: 8px;
+            font-size: 16px;
+            font-weight: 600;
+            text-decoration: none;
+            transition: opacity 0.2s;
+        }
+        .cta a:hover { opacity: 0.85; }
+        .cta-primary { background: #fff; color: #764ba2; }
+        .cta-secondary { background: rgba(255,255,255,0.2); color: #fff; border: 1px solid rgba(255,255,255,0.4); }
+        .container { max-width: 960px; margin: 0 auto; padding: 60px 20px; }
+        h2 { font-size: 28px; margin-bottom: 24px; color: #24292e; }
+        .features {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+            gap: 24px;
+            margin-bottom: 20px;
+        }
+        .feature {
+            padding: 24px;
+            border: 1px solid #e1e4e8;
+            border-radius: 8px;
+        }
+        .feature h3 { font-size: 18px; margin-bottom: 8px; }
+        .feature p { font-size: 14px; color: #586069; }
+        .platforms { margin-top: 40px; }
+        .platforms table { width: 100%; border-collapse: collapse; }
+        .platforms th, .platforms td { padding: 10px 16px; text-align: left; border-bottom: 1px solid #e1e4e8; }
+        .platforms th { font-weight: 600; background: #f6f8fa; }
+        pre {
+            background: #f6f8fa;
+            padding: 16px;
+            border-radius: 8px;
+            overflow-x: auto;
+            font-size: 14px;
+            line-height: 1.5;
+        }
+        code { font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace; }
+        .install-section { background: #f6f8fa; }
+        .docs-links { list-style: none; }
+        .docs-links li { padding: 10px 0; border-bottom: 1px solid #e1e4e8; }
+        .docs-links li:last-child { border-bottom: none; }
+        .docs-links a { color: #0366d6; text-decoration: none; font-weight: 500; }
+        .docs-links a:hover { text-decoration: underline; }
+        footer {
+            text-align: center;
+            padding: 40px 20px;
+            color: #586069;
+            font-size: 14px;
+            border-top: 1px solid #e1e4e8;
+        }
+        footer a { color: #0366d6; text-decoration: none; }
+    </style>
+</head>
+<body>
+    <div class="hero">
+        <h1>Flowdux</h1>
+        <p>A lightweight Redux-style state management library for <strong>Kotlin Multiplatform</strong> and <strong>Dart/Flutter</strong> with Middleware support.</p>
+        <div class="badges">
+            <a href="https://jitpack.io/#chibimoons/flowdux"><img src="https://jitpack.io/v/chibimoons/flowdux.svg" alt="Kotlin JitPack version"></a>
+            <a href="https://pub.dev/packages/flowdux"><img src="https://img.shields.io/pub/v/flowdux.svg" alt="Dart pub.dev version"></a>
+            <a href="https://pub.dev/packages/flowdux_flutter"><img src="https://img.shields.io/pub/v/flowdux_flutter.svg" alt="Flutter pub.dev version"></a>
+        </div>
+        <div class="cta">
+            <a class="cta-primary" href="https://github.com/chibimoons/flowdux">GitHub Repository</a>
+            <a class="cta-secondary" href="https://github.com/chibimoons/flowdux#quick-start-kotlin">Quick Start</a>
+        </div>
+    </div>
+
+    <div class="container">
+        <h2>Features</h2>
+        <div class="features">
+            <div class="feature">
+                <h3>Redux Pattern</h3>
+                <p>Predictable state management with Reducer pattern, unidirectional data flow, and immutable state.</p>
+            </div>
+            <div class="feature">
+                <h3>Middleware &amp; Strategies</h3>
+                <p>Side effect handling with execution strategies: takeLatest, debounce, throttle, retry, sequential, and strategy chaining.</p>
+            </div>
+            <div class="feature">
+                <h3>Remote State Sync</h3>
+                <p>Real-time client-server state synchronization over WebSocket with type-safe shared action contracts.</p>
+            </div>
+            <div class="feature">
+                <h3>Time Travel</h3>
+                <p>Undo/redo, state history navigation, and branching for debugging and development.</p>
+            </div>
+            <div class="feature">
+                <h3>Kotlin Multiplatform</h3>
+                <p>Runs on JVM, Android, iOS, JavaScript, and WebAssembly. Built on Coroutines and Flow.</p>
+            </div>
+            <div class="feature">
+                <h3>Dart &amp; Flutter</h3>
+                <p>Full Dart implementation with Flutter widget bindings and Stream-based reactive state.</p>
+            </div>
+        </div>
+    </div>
+
+    <div class="install-section">
+        <div class="container">
+            <h2>Installation</h2>
+            <h3 style="margin-bottom:12px;">Kotlin (JitPack)</h3>
+            <pre><code>dependencies {
+    implementation("com.github.chibimoons:flowdux:1.8.2")
+}</code></pre>
+            <h3 style="margin:24px 0 12px;">Dart / Flutter</h3>
+            <pre><code>dependencies:
+  flowdux: ^0.2.3</code></pre>
+        </div>
+    </div>
+
+    <div class="container">
+        <h2>Quick Start</h2>
+        <pre><code>// Define State and Actions
+data class CounterState(val count: Int = 0) : State
+
+sealed class CounterAction : Action {
+    object Increment : CounterAction()
+    object Decrement : CounterAction()
+}
+
+// Create Reducer
+val counterReducer = buildReducer&lt;CounterState, CounterAction&gt; {
+    on&lt;CounterAction.Increment&gt; { state, _ -&gt;
+        state.copy(count = state.count + 1)
+    }
+}
+
+// Create and Use Store
+val store = createStore(
+    initialState = CounterState(),
+    reducer = counterReducer,
+)
+
+store.state.collect { println("Count: ${it.count}") }
+store.dispatch(CounterAction.Increment)</code></pre>
+    </div>
+
+    <div class="container platforms">
+        <h2>Platform Support</h2>
+        <table>
+            <thead><tr><th>Platform</th><th>Kotlin</th><th>Dart</th></tr></thead>
+            <tbody>
+                <tr><td>JVM</td><td>Yes</td><td>-</td></tr>
+                <tr><td>Android</td><td>Yes</td><td>-</td></tr>
+                <tr><td>iOS</td><td>Yes</td><td>-</td></tr>
+                <tr><td>JavaScript</td><td>Yes</td><td>Yes</td></tr>
+                <tr><td>WebAssembly</td><td>Yes</td><td>-</td></tr>
+                <tr><td>Flutter</td><td>-</td><td>Yes</td></tr>
+            </tbody>
+        </table>
+    </div>
+
+    <div class="container">
+        <h2>Documentation</h2>
+        <ul class="docs-links">
+            <li><a href="https://github.com/chibimoons/flowdux/blob/main/docs/guide/architecture.md">Architecture - Store pipeline, middleware chain, action flow</a></li>
+            <li><a href="https://github.com/chibimoons/flowdux/blob/main/docs/guide/execution-strategies.md">Execution Strategies - takeLatest, debounce, throttle, retry</a></li>
+            <li><a href="https://github.com/chibimoons/flowdux/blob/main/docs/guide/remote.md">Remote (WebSocket) - Client-server state sync</a></li>
+            <li><a href="https://github.com/chibimoons/flowdux/blob/main/docs/guide/timetravel.md">Time Travel - Undo/redo, state history</a></li>
+            <li><a href="https://github.com/chibimoons/flowdux/blob/main/docs/guide/samples.md">Sample Apps - How to run each sample</a></li>
+            <li><a href="https://github.com/chibimoons/flowdux/blob/main/dart/flowdux/README.md">Dart/Flutter - API, widgets, stream integration</a></li>
+        </ul>
+    </div>
+
+    <footer>
+        <p>Flowdux is open source under the <a href="https://github.com/chibimoons/flowdux/blob/main/LICENSE">Apache License 2.0</a>.</p>
+        <p style="margin-top:8px;"><a href="https://github.com/chibimoons/flowdux">GitHub</a> &middot; <a href="https://jitpack.io/#chibimoons/flowdux">JitPack</a> &middot; <a href="https://pub.dev/packages/flowdux">pub.dev</a></p>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `docs/index.html` as a GitHub Pages landing page with SEO meta tags
- Includes Open Graph tags, canonical URL, keywords, and structured content
- Prerequisite for enabling GitHub Pages and search engine indexing

## After merge
1. Enable GitHub Pages: **Settings > Pages > Source: main branch, /docs folder**
2. Set homepage URL (automated below)

## Test plan
- [x] `docs/index.html` renders correctly in browser
- [ ] Enable Pages after merge and verify `https://chibimoons.github.io/flowdux/` loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)