### PR TITLE
fix(remote-ktor): add @Volatile to session for Native thread safety

### DIFF
--- a/kotlin/remote/ktor/src/commonMain/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnection.kt
+++ b/kotlin/remote/ktor/src/commonMain/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnection.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlin.concurrent.Volatile
 
 /**
  * Ktor-based WebSocket client implementation of [ClientConnection].
@@ -69,6 +70,7 @@ class KtorWebSocketClientConnection(
 
     private val outgoingChannel = Channel<String>(Channel.BUFFERED)
 
+    @Volatile
     private var session: WebSocketSession? = null
     private val connectMutex = Mutex()
 


### PR DESCRIPTION
## Summary

- Add `@Volatile` annotation to `session` field in `KtorWebSocketClientConnection`
- `connect()` writes `session` (line 94, 112) and `disconnect()` reads it (line 122) from different coroutines — on Kotlin/Native, without `@Volatile`, stale cache reads can cause `disconnect()` to see `null` even after `connect()` has set the session
- Uses `kotlin.concurrent.Volatile` for multiplatform compatibility (JVM → Java `volatile`, Native → equivalent memory ordering)

Closes #239

## Test plan

- [x] `./gradlew :kotlin:flowdux-remote-ktor:jvmTest` — all tests pass
- [ ] CI: JVM tests + iOS compilation check

🤖 Generated with [Claude Code](https://claude.com/claude-code)