### PR TITLE
feat(kotlin): add Maven Central publishing

### DIFF
--- a/.github/workflows/publish-maven-central.yml
+++ b/.github/workflows/publish-maven-central.yml
@@ -1,0 +1,48 @@
+name: Publish to Maven Central
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (publish to Maven Local only)'
+        required: false
+        default: 'true'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+
+jobs:
+  publish:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Publish to Maven Local (dry run)
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true'
+        run: |
+          ./gradlew publishToMavenLocal -x kotlinNpmInstall -x kotlinStoreYarnLock
+
+      - name: Publish to Maven Central
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'false')
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_KEY_PASSWORD }}
+        run: |
+          ./gradlew publishAllPublicationsToMavenCentralRepository -x kotlinNpmInstall -x kotlinStoreYarnLock

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,0 +1,6 @@
+plugins {
+    `kotlin-dsl`
+}
+dependencies {
+    implementation("com.vanniktech:gradle-maven-publish-plugin:0.36.0")
+}

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,0 +1,7 @@
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+rootProject.name = "build-logic"

--- a/build-logic/src/main/kotlin/flowdux.publish-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/flowdux.publish-conventions.gradle.kts
@@ -1,0 +1,33 @@
+plugins {
+    id("com.vanniktech.maven.publish")
+}
+
+mavenPublishing {
+    publishToMavenCentral(automaticRelease = true)
+    signAllPublications()
+
+    pom {
+        url.set("https://github.com/chibimoons/flowdux")
+
+        licenses {
+            license {
+                name.set("Apache License 2.0")
+                url.set("https://www.apache.org/licenses/LICENSE-2.0")
+            }
+        }
+
+        developers {
+            developer {
+                id.set("chibimoons")
+                name.set("chibimoons")
+                url.set("https://github.com/chibimoons")
+            }
+        }
+
+        scm {
+            url.set("https://github.com/chibimoons/flowdux")
+            connection.set("scm:git:git://github.com/chibimoons/flowdux.git")
+            developerConnection.set("scm:git:ssh://git@github.com/chibimoons/flowdux.git")
+        }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,5 @@ android.r8.strictFullModeForKeepRules=false
 android.r8.optimizedResourceShrinking=false
 android.builtInKotlin=false
 android.newDsl=false
+
+flowdux.version=1.11.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ lifecycle = "2.7.0"
 ktor = "2.3.7"
 kotlinx-serialization-json = "1.7.3"
 kotlinx-browser = "0.3"
+mavenPublish = "0.36.0"
 
 [libraries]
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }

--- a/kotlin/flowdux/build.gradle.kts
+++ b/kotlin/flowdux/build.gradle.kts
@@ -1,10 +1,15 @@
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
-    `maven-publish`
+    id("flowdux.publish-conventions")
 }
 
-group = "io.flowdux"
-version = "1.10.0"
+mavenPublishing {
+    coordinates("io.github.chibimoons", "flowdux", providers.gradleProperty("flowdux.version").get())
+    pom {
+        name.set("Flowdux")
+        description.set("A lightweight Redux-style state management library for Kotlin Multiplatform")
+    }
+}
 
 // JitPack only publishes JVM artifacts to avoid variant resolution issues for JVM/Android consumers
 val isJitPack = System.getenv("JITPACK") == "true"
@@ -52,23 +57,3 @@ kotlin {
         }
     }
 }
-
-publishing {
-    publications {
-        withType<MavenPublication> {
-            pom {
-                name.set("Flowdux")
-                description.set("A lightweight Redux-style state management library for Kotlin Multiplatform")
-                url.set("https://github.com/chibimoons/flowdux")
-
-                licenses {
-                    license {
-                        name.set("Apache License 2.0")
-                        url.set("https://www.apache.org/licenses/LICENSE-2.0")
-                    }
-                }
-            }
-        }
-    }
-}
-

--- a/kotlin/remote/client/build.gradle.kts
+++ b/kotlin/remote/client/build.gradle.kts
@@ -1,10 +1,15 @@
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
-    `maven-publish`
+    id("flowdux.publish-conventions")
 }
 
-group = "io.flowdux"
-version = "1.10.0"
+mavenPublishing {
+    coordinates("io.github.chibimoons", "flowdux-remote-client", providers.gradleProperty("flowdux.version").get())
+    pom {
+        name.set("Flowdux Remote Client")
+        description.set("Client middleware for server-driven state management with Flowdux")
+    }
+}
 
 // JitPack only publishes JVM artifacts to avoid variant resolution issues for JVM/Android consumers
 val isJitPack = System.getenv("JITPACK") == "true"
