### PR TITLE
feat(serialization): add upcast() for type-safe TypedConnection conversion (#84)

### DIFF
--- a/kotlin/remote/serialization/build.gradle.kts
+++ b/kotlin/remote/serialization/build.gradle.kts
@@ -42,6 +42,7 @@ kotlin {
         }
         commonTest.dependencies {
             implementation(kotlin("test"))
+            implementation(libs.kotlinx.coroutines.test)
         }
     }
 

--- a/kotlin/remote/serialization/src/commonMain/kotlin/io/flowdux/remote/serialization/TypedConnectionExt.kt
+++ b/kotlin/remote/serialization/src/commonMain/kotlin/io/flowdux/remote/serialization/TypedConnectionExt.kt
@@ -2,11 +2,15 @@ package io.flowdux.remote.serialization
 
 import io.flowdux.Action
 import io.flowdux.remote.ClientConnection
+import io.flowdux.remote.ConnectionState
 import io.flowdux.remote.TypedClientConnection
 import io.flowdux.remote.server.ServerConnection
 import io.flowdux.remote.server.TypedServerConnection
 import io.flowdux.remote.server.typed
 import io.flowdux.remote.typed
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
 import kotlinx.serialization.json.Json
 
 /**
@@ -46,3 +50,89 @@ inline fun <reified A : Action> ClientConnection.typedJson(
 inline fun <reified A : Action> ServerConnection.typedJson(
     json: Json = SerializableActionCodec.DefaultJson,
 ): TypedServerConnection<A> = typed(actionCodecOf<A>(json), JsonMessageCodec())
+
+/**
+ * Upcasts this [TypedClientConnection] to work with a supertype action.
+ *
+ * This is useful when the connection is typed with a narrow serializable type (e.g., `SharedAction`)
+ * but the middleware/store uses a broader action type (e.g., `AppAction`).
+ *
+ * **Safety contract:**
+ * - Incoming actions from the server are always [Sub] type (safe upcast to [Super])
+ * - Only [Sub] actions should be sent through the connection (enforced at runtime)
+ *
+ * Example:
+ * ```kotlin
+ * // Before (unchecked cast)
+ * val connection = ktConnection.typedJson<SharedAction>() as TypedClientConnection<AppAction>
+ *
+ * // After (type-safe upcast)
+ * val connection = ktConnection.typedJson<SharedAction>().upcast<AppAction>()
+ * ```
+ *
+ * @param Super The broader action type that [Sub] extends
+ * @throws ClassCastException if [send] is called with an action that is not a [Sub] instance
+ */
+inline fun <reified Sub : Super, reified Super : Action> TypedClientConnection<Sub>.upcast(): TypedClientConnection<Super> =
+    UpcastTypedClientConnection(this, Sub::class)
+
+/**
+ * Upcasts this [TypedServerConnection] to work with a supertype action.
+ *
+ * This is useful when the connection is typed with a narrow serializable type (e.g., `SharedAction`)
+ * but the middleware/store uses a broader action type (e.g., `AppAction`).
+ *
+ * **Safety contract:**
+ * - Incoming actions from the client are always [Sub] type (safe upcast to [Super])
+ * - Only [Sub] actions should be sent through the connection (enforced at runtime)
+ *
+ * Example:
+ * ```kotlin
+ * // Before (unchecked cast)
+ * val connection = ktConnection.typedJson<SharedAction>() as TypedServerConnection<AppAction>
+ *
+ * // After (type-safe upcast)
+ * val connection = ktConnection.typedJson<SharedAction>().upcast<AppAction>()
+ * ```
+ *
+ * @param Super The broader action type that [Sub] extends
+ * @throws ClassCastException if [send] is called with an action that is not a [Sub] instance
+ */
+inline fun <reified Sub : Super, reified Super : Action> TypedServerConnection<Sub>.upcast(): TypedServerConnection<Super> =
+    UpcastTypedServerConnection(this, Sub::class)
+
+@PublishedApi
+internal class UpcastTypedClientConnection<Sub : Super, Super : Action>(
+    private val delegate: TypedClientConnection<Sub>,
+    private val subClass: kotlin.reflect.KClass<Sub>,
+) : TypedClientConnection<Super> {
+    override val connectionState: StateFlow<ConnectionState> = delegate.connectionState
+    override val incoming: Flow<Super> = delegate.incoming.map { it }
+
+    override suspend fun send(action: Super) {
+        require(subClass.isInstance(action)) {
+            "Cannot send ${action::class.simpleName} through connection typed for ${subClass.simpleName}"
+        }
+        @Suppress("UNCHECKED_CAST")
+        delegate.send(action as Sub)
+    }
+
+    override suspend fun connect() = delegate.connect()
+    override suspend fun disconnect() = delegate.disconnect()
+}
+
+@PublishedApi
+internal class UpcastTypedServerConnection<Sub : Super, Super : Action>(
+    private val delegate: TypedServerConnection<Sub>,
+    private val subClass: kotlin.reflect.KClass<Sub>,
+) : TypedServerConnection<Super> {
+    override val incoming: Flow<Super> = delegate.incoming.map { it }
+
+    override suspend fun send(action: Super) {
+        require(subClass.isInstance(action)) {
+            "Cannot send ${action::class.simpleName} through connection typed for ${subClass.simpleName}"
+        }
+        @Suppress("UNCHECKED_CAST")
+        delegate.send(action as Sub)
+    }
+}

