### PR TITLE
chore: add missing remote modules to jitpack.yml

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -17,5 +17,8 @@ install:
     :kotlin:flowdux-remote-server:publishToMavenLocal
     :kotlin:flowdux-remote-serialization:publishToMavenLocal
     :kotlin:flowdux-remote-ktor:publishToMavenLocal
+    :kotlin:flowdux-remote-auth:publishToMavenLocal
+    :kotlin:flowdux-remote-multiplexer:publishToMavenLocal
+    :kotlin:flowdux-remote-node-mediator:publishToMavenLocal
     -x kotlinNpmInstall -x kotlinStoreYarnLock
     -x jsTest -x wasmJsTest -x iosX64Test -x iosSimulatorArm64Test


### PR DESCRIPTION
## Summary

JitPack 빌드에 누락된 3개 remote 모듈을 추가합니다.

- `flowdux-remote-auth`
- `flowdux-remote-multiplexer`
- `flowdux-remote-node-mediator`

Closes #199

## Test plan

- [x] 설정 파일만 수정 — 코드 테스트 불필요
- [ ] JitPack 빌드 검증은 태그 배포 시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)