### PR TITLE
chore: sync main 1.16.0 back to develop

### DIFF
--- a/docs/guide/remote.md
+++ b/docs/guide/remote.md
@@ -39,17 +39,17 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             // Shared action markers (ServerSharedAction, ClientSharedAction)
-            implementation("io.github.chibimoons:flowdux-remote-core:1.15.0")
+            implementation("io.github.chibimoons:flowdux-remote-core:1.16.0")
             // Client middleware (SyncMiddleware)
-            implementation("io.github.chibimoons:flowdux-remote-client:1.15.0")
+            implementation("io.github.chibimoons:flowdux-remote-client:1.16.0")
             // Server middleware (SingleClientSyncMiddleware, MultiClientSyncMiddleware)
-            implementation("io.github.chibimoons:flowdux-remote-server:1.15.0")
+            implementation("io.github.chibimoons:flowdux-remote-server:1.16.0")
             // kotlinx.serialization codecs (ActionCodec, MessageCodec)
-            implementation("io.github.chibimoons:flowdux-remote-serialization:1.15.0")
+            implementation("io.github.chibimoons:flowdux-remote-serialization:1.16.0")
             // Ktor WebSocket transport (JVM, iOS, JS — WASM not supported)
-            implementation("io.github.chibimoons:flowdux-remote-ktor:1.15.0")
+            implementation("io.github.chibimoons:flowdux-remote-ktor:1.16.0")
             // Optional: In-band WebSocket authentication
-            implementation("io.github.chibimoons:flowdux-remote-auth:1.15.0")
+            implementation("io.github.chibimoons:flowdux-remote-auth:1.16.0")
         }
     }
 }

--- a/docs/guide/timetravel.md
+++ b/docs/guide/timetravel.md
@@ -9,14 +9,14 @@ Time travel debugging is available as a separate module.
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            implementation("io.github.chibimoons:flowdux-timetravel:1.15.0")
+            implementation("io.github.chibimoons:flowdux-timetravel:1.16.0")
         }
     }
 }
 
 // build.gradle.kts (JVM / Android)
 dependencies {
-    implementation("io.github.chibimoons:flowdux-timetravel:1.15.0")
+    implementation("io.github.chibimoons:flowdux-timetravel:1.16.0")
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,4 +17,4 @@ android.r8.optimizedResourceShrinking=false
 android.builtInKotlin=false
 android.newDsl=false
 
-flowdux.version=1.15.0
+flowdux.version=1.16.0


### PR DESCRIPTION
## Summary
- Sync version bump (1.15.0 → 1.16.0) from main back to develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)