### PR TITLE
chore: bump version to 1.13.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,4 +17,4 @@ android.r8.optimizedResourceShrinking=false
 android.builtInKotlin=false
 android.newDsl=false
 
-flowdux.version=1.12.0
+flowdux.version=1.13.0


### PR DESCRIPTION
Version bump for release 1.13.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)