### PR TITLE
fix(ktor): handle CancellationException on closed server session

### DIFF
--- a/kotlin/remote/ktor/src/jvmMain/kotlin/io/flowdux/remote/ktor/KtorWebSocketServerConnection.kt
+++ b/kotlin/remote/ktor/src/jvmMain/kotlin/io/flowdux/remote/ktor/KtorWebSocketServerConnection.kt
@@ -27,13 +27,20 @@ class KtorWebSocketServerConnection(
         .filterIsInstance<Frame.Text>()
         .map { it.readText() }
 
+    @OptIn(kotlinx.coroutines.DelicateCoroutinesApi::class)
     override suspend fun send(message: String) {
         try {
             session.outgoing.send(Frame.Text(message))
         } catch (_: ClosedSendChannelException) {
             // Session already closed; ignore silently
         } catch (e: CancellationException) {
-            throw e // Propagate coroutine cancellation
+            // Check if this is external coroutine cancellation or just session closure
+            // Note: isClosedForSend is marked as DelicateCoroutinesApi but is the correct
+            // way to distinguish between session closure and external cancellation
+            if (!session.outgoing.isClosedForSend) {
+                throw e // Propagate external coroutine cancellation
+            }
+            // Session was closed; ignore silently (same as ClosedSendChannelException)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Fixed `CancellationException` being incorrectly re-thrown when sending on a closed WebSocket session
- Added check for `isClosedForSend` to distinguish between external cancellation and session closure
- Unblocks 1.13.0 release which was failing due to `send after session close does not throw` test

## Test plan
- [x] `KtorWebSocketServerConnectionTest` passes locally
- [ ] CI validates on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)