### PR TITLE
release: 1.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Add the dependency to your KMP project's `build.gradle.kts`:
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            implementation("io.github.chibimoons:flowdux:1.11.0")
+            implementation("io.github.chibimoons:flowdux:1.12.0")
         }
     }
 }
@@ -45,7 +45,7 @@ If your project is not KMP, add the dependency directly:
 
 ```kotlin
 dependencies {
-    implementation("io.github.chibimoons:flowdux:1.11.0")
+    implementation("io.github.chibimoons:flowdux:1.12.0")
 }
 ```
 
@@ -58,15 +58,15 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             // Shared action markers (ServerSharedAction, ClientSharedAction)
-            implementation("io.github.chibimoons:flowdux-remote-core:1.11.0")
+            implementation("io.github.chibimoons:flowdux-remote-core:1.12.0")
             // Client middleware (ClientRemoteMiddleware)
-            implementation("io.github.chibimoons:flowdux-remote-client:1.11.0")
+            implementation("io.github.chibimoons:flowdux-remote-client:1.12.0")
             // Server middleware (ServerRemoteMiddleware)
-            implementation("io.github.chibimoons:flowdux-remote-server:1.11.0")
+            implementation("io.github.chibimoons:flowdux-remote-server:1.12.0")
             // kotlinx.serialization codecs (ActionCodec, MessageCodec)
-            implementation("io.github.chibimoons:flowdux-remote-serialization:1.11.0")
+            implementation("io.github.chibimoons:flowdux-remote-serialization:1.12.0")
             // Ktor WebSocket transport (JVM, iOS, JS — WASM not supported)
-            implementation("io.github.chibimoons:flowdux-remote-ktor:1.11.0")
+            implementation("io.github.chibimoons:flowdux-remote-ktor:1.12.0")
         }
     }
 }

--- a/docs/guide/remote.md
+++ b/docs/guide/remote.md
@@ -39,15 +39,15 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             // Shared action markers (ServerSharedAction, ClientSharedAction)
-            implementation("io.github.chibimoons:flowdux-remote-core:1.11.0")
+            implementation("io.github.chibimoons:flowdux-remote-core:1.12.0")
             // Client middleware (ClientRemoteMiddleware)
-            implementation("io.github.chibimoons:flowdux-remote-client:1.11.0")
+            implementation("io.github.chibimoons:flowdux-remote-client:1.12.0")
             // Server middleware (ServerRemoteMiddleware)
-            implementation("io.github.chibimoons:flowdux-remote-server:1.11.0")
+            implementation("io.github.chibimoons:flowdux-remote-server:1.12.0")
             // kotlinx.serialization codecs (ActionCodec, MessageCodec)
-            implementation("io.github.chibimoons:flowdux-remote-serialization:1.11.0")
+            implementation("io.github.chibimoons:flowdux-remote-serialization:1.12.0")
             // Ktor WebSocket transport (JVM, iOS, JS — WASM not supported)
-            implementation("io.github.chibimoons:flowdux-remote-ktor:1.11.0")
+            implementation("io.github.chibimoons:flowdux-remote-ktor:1.12.0")
         }
     }
 }

--- a/docs/guide/timetravel.md
+++ b/docs/guide/timetravel.md
@@ -9,14 +9,14 @@ Time travel debugging is available as a separate module.
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            implementation("io.github.chibimoons:flowdux-timetravel:1.11.0")
+            implementation("io.github.chibimoons:flowdux-timetravel:1.12.0")
         }
     }
 }
 
 // build.gradle.kts (JVM / Android)
 dependencies {
-    implementation("io.github.chibimoons:flowdux-timetravel:1.11.0")
+    implementation("io.github.chibimoons:flowdux-timetravel:1.12.0")
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,4 +17,4 @@ android.r8.optimizedResourceShrinking=false
 android.builtInKotlin=false
 android.newDsl=false
 
-flowdux.version=1.11.0
+flowdux.version=1.12.0


### PR DESCRIPTION
## Summary

- feat: flowdux-remote-ktor JS target support (ktor-client-js engine)
- docs: KMP installation guide, version bump to 1.12.0

## Changes since 1.11.0

- `flowdux-remote-ktor` now supports JVM, iOS, **JS** (WASM not supported by Ktor)
- README updated with KMP `commonMain.dependencies` installation guide
- `docs/guide/remote.md`, `docs/guide/timetravel.md` updated to Maven Central coordinates

🤖 Generated with [Claude Code](https://claude.com/claude-code)