### PR TITLE
perf(remote-ktor): replace Channel.UNLIMITED with bounded channel

### DIFF
--- a/kotlin/remote/ktor/src/commonMain/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnection.kt
+++ b/kotlin/remote/ktor/src/commonMain/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnection.kt
@@ -54,10 +54,10 @@ class KtorWebSocketClientConnection(
     private val _connectionState = MutableStateFlow(ConnectionState.DISCONNECTED)
     override val connectionState: StateFlow<ConnectionState> = _connectionState
 
-    private val incomingChannel = Channel<String>(Channel.UNLIMITED)
+    private val incomingChannel = Channel<String>(Channel.BUFFERED)
     override val incoming: Flow<String> = incomingChannel.receiveAsFlow()
 
-    private val outgoingChannel = Channel<String>(Channel.UNLIMITED)
+    private val outgoingChannel = Channel<String>(Channel.BUFFERED)
 
     private var session: WebSocketSession? = null
     private val connectMutex = Mutex()


### PR DESCRIPTION
## Summary
- Replace `Channel.UNLIMITED` with `Channel.BUFFERED` in `KtorWebSocketClientConnection`
- Applies to both `incomingChannel` and `outgoingChannel`
- Prevents unbounded memory growth (OOM) when server sends faster than client consumes
- `BUFFERED` suspends senders when full, providing natural backpressure without message loss

Closes #208

## Test plan
- [x] All remote-ktor JVM tests pass (8 tests including integration tests with embedded server)
- [x] Message exchange tests verify send/receive still works correctly with bounded buffer

🤖 Generated with [Claude Code](https://claude.com/claude-code)