### PR TITLE
fix(publish): resolve MavenCentralBuildService classloader conflict

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,4 +5,5 @@ plugins {
     alias(libs.plugins.androidApplication) apply false
     alias(libs.plugins.androidLibrary) apply false
     alias(libs.plugins.kotlinCompose) apply false
+    alias(libs.plugins.mavenPublish) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+mavenPublish = "0.36.0"
 kotlin = "2.2.10"
 coroutines = "1.8.1"
 datetime = "0.5.0"
@@ -47,3 +48,4 @@ androidApplication = { id = "com.android.application", version.ref = "agp" }
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
 kotlinCompose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish" }


### PR DESCRIPTION
## Summary

- vanniktech maven-publish plugin applied to multiple sibling projects causes `MavenCentralBuildService` classloader conflict
- Added `alias(libs.plugins.mavenPublish) apply false` to root `build.gradle.kts` so all subprojects share the same classloader
- Added `mavenPublish` version and plugin entry to `libs.versions.toml`

## Test plan

- [ ] After merge, delete tag `1.11.0` and re-tag to trigger actual Maven Central publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)