### PR TITLE
chore(ci): add Kover code coverage reporting

### DIFF
--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -69,6 +69,16 @@ jobs:
       - name: Run flowdux-remote-node-mediator tests
         run: ./gradlew :kotlin:flowdux-remote-node-mediator:jvmTest
 
+      - name: Generate coverage report
+        run: ./gradlew koverXmlReport koverHtmlReport
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: build/reports/kover/
+
   # iOS/Native compilation check — catches issues like missing imports
   # that only surface on non-JVM targets (e.g. kotlin.concurrent.Volatile)
   compile-native:

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -3,4 +3,5 @@ plugins {
 }
 dependencies {
     implementation("com.vanniktech:gradle-maven-publish-plugin:0.36.0")
+    implementation("org.jetbrains.kotlinx:kover-gradle-plugin:0.9.1")
 }

--- a/build-logic/src/main/kotlin/flowdux.publish-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/flowdux.publish-conventions.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("com.vanniktech.maven.publish")
+    id("org.jetbrains.kotlinx.kover")
 }
 
 mavenPublishing {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,4 +6,18 @@ plugins {
     alias(libs.plugins.androidLibrary) apply false
     alias(libs.plugins.kotlinCompose) apply false
     alias(libs.plugins.mavenPublish) apply false
+    alias(libs.plugins.kover)
+}
+
+dependencies {
+    kover(project(":kotlin:flowdux"))
+    kover(project(":kotlin:flowdux-timetravel"))
+    kover(project(":kotlin:flowdux-remote-core"))
+    kover(project(":kotlin:flowdux-remote-client"))
+    kover(project(":kotlin:flowdux-remote-server"))
+    kover(project(":kotlin:flowdux-remote-serialization"))
+    kover(project(":kotlin:flowdux-remote-ktor"))
+    kover(project(":kotlin:flowdux-remote-multiplexer"))
+    kover(project(":kotlin:flowdux-remote-auth"))
+    kover(project(":kotlin:flowdux-remote-node-mediator"))
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+kover = "0.9.1"
 mavenPublish = "0.36.0"
 kotlin = "2.2.10"
 coroutines = "1.10.2"
@@ -49,4 +50,5 @@ androidApplication = { id = "com.android.application", version.ref = "agp" }
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
 kotlinCompose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish" }


### PR DESCRIPTION
## Summary
- Apply Kover 0.9.1 to all 10 library modules via publish-conventions plugin
- Configure merged XML + HTML coverage reports at root project level
- Add CI steps to generate and upload coverage reports as artifacts

Closes #205

## Test plan
- [x] `koverXmlReport` generates valid XML report (269KB)
- [x] `koverHtmlReport` generates HTML report
- [x] All JVM tests pass with Kover instrumentation
- [x] Configuration cache compatible

🤖 Generated with [Claude Code](https://claude.com/claude-code)