### PR TITLE
fix(ktor): guard connect() with Mutex to prevent race condition (#87)

### DIFF
--- a/kotlin/remote/ktor/src/commonMain/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnection.kt
+++ b/kotlin/remote/ktor/src/commonMain/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnection.kt
@@ -16,6 +16,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 /**
  * Ktor-based WebSocket client implementation of [ClientConnection].
@@ -57,6 +59,7 @@ class KtorWebSocketClientConnection(
     private val outgoingChannel = Channel<String>(Channel.UNLIMITED)
 
     private var session: WebSocketSession? = null
+    private val connectMutex = Mutex()
 
     override suspend fun send(message: String) {
         if (_connectionState.value != ConnectionState.CONNECTED) {
@@ -66,8 +69,10 @@ class KtorWebSocketClientConnection(
     }
 
     override suspend fun connect() {
-        if (_connectionState.value != ConnectionState.DISCONNECTED) return
-        _connectionState.value = ConnectionState.CONNECTING
+        connectMutex.withLock {
+            if (_connectionState.value != ConnectionState.DISCONNECTED) return
+            _connectionState.value = ConnectionState.CONNECTING
+        }
 
         try {
             httpClient.webSocket(url) {

--- a/kotlin/remote/ktor/src/jvmTest/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnectionTest.kt
+++ b/kotlin/remote/ktor/src/jvmTest/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnectionTest.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -151,6 +152,44 @@ class KtorWebSocketClientConnectionTest {
             delay(500)
 
             assertTrue(serverSessionEnded.get(), "Server session should end after client disconnect")
+        } finally {
+            server.stop(500, 1_000)
+        }
+    }
+
+    @Test
+    fun `concurrent connect calls create only one connection`() = runBlocking {
+        val connectionCount = AtomicInteger(0)
+        val server = embeddedServer(CIO, port = 0) {
+            install(WebSockets)
+            routing {
+                webSocket("/test") {
+                    connectionCount.incrementAndGet()
+                    for (frame in incoming) { /* keep alive */ }
+                }
+            }
+        }.start(wait = false)
+
+        try {
+            val port = server.resolvedConnectors().first().port
+            val connection = KtorWebSocketClientConnection("ws://localhost:$port/test")
+
+            // Launch 10 coroutines that all call connect() concurrently
+            val jobs = (1..10).map {
+                launch(Dispatchers.Default) { connection.connect() }
+            }
+
+            // Wait for connection to be established
+            withTimeout(5_000) {
+                connection.connectionState.first { it == ConnectionState.CONNECTED }
+            }
+            // Allow time for any extra connections to be established
+            delay(1_000)
+
+            assertEquals(1, connectionCount.get(), "Only one WebSocket connection should be created")
+
+            connection.disconnect()
+            jobs.forEach { it.join() }
         } finally {
             server.stop(500, 1_000)
         }


### PR DESCRIPTION
## Summary
- `connect()`의 non-atomic check-then-act guard를 `Mutex.withLock`으로 감싸서 동시 호출 시 중복 WebSocket 연결이 생성되는 race condition 수정
- 10개 코루틴에서 동시 `connect()` 호출 시 서버 연결이 1개만 생성되는지 검증하는 테스트 추가

## Test plan
- [x] 수정 전 코드로 새 테스트 실패 확인 (RED)
- [x] Mutex 적용 후 새 테스트 통과 확인 (GREEN)
- [x] 기존 4개 테스트 전부 통과 확인

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)