--- a/kotlin/remote/serialization/src/commonTest/kotlin/io/flowdux/remote/serialization/UpcastConnectionTest.kt
+++ b/kotlin/remote/serialization/src/commonTest/kotlin/io/flowdux/remote/serialization/UpcastConnectionTest.kt
@@ -1,0 +1,148 @@
+package io.flowdux.remote.serialization
+
+import io.flowdux.Action
+import io.flowdux.remote.ConnectionState
+import io.flowdux.remote.TypedClientConnection
+import io.flowdux.remote.server.TypedServerConnection
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class UpcastConnectionTest {
+
+    // -- Test Action Hierarchy --
+    interface AppAction : Action
+    sealed interface SharedAction : AppAction {
+        data class Message(val text: String) : SharedAction
+    }
+    data class LocalAction(val value: Int) : AppAction
+
+    // -- Mock TypedClientConnection --
+    class MockTypedClientConnection : TypedClientConnection<SharedAction> {
+        private val _connectionState = MutableStateFlow(ConnectionState.DISCONNECTED)
+        override val connectionState: StateFlow<ConnectionState> = _connectionState
+        override val incoming: Flow<SharedAction> = flowOf(SharedAction.Message("hello"))
+
+        val sentActions = mutableListOf<SharedAction>()
+
+        override suspend fun send(action: SharedAction) {
+            sentActions.add(action)
+        }
+
+        override suspend fun connect() {
+            _connectionState.value = ConnectionState.CONNECTED
+        }
+
+        override suspend fun disconnect() {
+            _connectionState.value = ConnectionState.DISCONNECTED
+        }
+    }
+
+    // -- Mock TypedServerConnection --
+    class MockTypedServerConnection : TypedServerConnection<SharedAction> {
+        override val incoming: Flow<SharedAction> = flowOf(SharedAction.Message("from client"))
+
+        val sentActions = mutableListOf<SharedAction>()
+
+        override suspend fun send(action: SharedAction) {
+            sentActions.add(action)
+        }
+    }
+
+    // -- Tests --
+
+    @Test
+    fun `upcast TypedClientConnection - incoming actions are upcasted`() = runTest {
+        val mockConnection = MockTypedClientConnection()
+        val upcastedConnection: TypedClientConnection<AppAction> =
+            mockConnection.upcast<SharedAction, AppAction>()
+
+        val actions = upcastedConnection.incoming.toList()
+
+        assertEquals(1, actions.size)
+        assertTrue(actions[0] is SharedAction.Message)
+        assertEquals("hello", (actions[0] as SharedAction.Message).text)
+    }
+
+    @Test
+    fun `upcast TypedClientConnection - send shared action works`() = runTest {
+        val mockConnection = MockTypedClientConnection()
+        val upcastedConnection: TypedClientConnection<AppAction> =
+            mockConnection.upcast<SharedAction, AppAction>()
+
+        upcastedConnection.send(SharedAction.Message("test"))
+
+        assertEquals(1, mockConnection.sentActions.size)
+        assertEquals(SharedAction.Message("test"), mockConnection.sentActions[0])
+    }
+
+    @Test
+    fun `upcast TypedClientConnection - send non-shared action throws`() = runTest {
+        val mockConnection = MockTypedClientConnection()
+        val upcastedConnection: TypedClientConnection<AppAction> =
+            mockConnection.upcast<SharedAction, AppAction>()
+
+        assertFailsWith<IllegalArgumentException> {
+            upcastedConnection.send(LocalAction(42))
+        }
+    }
+
+    @Test
+    fun `upcast TypedClientConnection - connect and disconnect delegate properly`() = runTest {
+        val mockConnection = MockTypedClientConnection()
+        val upcastedConnection: TypedClientConnection<AppAction> =
+            mockConnection.upcast<SharedAction, AppAction>()
+
+        assertEquals(ConnectionState.DISCONNECTED, upcastedConnection.connectionState.value)
+
+        upcastedConnection.connect()
+        assertEquals(ConnectionState.CONNECTED, upcastedConnection.connectionState.value)
+
+        upcastedConnection.disconnect()
+        assertEquals(ConnectionState.DISCONNECTED, upcastedConnection.connectionState.value)
+    }
+
+    @Test
+    fun `upcast TypedServerConnection - incoming actions are upcasted`() = runTest {
+        val mockConnection = MockTypedServerConnection()
+        val upcastedConnection: TypedServerConnection<AppAction> =
+            mockConnection.upcast<SharedAction, AppAction>()
+
+        val actions = upcastedConnection.incoming.toList()
+
+        assertEquals(1, actions.size)
+        assertTrue(actions[0] is SharedAction.Message)
+        assertEquals("from client", (actions[0] as SharedAction.Message).text)
+    }
+
+    @Test
+    fun `upcast TypedServerConnection - send shared action works`() = runTest {
+        val mockConnection = MockTypedServerConnection()
+        val upcastedConnection: TypedServerConnection<AppAction> =
+            mockConnection.upcast<SharedAction, AppAction>()
+
+        upcastedConnection.send(SharedAction.Message("server response"))
+
+        assertEquals(1, mockConnection.sentActions.size)
+        assertEquals(SharedAction.Message("server response"), mockConnection.sentActions[0])
+    }
+
+    @Test
+    fun `upcast TypedServerConnection - send non-shared action throws`() = runTest {
+        val mockConnection = MockTypedServerConnection()
+        val upcastedConnection: TypedServerConnection<AppAction> =
+            mockConnection.upcast<SharedAction, AppAction>()
+
+        assertFailsWith<IllegalArgumentException> {
+            upcastedConnection.send(LocalAction(99))
+        }
+    }
+}

