### PR TITLE
fix(test): increase timing margins for flaky CI tests

### DIFF
--- a/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/strategy/ConcurrencyStrategyTest.kt
+++ b/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/strategy/ConcurrencyStrategyTest.kt
@@ -519,6 +519,7 @@ class ConcurrencyStrategyTest {
 
         @Test
         fun `takeLatest cancels previous execution with real dispatcher`() = runBlocking {
+            // Large timing margins are needed for CI (especially iosSimulatorArm64).
             val executionOrder = mutableListOf<String>()
             val storeScope = CoroutineScope(Dispatchers.Default + Job())
 
@@ -526,7 +527,7 @@ class ConcurrencyStrategyTest {
                 override val processors = buildProcessors {
                     on<TestAction.Fetch>(takeLatest()) { _, action ->
                         executionOrder.add("start-${action.id}")
-                        delay(100)
+                        delay(500)
                         executionOrder.add("end-${action.id}")
                         emit(TestAction.FetchSuccess(action.id, "result-${action.id}"))
                     }
@@ -547,7 +548,7 @@ class ConcurrencyStrategyTest {
 
                     // Dispatch first action
                     store.dispatch(TestAction.Fetch("1"))
-                    delay(30) // Let it start but not complete
+                    delay(200) // Let it start but not complete
 
                     // Dispatch second action - should cancel first
                     store.dispatch(TestAction.Fetch("2"))
@@ -557,7 +558,7 @@ class ConcurrencyStrategyTest {
                     assertEquals(listOf("result-2"), result.values)
 
                     // Give some time for any pending operations
-                    delay(50)
+                    delay(300)
 
                     // Verify first was started but canceled
                     assertTrue(executionOrder.contains("start-1"))

--- a/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/strategy/ResilienceStrategyTest.kt
+++ b/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/strategy/ResilienceStrategyTest.kt
@@ -372,6 +372,7 @@ class ResilienceStrategyTest {
 
     @Test
     fun `retryWithBackoff works with real dispatcher`() = runBlocking {
+        // Large timing margins are needed for CI (especially iosSimulatorArm64).
         val attemptTimes = mutableListOf<Long>()
         var attempt = 0
         val startMark = kotlin.time.TimeSource.Monotonic.markNow()
@@ -381,7 +382,7 @@ class ResilienceStrategyTest {
             override val processors = buildProcessors {
                 on<TestAction.Fetch>(retryWithBackoff(
                     maxAttempts = 3,
-                    initialDelay = 50.milliseconds,
+                    initialDelay = 200.milliseconds,
                     factor = 2.0
                 )) { _, action ->
                     attemptTimes.add(startMark.elapsedNow().inWholeMilliseconds)
@@ -417,14 +418,14 @@ class ResilienceStrategyTest {
 
                 // Verify exponential backoff timing with generous tolerance
                 // First attempt: immediate (0ms)
-                // Second attempt: after ~50ms delay
-                // Third attempt: after ~100ms delay (50ms * 2)
+                // Second attempt: after ~200ms delay
+                // Third attempt: after ~400ms delay (200ms * 2)
                 val delay1to2 = attemptTimes[1] - attemptTimes[0]
                 val delay2to3 = attemptTimes[2] - attemptTimes[1]
 
                 // Allow generous timing tolerance for real dispatcher
-                assertTrue(delay1to2 >= 30, "First delay should be at least 30ms but was $delay1to2")
-                assertTrue(delay2to3 >= 60, "Second delay should be at least 60ms but was $delay2to3")
+                assertTrue(delay1to2 >= 100, "First delay should be at least 100ms but was $delay1to2")
+                assertTrue(delay2to3 >= 200, "Second delay should be at least 200ms but was $delay2to3")
                 assertTrue(delay2to3 > delay1to2, "Second delay should be longer than first (exponential backoff)")
 
                 cancelAndIgnoreRemainingEvents()

--- a/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/strategy/StrategyGroupTest.kt
+++ b/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/strategy/StrategyGroupTest.kt
@@ -236,12 +236,13 @@ class StrategyGroupTest {
 
     @Test
     fun `group with throttle limits rate across different action types`() = runBlocking {
+        // Large timing margins are needed for CI (especially iosSimulatorArm64).
         val executionOrder = mutableListOf<String>()
         val storeScope = CoroutineScope(Dispatchers.Default + Job())
 
         val middleware = object : Middleware<TestState, TestAction> {
             override val processors = buildProcessors {
-                group(throttle(100.milliseconds)) {
+                group(throttle(500.milliseconds)) {
                     on<TestAction.Fetch> { _, action ->
                         executionOrder.add("fetch-${action.id}")
                         emit(TestAction.FetchSuccess(action.id, action.id))
@@ -271,11 +272,11 @@ class StrategyGroupTest {
                 awaitItem()
 
                 // Second action (different type) within throttle window - should be ignored
-                delay(30)
+                delay(100)
                 store.dispatch(TestAction.Search("query"))
 
                 // Third action after throttle window - should execute
-                delay(100)
+                delay(800)
                 store.dispatch(TestAction.Search("query2"))
                 awaitItem()
 

--- a/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/strategy/TimingStrategyTest.kt
+++ b/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/strategy/TimingStrategyTest.kt
@@ -115,13 +115,14 @@ class TimingStrategyTest {
 
         @Test
         fun `throttle limits execution rate`() = runBlocking {
-            // Throttle uses real time (TimeSource.Monotonic), so we use runBlocking
+            // Throttle uses real time (TimeSource.Monotonic), so we use runBlocking.
+            // Large timing margins are needed for CI (especially iosSimulatorArm64).
             val executedClicks = mutableListOf<String>()
             val storeScope = CoroutineScope(Dispatchers.Default + Job())
 
             val middleware = object : Middleware<TestState, TestAction> {
                 override val processors = buildProcessors {
-                    on<TestAction.Click>(throttle(300.milliseconds)) { _, action ->
+                    on<TestAction.Click>(throttle(500.milliseconds)) { _, action ->
                         executedClicks.add(action.buttonId)
                         emit(TestAction.ClickProcessed(action.buttonId))
                     }
@@ -145,13 +146,13 @@ class TimingStrategyTest {
                     awaitItem()
 
                     // Clicks within throttle window - should be ignored
-                    delay(50)
+                    delay(100)
                     store.dispatch(TestAction.Click("2"))
-                    delay(50)
+                    delay(100)
                     store.dispatch(TestAction.Click("3"))
 
                     // Click after throttle window - should execute
-                    delay(400)
+                    delay(800)
                     store.dispatch(TestAction.Click("4"))
                     awaitItem()
 


### PR DESCRIPTION
## Summary

- Increased throttle windows, delays, and assertion thresholds across 4 real-time test files
- Tests using `runBlocking` with `Dispatchers.Default` are sensitive to scheduling jitter on slow CI environments (especially `iosSimulatorArm64`)
- Affected tests:
  - `TimingStrategyTest.throttle limits execution rate` — throttle 300ms→500ms, post-window delay 400ms→800ms
  - `ConcurrencyStrategyTest.takeLatest cancels previous execution with real dispatcher` — processor delay 100ms→500ms, start-detection delay 30ms→200ms
  - `ResilienceStrategyTest.retryWithBackoff works with real dispatcher` — initialDelay 50ms→200ms, assertion thresholds adjusted proportionally
  - `StrategyGroupTest.group with throttle limits rate across different action types` — throttle 100ms→500ms, post-window delay 100ms→800ms

## Test plan

- [ ] Verify all 4 tests pass locally (`./gradlew :kotlin:flowdux:jvmTest`)
- [ ] Re-run Maven Central publish dry-run workflow to verify CI stability

🤖 Generated with [Claude Code](https://claude.com/claude-code)