### PR TITLE
docs(commands): unify Copilot review request API in pr.md

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -84,8 +84,11 @@ EOF
 
 ### 1-7. Copilot 리뷰 요청 & 대기
 
+> **주의**: `gh pr edit --add-reviewer copilot`은 재요청 시 트리거되지 않습니다. 초기/재요청 모두 `requested_reviewers` API를 사용하세요. Copilot은 GitHub App 봇이라 `requested_reviewers` 목록에 나타나지 않으므로, 리뷰 도착 확인은 **reviews API 폴링**으로 해야 합니다.
+
 ```bash
-gh pr edit <pr-number> --repo chibimoons/flowdux --add-reviewer copilot
+gh api repos/chibimoons/flowdux/pulls/<pr-number>/requested_reviewers \
+  -X POST -f 'reviewers[]=copilot-pull-request-reviewer[bot]'
 ```
 
 최신 커밋에 대한 Copilot 리뷰가 도착할 때까지 10초 간격으로 폴링합니다 (최대 10분):
@@ -108,8 +111,6 @@ if [ "$count" -eq 0 ]; then
   echo "Timed out waiting for Copilot review (10min). Proceeding without it."
 fi
 ```
-
-> Copilot은 GitHub App 봇(`copilot-pull-request-reviewer[bot]`)이라 `requested_reviewers`에 나타나지 않습니다. reviews API로 확인해야 합니다.
 
 ---
 


### PR DESCRIPTION
## Summary

`pr.md` 1-7 섹션의 Copilot 리뷰 요청 방식을 `gh pr edit --add-reviewer copilot`에서 `requested_reviewers` API로 변경합니다.

- `gh pr edit --add-reviewer`는 재요청 시 트리거되지 않아 10분 타임아웃 발생
- `pr-respond.md` 2-4 섹션에서는 이미 올바른 API 방식 사용 중
- 초기/재요청 모두 동일한 `requested_reviewers` API로 통일

## Test plan

- [x] PR #224에서 API 방식으로 Copilot 재리뷰 정상 수신 확인 (2.5분)

🤖 Generated with [Claude Code](https://claude.com/claude-code)