### PR TITLE
docs: consolidate remote docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,10 +218,7 @@ if (!store.isClosed) {
 |-------|-------------|
 | [Architecture](docs/guide/architecture.md) | Store pipeline, middleware chain, action flow |
 | [Execution Strategies](docs/guide/execution-strategies.md) | takeLatest, debounce, throttle, retry, groups, chaining |
-| [Remote (WebSocket)](docs/guide/remote.md) | Client-server state sync, shared actions, setup guide |
-| [Remote Authentication](docs/guide/remote-authentication.md) | In-band WebSocket auth handshake, AuthVerifier, AuthPrincipal |
-| [JWT Integration](docs/guide/jwt-integration.md) | HS256, Firebase Auth, Supabase Auth integration guide |
-| [Server Patterns](docs/guide/server-patterns.md) | Pattern selection guide (Single Client, Shared State, Room, Per-Client) |
+| [Remote (WebSocket)](docs/guide/remote.md) | Client-server state sync, authentication, server patterns |
 | [Time Travel](docs/guide/timetravel.md) | Undo/redo, state history, branching |
 | [Sample Apps](docs/guide/samples.md) | How to run each sample |
 | [Dart/Flutter](dart/flowdux/README.md) | Dart API, Flutter widgets, stream integration |

--- a/docs/guide/remote.md
+++ b/docs/guide/remote.md
@@ -399,6 +399,7 @@ See `kotlin/samples/flowdux-remote/simple` for a complete working example.
 ## Next Steps
 
 - [Remote Authentication](./remote-authentication.md) — In-band WebSocket auth handshake (AuthVerifier, AuthPrincipal)
+- [JWT Integration](./jwt-integration.md) — HS256, Firebase Auth, Supabase Auth integration guide
 - [Server Patterns Overview](./server-patterns.md) — Pattern selection guide (Single Client, Shared State, Room, Per-Client)
 - [Scaling Architecture](./scaling.md) — Parallel broadcast for large-scale deployments
 - [Room Pattern](./pattern-room.md) — Multi-room management, session-aware broadcasting


### PR DESCRIPTION
## Summary

- README Documentation 테이블에서 Remote Authentication, JWT Integration, Server Patterns 3개 행 제거
- Remote (WebSocket) 1개 행으로 통합
- remote.md Next Steps에 JWT Integration 링크 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)