### PR TITLE
fix(test): fix flaky throttle test for CI

### DIFF
--- a/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/strategy/TimingStrategyTest.kt
+++ b/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/strategy/TimingStrategyTest.kt
@@ -121,7 +121,7 @@ class TimingStrategyTest {
 
             val middleware = object : Middleware<TestState, TestAction> {
                 override val processors = buildProcessors {
-                    on<TestAction.Click>(throttle(100.milliseconds)) { _, action ->
+                    on<TestAction.Click>(throttle(300.milliseconds)) { _, action ->
                         executedClicks.add(action.buttonId)
                         emit(TestAction.ClickProcessed(action.buttonId))
                     }
@@ -145,13 +145,13 @@ class TimingStrategyTest {
                     awaitItem()
 
                     // Clicks within throttle window - should be ignored
-                    delay(20)
+                    delay(50)
                     store.dispatch(TestAction.Click("2"))
-                    delay(30)
+                    delay(50)
                     store.dispatch(TestAction.Click("3"))
 
                     // Click after throttle window - should execute
-                    delay(100)
+                    delay(400)
                     store.dispatch(TestAction.Click("4"))
                     awaitItem()
 


### PR DESCRIPTION
## Summary
- `TimingStrategyTest.ThrottleTests.throttle limits execution rate` 테스트가 CI에서 간헐적으로 실패
- throttle 윈도우 100ms → 300ms, post-window delay 100ms → 400ms로 마진 확대
- CI 환경의 스케줄링 지터를 고려한 안정적인 타이밍으로 수정

## Test plan
- [x] 로컬 JVM 테스트 통과
- [ ] CI 테스트 통과 확인