### PR TITLE
chore: add .editorconfig for consistent code style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,31 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{kt,kts}]
+indent_size = 4
+max_line_length = 120
+
+[*.{yaml,yml}]
+indent_size = 2
+
+[*.{json,toml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{xml,html}]
+indent_size = 2
+
+[*.dart]
+indent_size = 2
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
## Summary
- Add `.editorconfig` with project-wide code style rules
- Kotlin/Gradle: 4-space indent, 120 char max line length
- YAML/JSON/TOML: 2-space indent
- Markdown: preserve trailing whitespace
- Dart: 2-space indent
- UTF-8, LF line endings, trim trailing whitespace, insert final newline

Closes #207

## Test plan
- [x] Build and tests unaffected (editor-only configuration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)