### PR TITLE
test(remote-core): add SharedAction marker interface and serialization tests

### DIFF
--- a/kotlin/remote/core/build.gradle.kts
+++ b/kotlin/remote/core/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
+    alias(libs.plugins.kotlinSerialization)
     id("flowdux.publish-conventions")
 }
 
@@ -45,6 +46,7 @@ kotlin {
             implementation(kotlin("test"))
             implementation(libs.kotlinx.coroutines.test)
             implementation(libs.turbine)
+            implementation(libs.kotlinx.serialization.json)
         }
     }
 

--- a/kotlin/remote/core/src/commonTest/kotlin/io/flowdux/remote/SharedActionTest.kt
+++ b/kotlin/remote/core/src/commonTest/kotlin/io/flowdux/remote/SharedActionTest.kt
@@ -1,0 +1,172 @@
+package io.flowdux.remote
+
+import io.flowdux.Action
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.encodeToString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class SharedActionTest {
+
+    // -- Test domain actions --
+
+    interface ChatAction : Action
+
+    @Serializable
+    sealed interface SharedChatAction : ChatAction {
+        @Serializable
+        data class SendMessage(val text: String) : SharedChatAction, ServerSharedAction
+
+        @Serializable
+        data class JoinRoom(val user: String) : SharedChatAction, ServerSharedAction
+
+        @Serializable
+        data class SyncState(val messages: List<String>) : SharedChatAction, ClientSharedAction
+
+        @Serializable
+        data class Kicked(val reason: String) : SharedChatAction, ClientSharedAction
+    }
+
+    data class LocalAction(val value: Int) : ChatAction
+
+    // -- Type hierarchy tests --
+
+    @Test
+    fun serverSharedActionExtendsSharedAction() {
+        val action: Action = SharedChatAction.SendMessage("hello")
+        assertTrue(action is SharedAction)
+        assertTrue(action is ServerSharedAction)
+        assertFalse(action is ClientSharedAction)
+    }
+
+    @Test
+    fun clientSharedActionExtendsSharedAction() {
+        val action: Action = SharedChatAction.SyncState(listOf("msg"))
+        assertTrue(action is SharedAction)
+        assertTrue(action is ClientSharedAction)
+        assertFalse(action is ServerSharedAction)
+    }
+
+    @Test
+    fun localActionIsNotSharedAction() {
+        val action: Action = LocalAction(42)
+        assertFalse(action is SharedAction)
+        assertFalse(action is ServerSharedAction)
+        assertFalse(action is ClientSharedAction)
+    }
+
+    // -- Filtering tests --
+
+    @Test
+    fun filterServerSharedActionsFromMixedList() {
+        val actions: List<Action> = listOf(
+            SharedChatAction.SendMessage("hello"),
+            LocalAction(1),
+            SharedChatAction.SyncState(listOf("msg")),
+            SharedChatAction.JoinRoom("alice"),
+        )
+
+        val serverActions = actions.filterIsInstance<ServerSharedAction>()
+        assertEquals(2, serverActions.size)
+        assertIs<SharedChatAction.SendMessage>(serverActions[0])
+        assertIs<SharedChatAction.JoinRoom>(serverActions[1])
+    }
+
+    @Test
+    fun filterClientSharedActionsFromMixedList() {
+        val actions: List<Action> = listOf(
+            SharedChatAction.SendMessage("hello"),
+            SharedChatAction.SyncState(listOf("msg")),
+            LocalAction(1),
+            SharedChatAction.Kicked("spam"),
+        )
+
+        val clientActions = actions.filterIsInstance<ClientSharedAction>()
+        assertEquals(2, clientActions.size)
+        assertIs<SharedChatAction.SyncState>(clientActions[0])
+        assertIs<SharedChatAction.Kicked>(clientActions[1])
+    }
+
+    @Test
+    fun filterSharedActionsExcludesLocalActions() {
+        val actions: List<Action> = listOf(
+            SharedChatAction.SendMessage("hello"),
+            LocalAction(1),
+            LocalAction(2),
+            SharedChatAction.SyncState(listOf("msg")),
+        )
+
+        val sharedActions = actions.filterIsInstance<SharedAction>()
+        assertEquals(2, sharedActions.size)
+    }
+
+    // -- Serialization tests --
+
+    private val json = Json
+
+    @Test
+    fun serializeAndDeserializeServerSharedAction() {
+        val original = SharedChatAction.SendMessage("hello")
+        val encoded = json.encodeToString<SharedChatAction>(original)
+        val decoded = json.decodeFromString<SharedChatAction>(encoded)
+
+        assertEquals(original, decoded)
+        assertTrue(decoded is ServerSharedAction)
+        assertFalse(decoded is ClientSharedAction)
+    }
+
+    @Test
+    fun serializeAndDeserializeClientSharedAction() {
+        val original = SharedChatAction.SyncState(listOf("msg1", "msg2"))
+        val encoded = json.encodeToString<SharedChatAction>(original)
+        val decoded = json.decodeFromString<SharedChatAction>(encoded)
+
+        assertEquals(original, decoded)
+        assertTrue(decoded is ClientSharedAction)
+        assertFalse(decoded is ServerSharedAction)
+    }
+
+    @Test
+    fun polymorphicSerializationPreservesDirectionMarkers() {
+        val actions = listOf<SharedChatAction>(
+            SharedChatAction.SendMessage("hello"),
+            SharedChatAction.JoinRoom("alice"),
+            SharedChatAction.SyncState(listOf("msg")),
+            SharedChatAction.Kicked("spam"),
+        )
+
+        for (action in actions) {
+            val encoded = json.encodeToString<SharedChatAction>(action)
+            val decoded = json.decodeFromString<SharedChatAction>(encoded)
+
+            assertEquals(action, decoded)
+            assertEquals(action is ServerSharedAction, decoded is ServerSharedAction)
+            assertEquals(action is ClientSharedAction, decoded is ClientSharedAction)
+        }
+    }
+
+    @Test
+    fun serializedJsonContainsTypeDiscriminator() {
+        val action = SharedChatAction.SendMessage("hello")
+        val encoded = json.encodeToString<SharedChatAction>(action)
+
+        // Polymorphic serialization includes type discriminator
+        assertTrue(encoded.contains("type"), "JSON should contain type discriminator: $encoded")
+        assertTrue(encoded.contains("SendMessage"), "JSON should contain class name: $encoded")
+    }
+
+    @Test
+    fun emptyCollectionFieldSerializesCorrectly() {
+        val original = SharedChatAction.SyncState(emptyList())
+        val encoded = json.encodeToString<SharedChatAction>(original)
+        val decoded = json.decodeFromString<SharedChatAction>(encoded)
+
+        assertEquals(original, decoded)
+        assertIs<SharedChatAction.SyncState>(decoded)
+        assertEquals(emptyList(), (decoded as SharedChatAction.SyncState).messages)
+    }
+}


### PR DESCRIPTION
## Summary

`flowdux-remote-core` 모듈에 테스트를 추가합니다.

- **타입 계층 테스트**: `ServerSharedAction`/`ClientSharedAction` → `SharedAction` → `Action` 관계 검증
- **필터링 테스트**: `filterIsInstance`로 방향별 액션 분류 검증 (미들웨어 라우팅 패턴)
- **직렬화 테스트**: polymorphic encode/decode, 타입 디스크리미네이터, 방향 마커 보존 검증

`build.gradle.kts`에 kotlinSerialization 플러그인 및 `kotlinx-serialization-json` 테스트 의존성 추가.

Closes #201

## Test plan

- [x] `./gradlew :kotlin:flowdux-remote-core:jvmTest` — 12개 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)