### PR TITLE
chore(build): deduplicate Kover and Maven Publish versions in build-logic

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -2,6 +2,6 @@ plugins {
     `kotlin-dsl`
 }
 dependencies {
-    implementation("com.vanniktech:gradle-maven-publish-plugin:0.36.0")
-    implementation("org.jetbrains.kotlinx:kover-gradle-plugin:0.9.1")
+    implementation(libs.maven.publish.gradle.plugin)
+    implementation(libs.kover.gradle.plugin)
 }

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -3,5 +3,10 @@ dependencyResolutionManagement {
         mavenCentral()
         gradlePluginPortal()
     }
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
 }
 rootProject.name = "build-logic"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,6 +41,9 @@ ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "kto
 ktor-client-js = { module = "io.ktor:ktor-client-js", version.ref = "ktor" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
 kotlinx-browser = { module = "org.jetbrains.kotlinx:kotlinx-browser", version.ref = "kotlinx-browser" }
+# Gradle plugin artifacts (for build-logic convention plugins)
+maven-publish-gradle-plugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "mavenPublish" }
+kover-gradle-plugin = { module = "org.jetbrains.kotlinx:kover-gradle-plugin", version.ref = "kover" }
 
 [plugins]
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }


### PR DESCRIPTION
## Summary

- Share version catalog from root project with `build-logic` via `settings.gradle.kts` `versionCatalogs` block
- Replace hardcoded versions in `build-logic/build.gradle.kts` with `libs.maven.publish.gradle.plugin` and `libs.kover.gradle.plugin` references
- Add plugin artifact library entries to `gradle/libs.versions.toml` for build-logic consumption
- Before: versions duplicated in `build-logic/build.gradle.kts` and `gradle/libs.versions.toml` — version drift risk
- After: single source of truth in `libs.versions.toml`

Closes #241

## Test plan

- [x] `./gradlew jvmTest` — all tests pass (configuration cache compatible)
- [ ] CI: JVM tests + iOS compilation check

🤖 Generated with [Claude Code](https://claude.com/claude-code)