### PR TITLE
fix(deps): upgrade kotlinx.coroutines to 1.10.2 for wasmJs support (#94)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 kotlin = "2.2.10"
-coroutines = "1.8.1"
+coroutines = "1.10.2"
 datetime = "0.5.0"
 turbine = "1.1.0"
 junit5 = "5.10.1"


### PR DESCRIPTION
## Summary
- kotlinx.coroutines 1.8.1 → 1.10.2 업그레이드
- wasmJs에서 `RuntimeError: dereferencing a null pointer` 해결

## Problem
kotlinx.coroutines 1.8.1이 Kotlin 2.2.10의 wasmJs 타겟과 호환되지 않아 인터페이스 vtable 조회 실패:
```
RuntimeError: dereferencing a null pointer
    at kotlin.wasm.internal.getInterfaceVTable
    at kotlinx.coroutines.AbstractCoroutine.<init>
```

## Solution
kotlinx.coroutines를 1.10.2로 업그레이드하여 wasmJs 호환성 확보.

## Test plan
- [x] `./gradlew :kotlin:flowdux-remote-server:wasmJsBrowserTest` 통과
- [x] `./gradlew :kotlin:flowdux-remote-server:jsBrowserTest` 통과
- [x] `./gradlew :kotlin:flowdux-remote-server:jvmTest` 통과
- [x] `./gradlew :kotlin:flowdux:jvmTest` 통과

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)