### PR TITLE
docs(remote-ktor): add WASM not-supported notice

### DIFF
--- a/docs/guide/remote.md
+++ b/docs/guide/remote.md
@@ -55,6 +55,17 @@ kotlin {
 }
 ```
 
+> **WASM not supported**: `flowdux-remote-ktor` uses Ktor's WebSocket client, which does not support WASM targets. If your project targets WASM, implement `ClientConnection` / `ServerConnection` with a WASM-compatible WebSocket library and use `flowdux-remote-client` / `flowdux-remote-server` directly without the Ktor transport module.
+
+### Platform Support (flowdux-remote-ktor)
+
+| Platform | Status |
+|----------|--------|
+| JVM | Supported |
+| iOS | Supported |
+| JS | Supported |
+| WASM | Not supported (Ktor client unavailable) |
+
 ## Version Compatibility
 
 FlowDux remote modules require matching Kotlin and serialization versions:


### PR DESCRIPTION
## Summary

`docs/guide/remote.md` Installation 섹션에 WASM 미지원 안내를 추가합니다.

- Callout: WASM 미지원 사유와 대안 (직접 `ClientConnection` 구현)
- Platform Support 테이블: JVM/iOS/JS/WASM 지원 여부 명시

Closes #200

## Test plan

- [x] 문서만 수정 — 테스트 불필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)