@@ -49,25 +54,6 @@ kotlin {
             compileTaskProvider.configure {
                 compilerOptions {
                     jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
-                }
-            }
-        }
-    }
-}
-
-publishing {
-    publications {
-        withType<MavenPublication> {
-            pom {
-                name.set("Flowdux Remote Client")
-                description.set("Client middleware for server-driven state management with Flowdux")
-                url.set("https://github.com/chibimoons/flowdux")
-
-                licenses {
-                    license {
-                        name.set("Apache License 2.0")
-                        url.set("https://www.apache.org/licenses/LICENSE-2.0")
-                    }
                 }
             }
         }

--- a/kotlin/remote/core/build.gradle.kts
+++ b/kotlin/remote/core/build.gradle.kts
@@ -1,10 +1,15 @@
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
-    `maven-publish`
+    id("flowdux.publish-conventions")
 }
 
-group = "io.flowdux"
-version = "1.10.0"
+mavenPublishing {
+    coordinates("io.github.chibimoons", "flowdux-remote-core", providers.gradleProperty("flowdux.version").get())
+    pom {
+        name.set("Flowdux Remote Core")
+        description.set("Shared contracts for Flowdux remote state management")
+    }
+}
 
 // JitPack only publishes JVM artifacts to avoid variant resolution issues for JVM/Android consumers
 val isJitPack = System.getenv("JITPACK") == "true"
@@ -48,25 +53,6 @@ kotlin {
             compileTaskProvider.configure {
                 compilerOptions {
                     jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
-                }
-            }
-        }
-    }
-}
-
-publishing {
-    publications {
-        withType<MavenPublication> {
-            pom {
-                name.set("Flowdux Remote Core")
-                description.set("Shared contracts for Flowdux remote state management")
-                url.set("https://github.com/chibimoons/flowdux")
-
-                licenses {
-                    license {
-                        name.set("Apache License 2.0")
-                        url.set("https://www.apache.org/licenses/LICENSE-2.0")
-                    }
                 }
             }
         }

--- a/kotlin/remote/ktor/build.gradle.kts
+++ b/kotlin/remote/ktor/build.gradle.kts
@@ -1,10 +1,15 @@
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
-    `maven-publish`
+    id("flowdux.publish-conventions")
 }
 
-group = "io.flowdux"
-version = "1.10.0"
+mavenPublishing {
+    coordinates("io.github.chibimoons", "flowdux-remote-ktor", providers.gradleProperty("flowdux.version").get())
+    pom {
+        name.set("Flowdux Remote Ktor")
+        description.set("Ktor WebSocket implementation for Flowdux remote modules")
+    }
+}
 
 // JitPack only publishes JVM artifacts to avoid variant resolution issues for JVM/Android consumers
 val isJitPack = System.getenv("JITPACK") == "true"
@@ -49,25 +54,6 @@ kotlin {
             compileTaskProvider.configure {
                 compilerOptions {
                     jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
-                }
-            }
-        }
-    }
-}
-
-publishing {
-    publications {
-        withType<MavenPublication> {
-            pom {
-                name.set("Flowdux Remote Ktor")
-                description.set("Ktor WebSocket implementation for Flowdux remote modules")
-                url.set("https://github.com/chibimoons/flowdux")
-
-                licenses {
-                    license {
-                        name.set("Apache License 2.0")
-                        url.set("https://www.apache.org/licenses/LICENSE-2.0")
-                    }
                 }
             }
         }

--- a/kotlin/remote/serialization/build.gradle.kts
+++ b/kotlin/remote/serialization/build.gradle.kts
@@ -1,11 +1,16 @@
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.kotlinSerialization)
-    `maven-publish`
+    id("flowdux.publish-conventions")
 }
 
-group = "io.flowdux"
-version = "1.10.0"
+mavenPublishing {
+    coordinates("io.github.chibimoons", "flowdux-remote-serialization", providers.gradleProperty("flowdux.version").get())
+    pom {
+        name.set("Flowdux Remote Serialization")
+        description.set("kotlinx.serialization-based ActionCodec for Flowdux remote state management")
+    }
+}
 
 // JitPack only publishes JVM artifacts to avoid variant resolution issues for JVM/Android consumers
 val isJitPack = System.getenv("JITPACK") == "true"