--- a/kotlin/samples/flowdux-remote/multi-client/client/src/main/kotlin/io/flowdux/sample/chat/multiclient/Main.kt
+++ b/kotlin/samples/flowdux-remote/multi-client/client/src/main/kotlin/io/flowdux/sample/chat/multiclient/Main.kt
@@ -2,9 +2,9 @@ package io.flowdux.sample.chat.multiclient
 
 import io.flowdux.Store
 import io.flowdux.createStore
-import io.flowdux.remote.TypedClientConnection
 import io.flowdux.remote.ktor.KtorWebSocketClientConnection
 import io.flowdux.remote.serialization.typedJson
+import io.flowdux.remote.serialization.upcast
 import io.flowdux.sample.chat.ChatAction
 import io.flowdux.sample.chat.ChatEvent
 import io.flowdux.sample.chat.SharedChatAction
@@ -96,13 +96,12 @@ fun main(args: Array<String>) = runBlocking {
     println("Bye!")
 }
 
-@Suppress("UNCHECKED_CAST")
 private fun createChatStore(): Store<ClientChatState, ChatAction> {
     val connection = KtorWebSocketClientConnection.create(
         host = "localhost",
         port = 8080,
         path = "/chat",
-    ).typedJson<SharedChatAction>() as TypedClientConnection<ChatAction>
+    ).typedJson<SharedChatAction>().upcast<SharedChatAction, ChatAction>()
     return createStore(
         initialState = ClientChatState(),
         reducer = clientChatReducer,

--- a/kotlin/samples/flowdux-remote/multi-client/server/src/main/kotlin/io/flowdux/sample/chat/multiserver/Main.kt
+++ b/kotlin/samples/flowdux-remote/multi-client/server/src/main/kotlin/io/flowdux/sample/chat/multiserver/Main.kt
@@ -3,7 +3,7 @@ package io.flowdux.sample.chat.multiserver
 import io.flowdux.Middleware
 import io.flowdux.remote.ktor.KtorWebSocketServerConnection
 import io.flowdux.remote.serialization.typedJson
-import io.flowdux.remote.server.TypedServerConnection
+import io.flowdux.remote.serialization.upcast
 import io.flowdux.remote.server.createRemoteServer
 import io.flowdux.sample.chat.ChatAction
 import io.flowdux.sample.chat.ChatState
@@ -56,9 +56,9 @@ fun main() {
                 val sessionId = UUID.randomUUID().toString()
                 println("[Server] Client connected: $sessionId")
 
-                @Suppress("UNCHECKED_CAST")
                 val connection = KtorWebSocketServerConnection(this)
-                    .typedJson<SharedChatAction>() as TypedServerConnection<ChatAction>
+                    .typedJson<SharedChatAction>()
+                    .upcast<SharedChatAction, ChatAction>()
 
                 try {
                     session.handleClient(sessionId, connection)

--- a/kotlin/samples/flowdux-remote/simple/client/src/main/kotlin/io/flowdux/sample/chat/client/Main.kt
+++ b/kotlin/samples/flowdux-remote/simple/client/src/main/kotlin/io/flowdux/sample/chat/client/Main.kt
@@ -2,9 +2,9 @@ package io.flowdux.sample.chat.client
 
 import io.flowdux.Store
 import io.flowdux.createStore
-import io.flowdux.remote.TypedClientConnection
 import io.flowdux.remote.ktor.KtorWebSocketClientConnection
 import io.flowdux.remote.serialization.typedJson
+import io.flowdux.remote.serialization.upcast
 import io.flowdux.sample.chat.ChatAction
 import io.flowdux.sample.chat.ChatEvent
 import io.flowdux.sample.chat.SharedChatAction
@@ -77,13 +77,12 @@ fun main() = runBlocking {
     println("=== Demo Complete ===")
 }
 
-@Suppress("UNCHECKED_CAST")
 private fun createChatStore(): Store<ClientChatState, ChatAction> {
     val connection = KtorWebSocketClientConnection.create(
         host = "localhost",
         port = 8080,
         path = "/chat",
-    ).typedJson<SharedChatAction>() as TypedClientConnection<ChatAction>
+    ).typedJson<SharedChatAction>().upcast<SharedChatAction, ChatAction>()
     return createStore(
         initialState = ClientChatState(),
         reducer = clientChatReducer,

--- a/kotlin/samples/flowdux-remote/simple/server/src/main/kotlin/io/flowdux/sample/chat/server/Main.kt
+++ b/kotlin/samples/flowdux-remote/simple/server/src/main/kotlin/io/flowdux/sample/chat/server/Main.kt
@@ -4,7 +4,7 @@ import io.flowdux.Store
 import io.flowdux.createStore
 import io.flowdux.remote.ktor.KtorWebSocketServerConnection
 import io.flowdux.remote.serialization.typedJson
-import io.flowdux.remote.server.TypedServerConnection
+import io.flowdux.remote.serialization.upcast
 import io.flowdux.remote.server.serve
 import io.flowdux.sample.chat.ChatAction
 import io.flowdux.sample.chat.ChatState
@@ -37,10 +37,10 @@ fun main() {
     }.start(wait = true)
 }
 
-@Suppress("UNCHECKED_CAST")
 private fun createChatStore(session: DefaultWebSocketServerSession): Store<ServerChatState, ChatAction> {
     val typedConnection = KtorWebSocketServerConnection(session)
-        .typedJson<SharedChatAction>() as TypedServerConnection<ChatAction>
+        .typedJson<SharedChatAction>()
+        .upcast<SharedChatAction, ChatAction>()
     return createStore(
         initialState = ServerChatState(),
         reducer = serverChatReducer,


### PR DESCRIPTION
## Summary
- `upcast<Sub, Super>()` 확장 함수 추가로 타입 안전한 TypedConnection 변환 제공
- 샘플 앱에서 `@Suppress("UNCHECKED_CAST")` 제거

## Problem
샘플 앱에서 TypedConnection 생성 시 unchecked cast 필요:
```kotlin
@Suppress("UNCHECKED_CAST")
val connection = ktConnection.typedJson<SharedChatAction>() as TypedClientConnection<ChatAction>
```

## Solution
`upcast()` 확장 함수로 타입 안전한 변환 제공:
```kotlin
val connection = ktConnection.typedJson<SharedChatAction>().upcast<SharedChatAction, ChatAction>()
```

### Safety
- Incoming actions: Sub → Super 업캐스트는 항상 안전
- Send actions: 런타임에 Sub 타입 검증, 위반 시 `IllegalArgumentException`

## Changes
1. **TypedConnectionExt.kt**: `upcast()` 확장 함수 및 어댑터 클래스 추가
2. **build.gradle.kts**: 테스트 의존성 추가 (kotlinx-coroutines-test)
3. **Sample apps**: unchecked cast → `upcast()` 변환

## Test plan
- [x] `UpcastConnectionTest` 7개 테스트 케이스 추가
- [x] 샘플 앱 빌드 확인

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)