### PR TITLE
chore(build): enable Gradle configuration cache

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 org.gradle.jvmargs=-Xmx4096m -XX:+HeapDumpOnOutOfMemoryError
-org.gradle.configuration-cache=false
+org.gradle.configuration-cache=true
 
 kotlin.code.style=official
 kotlin.mpp.androidSourceSetLayoutVersion=2

--- a/kotlin/flowdux/build.gradle.kts
+++ b/kotlin/flowdux/build.gradle.kts
@@ -12,7 +12,7 @@ mavenPublishing {
 }
 
 // JitPack only publishes JVM artifacts to avoid variant resolution issues for JVM/Android consumers
-val isJitPack = System.getenv("JITPACK") == "true"
+val isJitPack = providers.environmentVariable("JITPACK").map { it == "true" }.getOrElse(false)
 
 kotlin {
     jvm()

--- a/kotlin/remote/auth/build.gradle.kts
+++ b/kotlin/remote/auth/build.gradle.kts
@@ -13,7 +13,7 @@ mavenPublishing {
 }
 
 // JitPack only publishes JVM artifacts to avoid variant resolution issues for JVM/Android consumers
-val isJitPack = System.getenv("JITPACK") == "true"
+val isJitPack = providers.environmentVariable("JITPACK").map { it == "true" }.getOrElse(false)
 
 kotlin {
     jvm()

--- a/kotlin/remote/client/build.gradle.kts
+++ b/kotlin/remote/client/build.gradle.kts
@@ -12,7 +12,7 @@ mavenPublishing {
 }
 
 // JitPack only publishes JVM artifacts to avoid variant resolution issues for JVM/Android consumers
-val isJitPack = System.getenv("JITPACK") == "true"
+val isJitPack = providers.environmentVariable("JITPACK").map { it == "true" }.getOrElse(false)
 
 kotlin {
     jvm()

--- a/kotlin/remote/core/build.gradle.kts
+++ b/kotlin/remote/core/build.gradle.kts
@@ -13,7 +13,7 @@ mavenPublishing {
 }
 
 // JitPack only publishes JVM artifacts to avoid variant resolution issues for JVM/Android consumers
-val isJitPack = System.getenv("JITPACK") == "true"
+val isJitPack = providers.environmentVariable("JITPACK").map { it == "true" }.getOrElse(false)
 
 kotlin {
     jvm()

--- a/kotlin/remote/ktor/build.gradle.kts
+++ b/kotlin/remote/ktor/build.gradle.kts
@@ -12,7 +12,7 @@ mavenPublishing {
 }
 
 // JitPack only publishes JVM artifacts to avoid variant resolution issues for JVM/Android consumers
-val isJitPack = System.getenv("JITPACK") == "true"
+val isJitPack = providers.environmentVariable("JITPACK").map { it == "true" }.getOrElse(false)
 
 kotlin {
     jvm()

--- a/kotlin/remote/multiplexer/build.gradle.kts
+++ b/kotlin/remote/multiplexer/build.gradle.kts
@@ -13,7 +13,7 @@ mavenPublishing {
 }
 
 // JitPack only publishes JVM artifacts to avoid variant resolution issues for JVM/Android consumers
-val isJitPack = System.getenv("JITPACK") == "true"
+val isJitPack = providers.environmentVariable("JITPACK").map { it == "true" }.getOrElse(false)
 
 kotlin {
     jvm()

--- a/kotlin/remote/node-mediator/build.gradle.kts
+++ b/kotlin/remote/node-mediator/build.gradle.kts
@@ -13,7 +13,7 @@ mavenPublishing {
 }
 
 // JitPack only publishes JVM artifacts to avoid variant resolution issues for JVM/Android consumers
-val isJitPack = System.getenv("JITPACK") == "true"
+val isJitPack = providers.environmentVariable("JITPACK").map { it == "true" }.getOrElse(false)
 
 kotlin {
     jvm()

--- a/kotlin/remote/serialization/build.gradle.kts
+++ b/kotlin/remote/serialization/build.gradle.kts
@@ -13,7 +13,7 @@ mavenPublishing {
 }
 
 // JitPack only publishes JVM artifacts to avoid variant resolution issues for JVM/Android consumers
-val isJitPack = System.getenv("JITPACK") == "true"
+val isJitPack = providers.environmentVariable("JITPACK").map { it == "true" }.getOrElse(false)
 
 kotlin {
     jvm()

--- a/kotlin/remote/server/build.gradle.kts
+++ b/kotlin/remote/server/build.gradle.kts
@@ -12,7 +12,7 @@ mavenPublishing {
 }
 
 // JitPack only publishes JVM artifacts to avoid variant resolution issues for JVM/Android consumers
-val isJitPack = System.getenv("JITPACK") == "true"
+val isJitPack = providers.environmentVariable("JITPACK").map { it == "true" }.getOrElse(false)
 
 kotlin {
     jvm()

--- a/kotlin/timetravel/build.gradle.kts
+++ b/kotlin/timetravel/build.gradle.kts
@@ -12,7 +12,7 @@ mavenPublishing {
 }
 
 // JitPack only publishes JVM artifacts to avoid variant resolution issues for JVM/Android consumers
-val isJitPack = System.getenv("JITPACK") == "true"
+val isJitPack = providers.environmentVariable("JITPACK").map { it == "true" }.getOrElse(false)
 
 kotlin {
     jvm()


### PR DESCRIPTION
## Summary
- Replace `System.getenv("JITPACK")` with `providers.environmentVariable("JITPACK")` in all 10 module build scripts for configuration-cache compatibility
- Enable `org.gradle.configuration-cache=true` in `gradle.properties`
- Verified: first build stores cache entry, second build reuses it (12s → 495ms)

Closes #204

## Test plan
- [x] `./gradlew jvmTest` — all tests pass with configuration cache enabled
- [x] Second run confirms `Configuration cache entry reused.`
- [x] JitPack env var still correctly controls target platform selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)