@@ -50,25 +55,6 @@ kotlin {
             compileTaskProvider.configure {
                 compilerOptions {
                     jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
-                }
-            }
-        }
-    }
-}
-
-publishing {
-    publications {
-        withType<MavenPublication> {
-            pom {
-                name.set("Flowdux Remote Serialization")
-                description.set("kotlinx.serialization-based ActionCodec for Flowdux remote state management")
-                url.set("https://github.com/chibimoons/flowdux")
-
-                licenses {
-                    license {
-                        name.set("Apache License 2.0")
-                        url.set("https://www.apache.org/licenses/LICENSE-2.0")
-                    }
                 }
             }
         }

--- a/kotlin/remote/server/build.gradle.kts
+++ b/kotlin/remote/server/build.gradle.kts
@@ -1,10 +1,15 @@
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
-    `maven-publish`
+    id("flowdux.publish-conventions")
 }
 
-group = "io.flowdux"
-version = "1.10.0"
+mavenPublishing {
+    coordinates("io.github.chibimoons", "flowdux-remote-server", providers.gradleProperty("flowdux.version").get())
+    pom {
+        name.set("Flowdux Remote Server")
+        description.set("Server-side components for Flowdux remote state management")
+    }
+}
 
 // JitPack only publishes JVM artifacts to avoid variant resolution issues for JVM/Android consumers
 val isJitPack = System.getenv("JITPACK") == "true"
@@ -49,25 +54,6 @@ kotlin {
             compileTaskProvider.configure {
                 compilerOptions {
                     jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
-                }
-            }
-        }
-    }
-}
-
-publishing {
-    publications {
-        withType<MavenPublication> {
-            pom {
-                name.set("Flowdux Remote Server")
-                description.set("Server-side components for Flowdux remote state management")
-                url.set("https://github.com/chibimoons/flowdux")
-
-                licenses {
-                    license {
-                        name.set("Apache License 2.0")
-                        url.set("https://www.apache.org/licenses/LICENSE-2.0")
-                    }
                 }
             }
         }

--- a/kotlin/timetravel/build.gradle.kts
+++ b/kotlin/timetravel/build.gradle.kts
@@ -1,10 +1,15 @@
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
-    `maven-publish`
+    id("flowdux.publish-conventions")
 }
 
-group = "io.flowdux"
-version = "1.10.0"
+mavenPublishing {
+    coordinates("io.github.chibimoons", "flowdux-timetravel", providers.gradleProperty("flowdux.version").get())
+    pom {
+        name.set("Flowdux Time Travel")
+        description.set("Time travel debugging extension for Flowdux")
+    }
+}
 
 // JitPack only publishes JVM artifacts to avoid variant resolution issues for JVM/Android consumers
 val isJitPack = System.getenv("JITPACK") == "true"
@@ -54,23 +59,3 @@ kotlin {
         }
     }
 }
-
-publishing {
-    publications {
-        withType<MavenPublication> {
-            pom {
-                name.set("Flowdux Time Travel")
-                description.set("Time travel debugging extension for Flowdux")
-                url.set("https://github.com/chibimoons/flowdux")
-
-                licenses {
-                    license {
-                        name.set("Apache License 2.0")
-                        url.set("https://www.apache.org/licenses/LICENSE-2.0")
-                    }
-                }
-            }
-        }
-    }
-}
-

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,5 @@
 pluginManagement {
+    includeBuild("build-logic")
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
## Summary
- vanniktech/gradle-maven-publish-plugin 0.36.0 기반 build-logic convention plugin 추가
- 7개 Kotlin 모듈을 `io.github.chibimoons` groupId로 Maven Central(Sonatype Central Portal)에 배포 설정
- GitHub Actions 워크플로우 추가 (버전 태그 push 시 자동 배포, workflow_dispatch dry-run 지원)

## Changes
- **New**: `build-logic/` convention plugin (settings, build, publish-conventions)
- **New**: `.github/workflows/publish-maven-central.yml`
- **Modified**: `settings.gradle.kts` — `includeBuild("build-logic")`
- **Modified**: `gradle.properties` — `flowdux.version=1.11.0`
- **Modified**: `gradle/libs.versions.toml` — `mavenPublish` 버전 추가
- **Modified**: 7개 모듈 `build.gradle.kts` — `maven-publish` → `flowdux.publish-conventions`, `mavenPublishing {}` 블록 추가, `publishing {}` 블록 제거

## Test plan
- [x] `./gradlew :kotlin:flowdux:tasks --group=publishing` — publishing 태스크 확인
- [x] `./gradlew :kotlin:flowdux:publishToMavenLocal` — 아티팩트 + GPG 서명 생성 확인
- [x] POM 메타데이터 검증 (developers, scm, licenses 포함)
- [ ] GitHub Actions dry-run (workflow_dispatch)
- [ ] 태그 push 후 Maven Central 배포 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)