### PR TITLE
fix(server): use Channel(CONFLATED) for ResponseCollector signal (#77)

### DIFF
--- a/kotlin/remote/server/src/commonMain/kotlin/io/flowdux/remote/server/ResponseCollector.kt
+++ b/kotlin/remote/server/src/commonMain/kotlin/io/flowdux/remote/server/ResponseCollector.kt
@@ -55,9 +55,14 @@ class ResponseCollector<S : State, A : Action> : NoOpStoreLogger<S, A>() {
     /**
      * Suspends until at least one reduction has occurred since the last call.
      *
-     * If a reduction already occurred before this call, returns immediately.
-     * If multiple reductions occur while suspended, only one signal is consumed
-     * (subsequent reductions will trigger the next [awaitNextReduction] call).
+     * **CONFLATED semantics:** The underlying signal channel is conflated, meaning:
+     * - If a reduction already occurred before this call, returns immediately
+     * - If multiple reductions occur while suspended, they coalesce into a single signal
+     * - After returning, subsequent reductions will signal the next [awaitNextReduction] call
+     *
+     * This design eliminates race conditions but means you cannot rely on a 1:1 mapping
+     * between [awaitNextReduction] calls and individual reductions. Use [drainPending]
+     * to retrieve all actions that were reduced.
      */
     suspend fun awaitNextReduction() {
         reductionSignal.receive()
@@ -76,5 +81,16 @@ class ResponseCollector<S : State, A : Action> : NoOpStoreLogger<S, A>() {
             result.add(action)
         }
         return result
+    }
+
+    /**
+     * Closes the collector, releasing underlying channel resources.
+     *
+     * After calling this method, [awaitNextReduction] will throw [kotlinx.coroutines.channels.ClosedReceiveChannelException]
+     * and [drainPending] will return any remaining pending actions until exhausted.
+     */
+    fun close() {
+        pending.close()
+        reductionSignal.close()
     }
 }

--- a/kotlin/remote/server/src/commonTest/kotlin/io/flowdux/remote/server/ResponseCollectorTest.kt
+++ b/kotlin/remote/server/src/commonTest/kotlin/io/flowdux/remote/server/ResponseCollectorTest.kt
@@ -177,7 +177,7 @@ class ResponseCollectorTest {
         }
 
         // If we reach here without timeout, the test passes
-        assertEquals(50, store.currentState.count.let { it * 2 / (0 + 49) }) // sum of 0..49 is 1225
+        assertEquals(1225, store.currentState.count) // sum of 0..49 is 1225
     }
 
     /**


### PR DESCRIPTION
## Summary
- `ResponseCollector`의 `reductionSignal`을 `CompletableDeferred`에서 `Channel(CONFLATED)`로 변경
- race condition으로 인한 signal 유실 문제 해결

## Test plan
- [x] 동시성 테스트 추가 (100 dispatches, 50 concurrent awaiters)
- [x] 스트레스 테스트 추가 (50 iterations rapid dispatch-await cycles)
- [x] 기존 테스트 통과

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)