### PR TITLE
fix(publish): make GPG signing conditional on key availability

### DIFF
--- a/build-logic/src/main/kotlin/flowdux.publish-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/flowdux.publish-conventions.gradle.kts
@@ -4,7 +4,11 @@ plugins {
 
 mavenPublishing {
     publishToMavenCentral(automaticRelease = true)
-    signAllPublications()
+
+    // Only sign when signing credentials are available (skipped during dry-run)
+    if (providers.gradleProperty("signingInMemoryKey").isPresent) {
+        signAllPublications()
+    }
 
     pom {
         url.set("https://github.com/chibimoons/flowdux")


### PR DESCRIPTION
## Summary

- CI dry-run (`publishToMavenLocal`) fails because no signing credentials are available
- `signAllPublications()` now only activates when `signingInMemoryKey` Gradle property is present
- Actual Maven Central publish step passes secrets via `ORG_GRADLE_PROJECT_` env vars, so signing works as before

## Test plan

- [ ] Re-run Maven Central publish dry-run workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)