### PR TITLE
chore(flutter): bump flowdux_flutter to 0.2.5

### DIFF
--- a/dart/flowdux_flutter/CHANGELOG.md
+++ b/dart/flowdux_flutter/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.5] - 2026-02-04
+
+### Fixed
+
+- Fix selector not recalculating when selector function instance changes in didUpdateWidget
+- Fix StoreConsumer listener firing on every rebuild instead of only on real state changes
+- Replace StreamBuilder with StreamSubscription in _SelectorBuilder and StoreSelector for optimized rebuilds
+
+### Changed
+
+- Update flowdux dependency from ^0.2.3 to ^0.3.1
+
 ## [0.2.4] - 2026-01-24
 
 ### Changed

--- a/dart/flowdux_flutter/pubspec.yaml
+++ b/dart/flowdux_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: flowdux_flutter
 description: >
   Flutter bindings for FlowDux state management library.
   Provides StoreProvider, StoreBuilder, and StoreConsumer widgets.
-version: 0.2.4
+version: 0.2.5
 homepage: https://github.com/chibimoons/flowdux
 repository: https://github.com/chibimoons/flowdux
 issue_tracker: https://github.com/chibimoons/flowdux/issues


### PR DESCRIPTION
## Summary
- Bump `flowdux_flutter` version from 0.2.4 to 0.2.5
- Add CHANGELOG entry for 0.2.5 with fix descriptions from PR #108

### Fixes included in 0.2.5
- Fix selector not recalculating when selector function instance changes in `didUpdateWidget`
- Fix `StoreConsumer` listener firing on every rebuild instead of only on real state changes
- Replace `StreamBuilder` with `StreamSubscription` in `_SelectorBuilder` and `StoreSelector` for optimized rebuilds
- Update flowdux dependency from `^0.2.3` to `^0.3.1`

## Test plan
- [x] Verify CHANGELOG format follows Keep a Changelog spec
- [x] Verify pubspec.yaml version matches CHANGELOG
- [ ] Merge to main, tag `dart/0.2.5`, publish to pub.dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)