### PR TITLE
perf(remote-serialization): eliminate double JSON parsing in JsonMessageCodec

### DIFF
--- a/kotlin/remote/serialization/src/commonMain/kotlin/io/flowdux/remote/serialization/JsonMessageCodec.kt
+++ b/kotlin/remote/serialization/src/commonMain/kotlin/io/flowdux/remote/serialization/JsonMessageCodec.kt
@@ -5,6 +5,7 @@ import io.flowdux.remote.ServerResponse
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonUnquotedLiteral
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
@@ -22,10 +23,9 @@ class JsonMessageCodec(
 ) : MessageCodec {
 
     override fun encodeActionMessage(actionJson: String): String {
-        val payload = json.parseToJsonElement(actionJson)
         return json.encodeToString(JsonElement.serializer(), buildJsonObject {
             put("type", "action")
-            put("payload", payload)
+            put("payload", JsonUnquotedLiteral(actionJson))
         })
     }
 
@@ -33,11 +33,11 @@ class JsonMessageCodec(
         val obj = json.parseToJsonElement(raw).jsonObject
         val payload = obj["payload"]
             ?: error("Missing \"payload\" field in client message: $raw")
-        return json.encodeToString(JsonElement.serializer(), payload)
+        return payload.toString()
     }
 
     override fun encodeServerResponse(actions: List<String>): String {
-        val elements = actions.map { json.parseToJsonElement(it) }
+        val elements = actions.map { JsonUnquotedLiteral(it) }
         return json.encodeToString(JsonElement.serializer(), buildJsonObject {
             put("type", "response")
             put("actions", JsonArray(elements))
@@ -48,9 +48,7 @@ class JsonMessageCodec(
         val obj = json.parseToJsonElement(raw).jsonObject
         val actionsElement = obj["actions"]
             ?: error("Missing \"actions\" field in server message: $raw")
-        val actions = actionsElement.jsonArray.map {
-            json.encodeToString(JsonElement.serializer(), it)
-        }
+        val actions = actionsElement.jsonArray.map { it.toString() }
         return ServerResponse(actions = actions)
     }
 }


### PR DESCRIPTION
## Summary

- **Encode path**: Replace `json.parseToJsonElement(actionJson)` with `JsonUnquotedLiteral(actionJson)` — eliminates redundant parse when embedding action JSON into the wire envelope
- **Decode path**: Replace `json.encodeToString(JsonElement.serializer(), element)` with `element.toString()` — eliminates serializer overhead when extracting action JSON from parsed envelope
- Before: `String → parse → JsonElement → serialize → String → parse → Object` (2 parses per action)
- After: `String → embed directly` (encode) / `JsonElement → toString()` (decode) — 1 parse eliminated per action

Closes #210

## Test plan

- [x] `./gradlew :kotlin:flowdux-remote-serialization:jvmTest` — all 30 tests pass (JsonMessageCodecTest, DefaultTypedConnectionTest, SerializableActionCodecTest)
- [ ] CI: JVM tests + iOS compilation check

🤖 Generated with [Claude Code](https://claude.com/claude-code)