### PR TITLE
docs(serialization): fix upcast() KDoc examples and exception type

### DIFF
--- a/kotlin/remote/serialization/src/commonMain/kotlin/io/flowdux/remote/serialization/TypedConnectionExt.kt
+++ b/kotlin/remote/serialization/src/commonMain/kotlin/io/flowdux/remote/serialization/TypedConnectionExt.kt
@@ -67,11 +67,12 @@ inline fun <reified A : Action> ServerConnection.typedJson(
  * val connection = ktConnection.typedJson<SharedAction>() as TypedClientConnection<AppAction>
  *
  * // After (type-safe upcast)
- * val connection = ktConnection.typedJson<SharedAction>().upcast<AppAction>()
+ * val connection = ktConnection.typedJson<SharedAction>().upcast<SharedAction, AppAction>()
  * ```
  *
+ * @param Sub The narrow action type this connection is typed with
  * @param Super The broader action type that [Sub] extends
- * @throws ClassCastException if [send] is called with an action that is not a [Sub] instance
+ * @throws IllegalArgumentException if [send] is called with an action that is not a [Sub] instance
  */
 inline fun <reified Sub : Super, reified Super : Action> TypedClientConnection<Sub>.upcast(): TypedClientConnection<Super> =
     UpcastTypedClientConnection(this, Sub::class)
@@ -92,11 +93,12 @@ inline fun <reified Sub : Super, reified Super : Action> TypedClientConnection<S
  * val connection = ktConnection.typedJson<SharedAction>() as TypedServerConnection<AppAction>
  *
  * // After (type-safe upcast)
- * val connection = ktConnection.typedJson<SharedAction>().upcast<AppAction>()
+ * val connection = ktConnection.typedJson<SharedAction>().upcast<SharedAction, AppAction>()
  * ```
  *
+ * @param Sub The narrow action type this connection is typed with
  * @param Super The broader action type that [Sub] extends
- * @throws ClassCastException if [send] is called with an action that is not a [Sub] instance
+ * @throws IllegalArgumentException if [send] is called with an action that is not a [Sub] instance
  */
 inline fun <reified Sub : Super, reified Super : Action> TypedServerConnection<Sub>.upcast(): TypedServerConnection<Super> =
     UpcastTypedServerConnection(this, Sub::class)


### PR DESCRIPTION
## Summary
PR #141 리뷰 코멘트 대응

## Changes
- KDoc 예시를 실제 API와 일치하도록 수정: `upcast<AppAction>()` → `upcast<SharedAction, AppAction>()`
- @throws 예외 타입 수정: `ClassCastException` → `IllegalArgumentException`
- @param Sub 문서 추가

## Review comments addressed
- [x] TypedConnectionExt.kt:70 - 문서 예시 수정 (client)
- [x] TypedConnectionExt.kt:74 - @throws 수정 (client)
- [x] TypedConnectionExt.kt:95 - 문서 예시 수정 (server)
- [x] TypedConnectionExt.kt:99 - @throws 수정 (server)

🤖 Generated with [Claude Code](https://claude.com/claude-code)