### PR TITLE
fix(ktor): Ktor 3.x test compatibility

### DIFF
--- a/kotlin/remote/ktor/src/jvmTest/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnectionTest.kt
+++ b/kotlin/remote/ktor/src/jvmTest/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnectionTest.kt
@@ -33,7 +33,7 @@ class KtorWebSocketClientConnectionTest {
         }.start(wait = false)
 
         try {
-            val port = server.resolvedConnectors().first().port
+            val port = server.engine.resolvedConnectors().first().port
             val connection = KtorWebSocketClientConnection("ws://localhost:$port/test")
             assertEquals(ConnectionState.DISCONNECTED, connection.connectionState.value)
 
@@ -62,7 +62,7 @@ class KtorWebSocketClientConnectionTest {
         }.start(wait = false)
 
         try {
-            val port = server.resolvedConnectors().first().port
+            val port = server.engine.resolvedConnectors().first().port
             val connection = KtorWebSocketClientConnection("ws://localhost:$port/test")
 
             val connectJob = launch(Dispatchers.Default) { connection.connect() }
@@ -98,7 +98,7 @@ class KtorWebSocketClientConnectionTest {
         }.start(wait = false)
 
         try {
-            val port = server.resolvedConnectors().first().port
+            val port = server.engine.resolvedConnectors().first().port
             val connection = KtorWebSocketClientConnection("ws://localhost:$port/test")
 
             val connectJob = launch(Dispatchers.Default) { connection.connect() }
@@ -137,7 +137,7 @@ class KtorWebSocketClientConnectionTest {
         }.start(wait = false)
 
         try {
-            val port = server.resolvedConnectors().first().port
+            val port = server.engine.resolvedConnectors().first().port
             val connection = KtorWebSocketClientConnection("ws://localhost:$port/test")
 
             val connectJob = launch(Dispatchers.Default) { connection.connect() }
@@ -171,7 +171,7 @@ class KtorWebSocketClientConnectionTest {
         }.start(wait = false)
 
         try {
-            val port = server.resolvedConnectors().first().port
+            val port = server.engine.resolvedConnectors().first().port
             val connection = KtorWebSocketClientConnection("ws://localhost:$port/test")
 
             // Launch 10 coroutines that all call connect() concurrently

--- a/kotlin/remote/ktor/src/jvmTest/kotlin/io/flowdux/remote/ktor/KtorWebSocketServerConnectionTest.kt
+++ b/kotlin/remote/ktor/src/jvmTest/kotlin/io/flowdux/remote/ktor/KtorWebSocketServerConnectionTest.kt
@@ -35,7 +35,7 @@ class KtorWebSocketServerConnectionTest {
         }.start(wait = false)
 
         try {
-            val port = server.resolvedConnectors().first().port
+            val port = server.engine.resolvedConnectors().first().port
             val clientConnection = KtorWebSocketClientConnection("ws://localhost:$port/test")
 
             val connectJob = launch { clientConnection.connect() }
@@ -71,7 +71,7 @@ class KtorWebSocketServerConnectionTest {
         }.start(wait = false)
 
         try {
-            val port = server.resolvedConnectors().first().port
+            val port = server.engine.resolvedConnectors().first().port
             val clientConnection = KtorWebSocketClientConnection("ws://localhost:$port/test")
 
             val connectJob = launch { clientConnection.connect() }


### PR DESCRIPTION
## Summary
Fix Ktor test compilation error on CI.

### Changes
- Use `server.engine.resolvedConnectors()` instead of `server.resolvedConnectors()` for Ktor 3.x compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)