### PR TITLE
fix(serialization): handle malformed JSON gracefully in TypedConnections (#86)

### DIFF
--- a/kotlin/remote/serialization/src/commonMain/kotlin/io/flowdux/remote/DefaultTypedClientConnection.kt
+++ b/kotlin/remote/serialization/src/commonMain/kotlin/io/flowdux/remote/DefaultTypedClientConnection.kt
@@ -1,6 +1,7 @@
 package io.flowdux.remote
 
 import io.flowdux.Action
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.transform
@@ -22,12 +23,16 @@ internal class DefaultTypedClientConnection<A : Action>(
     override val incoming: Flow<A> = connection.incoming.transform { raw ->
         val response = try {
             messageCodec.decodeServerMessage(raw)
+        } catch (e: CancellationException) {
+            throw e
         } catch (_: Exception) {
             return@transform // Skip malformed server messages
         }
         for (actionJson in response.actions) {
             val action = try {
                 actionCodec.decode(actionJson)
+            } catch (e: CancellationException) {
+                throw e
             } catch (_: Exception) {
                 continue // Skip malformed actions
             }

--- a/kotlin/remote/serialization/src/commonMain/kotlin/io/flowdux/remote/server/DefaultTypedServerConnection.kt
+++ b/kotlin/remote/serialization/src/commonMain/kotlin/io/flowdux/remote/server/DefaultTypedServerConnection.kt
@@ -3,6 +3,7 @@ package io.flowdux.remote.server
 import io.flowdux.Action
 import io.flowdux.remote.ActionCodec
 import io.flowdux.remote.MessageCodec
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.mapNotNull
 
@@ -20,6 +21,8 @@ internal class DefaultTypedServerConnection<A : Action>(
         try {
             val actionJson = messageCodec.decodeActionFromClient(raw)
             actionCodec.decode(actionJson)
+        } catch (e: CancellationException) {
+            throw e
         } catch (_: Exception) {
             null // Skip malformed messages
         }


### PR DESCRIPTION
## Summary
- `DefaultTypedClientConnection`과 `DefaultTypedServerConnection`에서 malformed JSON 예외 처리
- 잘못된 메시지는 skip하고 flow를 crash하지 않음

## Test plan
- [x] 기존 테스트 통과

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)