### PR TITLE
fix(test): replace assert() with assertTrue() for Kotlin Native

### DIFF
--- a/kotlin/remote/serialization/src/commonTest/kotlin/io/flowdux/remote/serialization/SerializableActionCodecTest.kt
+++ b/kotlin/remote/serialization/src/commonTest/kotlin/io/flowdux/remote/serialization/SerializableActionCodecTest.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.SerializationException
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 class SerializableActionCodecTest {
 
@@ -68,7 +69,7 @@ class SerializableActionCodecTest {
     @Test
     fun classDiscriminatorUsesTypeField() {
         val json = codec.encode(TestAction.Add(10))
-        assert(json.contains("\"type\":")) { "Expected 'type' discriminator in: $json" }
+        assertTrue(json.contains("\"type\":"), "Expected 'type' discriminator in: $json")
     }
 
     @Test


### PR DESCRIPTION
## Summary

- `assert()` in Kotlin Native requires `@ExperimentalNativeApi` opt-in, causing compilation failure on iOS targets in CI
- Replaced with `kotlin.test.assertTrue()` which works across all KMP targets

## Test plan

- [ ] Re-run Maven Central publish dry-run workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)