### PR TITLE
feat(skill): add Copilot review re-request to PR skills

### DIFF
--- a/.claude/commands/pr-respond.md
+++ b/.claude/commands/pr-respond.md
@@ -55,7 +55,16 @@ gh run view <run-id> --log-failed
 
 실패 원인 분석 → 수정 → 테스트 확인 → 커밋 & 푸시
 
-## 5. 상태 재확인
+## 5. Copilot 코드리뷰 재요청
+
+푸시 후 Copilot에게 코드리뷰를 재요청합니다:
+
+```bash
+gh api repos/chibimoons/flowdux/pulls/<pr-number>/requested_reviewers \
+  --method POST -f 'reviewers[]=Copilot'
+```
+
+## 6. 상태 재확인
 
 ```bash
 gh pr checks <pr-number>
@@ -71,7 +80,7 @@ gh api repos/chibimoons/flowdux/pulls/<pr-number>/comments | jq '
 
 → 두 조건 모두 충족될 때까지 2번부터 반복
 
-## 6. 완료
+## 7. 완료
 
 ```
 PR #<number> 리뷰 대응 완료:

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -97,7 +97,16 @@ gh run view <run-id> --log-failed
 
 실패 원인 분석 → 수정 → 커밋 & 푸시
 
-### 2-4. 상태 재확인
+### 2-4. Copilot 코드리뷰 재요청
+
+푸시 후 Copilot에게 코드리뷰를 재요청합니다:
+
+```bash
+gh api repos/chibimoons/flowdux/pulls/<pr-number>/requested_reviewers \
+  --method POST -f 'reviewers[]=Copilot'
+```
+
+### 2-5. 상태 재확인
 
 ```bash
 gh pr checks <pr-number>


### PR DESCRIPTION
## Summary
- `/pr`과 `/pr-respond` 스킬에 푸시 후 Copilot 코드리뷰 재요청 단계 추가
- `gh api .../requested_reviewers --method POST -f 'reviewers[]=Copilot'`

## Test plan
- [x] PR #192에서 Copilot reviewer 이름(`Copilot`) 확인 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)