### PR TITLE
fix(server): add ClientSharedActionForwarder to pattern factories

### DIFF
--- a/kotlin/remote/server/src/commonMain/kotlin/io/flowdux/remote/server/pattern/MultiClientStore.kt
+++ b/kotlin/remote/server/src/commonMain/kotlin/io/flowdux/remote/server/pattern/MultiClientStore.kt
@@ -9,7 +9,7 @@ import io.flowdux.Reducer
 import io.flowdux.State
 import io.flowdux.Store
 import io.flowdux.StoreLogger
-import io.flowdux.createStore
+import io.flowdux.remote.server.createServerStore
 import io.flowdux.remote.server.middleware.MultiClientSyncMiddleware
 import io.flowdux.remote.server.session.SessionBroadcaster
 import kotlinx.coroutines.CoroutineScope
@@ -68,9 +68,9 @@ fun <S : State, A : Action> createMultiClientStore(
 ): Store<S, A> {
     val middleware = MultiClientSyncMiddleware<S, A>(processors, broadcaster)
 
-    return createStore(
+    return createServerStore(
         initialState = initialState,
-        middlewares = listOf(middleware),
+        syncMiddleware = middleware,
         reducer = reducer,
         errorProcessor = errorProcessor,
         logger = logger,

--- a/kotlin/remote/server/src/commonMain/kotlin/io/flowdux/remote/server/pattern/SingleClientServer.kt
+++ b/kotlin/remote/server/src/commonMain/kotlin/io/flowdux/remote/server/pattern/SingleClientServer.kt
@@ -9,8 +9,8 @@ import io.flowdux.Reducer
 import io.flowdux.State
 import io.flowdux.Store
 import io.flowdux.StoreLogger
-import io.flowdux.createStore
 import io.flowdux.remote.server.connection.TypedServerConnection
+import io.flowdux.remote.server.createServerStore
 import io.flowdux.remote.server.middleware.SingleClientSyncMiddleware
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -89,10 +89,10 @@ fun <S : State, A : Action> createSingleClientStore(
         }
     }
 
-    return createStore(
+    return createServerStore(
         initialState = initialState,
+        syncMiddleware = middleware,
         reducer = reducer,
-        middlewares = listOf(middleware),
         errorProcessor = errorProcessor,
         logger = logger,
         scope = scope,

--- a/kotlin/remote/server/src/commonTest/kotlin/io/flowdux/remote/server/SharedStateServerTest.kt
+++ b/kotlin/remote/server/src/commonTest/kotlin/io/flowdux/remote/server/SharedStateServerTest.kt
@@ -197,6 +197,57 @@ class SharedStateServerTest {
     }
 
     @Test
+    fun `ClientSharedAction emitted from processor is broadcast to all clients`() = runTest {
+        val conn1 = MockTypedServerConnection<ServerAction>()
+        val conn2 = MockTypedServerConnection<ServerAction>()
+
+        // Processor that emits a ClientSharedAction
+        val processors = Middleware.ActionProcessorBuilder<ServerState, ServerAction>().apply {
+            on<ServerAction.TriggerEmitClientAction> { _, action ->
+                // emit(ClientSharedAction) - should be auto-forwarded and broadcast
+                emit(ServerAction.Add(action.value))
+                // Also emit local action to verify processor runs
+                emit(ServerAction.InternalReset(1))
+            }
+        }.build()
+
+        val server = createSharedStateServer(
+            initialState = ServerState(),
+            reducer = serverReducer,
+            processors = processors,
+            stateMapper = { ServerAction.SyncState(it) },
+            errorProcessor = serverErrorProcessor,
+            scope = backgroundScope,
+        )
+
+        val job1 = backgroundScope.launch { server.handleClient("client-1", conn1) }
+        val job2 = backgroundScope.launch { server.handleClient("client-2", conn2) }
+        delay(100)
+
+        // Clear any initial SyncState
+        conn1.sentActions.clear()
+        conn2.sentActions.clear()
+
+        // Trigger the processor via client action
+        conn1.simulateClientAction(ServerAction.TriggerEmitClientAction(42))
+        delay(100)
+
+        // Local state should be updated by InternalReset(1)
+        assertEquals(1, server.currentState.count)
+
+        // ClientSharedAction (Add(42)) should be broadcast to all clients
+        val addActions1 = conn1.sentActions.filterIsInstance<ServerAction.Add>()
+        val addActions2 = conn2.sentActions.filterIsInstance<ServerAction.Add>()
+        assertEquals(1, addActions1.size, "emit(ClientSharedAction) should be sent to client 1")
+        assertEquals(1, addActions2.size, "emit(ClientSharedAction) should be sent to client 2")
+        assertEquals(42, addActions1[0].value)
+        assertEquals(42, addActions2[0].value)
+
+        job1.cancel()
+        job2.cancel()
+    }
+
+    @Test
     fun `processors are invoked for matching actions`() = runTest {
         val conn = MockTypedServerConnection<ServerAction>()
 

--- a/kotlin/remote/server/src/commonTest/kotlin/io/flowdux/remote/server/SingleClientServerTest.kt
+++ b/kotlin/remote/server/src/commonTest/kotlin/io/flowdux/remote/server/SingleClientServerTest.kt
@@ -131,6 +131,48 @@ class SingleClientServerTest {
     }
 
     @Test
+    fun `ClientSharedAction emitted from processor is sent to client`() = runTest {
+        val connection = MockTypedServerConnection<ServerAction>()
+
+        // Processor that emits a ClientSharedAction
+        val processors = Middleware.ActionProcessorBuilder<ServerState, ServerAction>().apply {
+            on<ServerAction.TriggerEmitClientAction> { _, action ->
+                // emit(ClientSharedAction) - should be auto-forwarded to client
+                emit(ServerAction.Add(action.value))
+                // Also emit local action to verify processor runs
+                emit(ServerAction.InternalReset(1))
+            }
+        }.build()
+
+        val server = createSingleClientServer(
+            initialState = ServerState(),
+            reducer = serverReducer,
+            connection = connection,
+            processors = processors,
+            errorProcessor = serverErrorProcessor,
+            scope = backgroundScope,
+        )
+
+        // Start listening
+        server.dispatchStartListening()
+        delay(100)
+
+        // Trigger the processor
+        server.dispatch(ServerAction.TriggerEmitClientAction(42))
+        delay(100)
+
+        // Local state should be updated by InternalReset(1)
+        assertEquals(1, server.state.value.count)
+
+        // ClientSharedAction (Add(42)) should be sent to client
+        val addActions = connection.sentActions.filterIsInstance<ServerAction.Add>()
+        assertEquals(1, addActions.size, "emit(ClientSharedAction) should be sent to client")
+        assertEquals(42, addActions[0].value)
+
+        server.close()
+    }
+
+    @Test
     fun `non-ClientSharedAction passes through to reducer`() = runTest {
         val connection = MockTypedServerConnection<ServerAction>()
 


### PR DESCRIPTION
## Summary

- Fix `createSingleClientStore` / `createSingleClientServer` to use `createServerStore`
- Fix `createMultiClientStore` (used by `SharedStateServer`) to use `createServerStore`
- `emit(ClientSharedAction)` from processors now auto-forwarded to clients

## Problem

Pattern-based factory functions (`createSingleClientServer`, `createSharedStateServer`, etc.) were using `createStore` directly without `ClientSharedActionForwarder`. This caused `ClientSharedAction`s emitted from processors to NOT be sent to clients.

```kotlin
// Before: emit() from processor didn't send to client
on<TriggerAction> { _, action ->
    emit(ServerAction.Add(action.value))  // ❌ NOT sent to client
}
```

## Solution

Changed pattern factories to use `createServerStore` which includes `ClientSharedActionForwarder`:

```kotlin
// SingleClientServer.kt
return createServerStore(  // was: createStore
    initialState = initialState,
    syncMiddleware = middleware,
    reducer = reducer,
    ...
)
```

## Test plan

- [x] Add test: `ClientSharedAction emitted from processor is sent to client` (SingleClientServerTest)
- [x] Add test: `ClientSharedAction emitted from processor is broadcast to all clients` (SharedStateServerTest)
- [x] Tests fail before fix, pass after fix
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)