### PR TITLE
test(remote-ktor): add backpressure tests for Channel.BUFFERED

### DIFF
--- a/kotlin/remote/ktor/src/jvmTest/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnectionTest.kt
+++ b/kotlin/remote/ktor/src/jvmTest/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnectionTest.kt
@@ -403,7 +403,7 @@ class KtorWebSocketClientConnectionTest {
             }
 
             connection.disconnect()
-            connectJob.join()
+            withTimeout(5_000) { connectJob.join() }
         } finally {
             server.stop(500, 1_000)
         }
@@ -439,8 +439,8 @@ class KtorWebSocketClientConnectionTest {
             }
 
             // Send more messages than the buffer can hold (64).
-            // With the slow server, the outgoing buffer fills up and send() suspends
-            // until the server drains messages. No messages should be dropped.
+            // With the slow server, the outgoing buffer is likely to fill up, causing
+            // send() to suspend until messages are drained. No messages should be dropped.
             withTimeout(30_000) {
                 for (i in 0 until messageCount) {
                     connection.send("msg-$i")
@@ -460,7 +460,7 @@ class KtorWebSocketClientConnectionTest {
             }
 
             connection.disconnect()
-            connectJob.join()
+            withTimeout(5_000) { connectJob.join() }
         } finally {
             server.stop(500, 1_000)
         }
@@ -482,33 +482,36 @@ class KtorWebSocketClientConnectionTest {
             }
         }.start(wait = false)
 
+        var connection: KtorWebSocketClientConnection? = null
         try {
             val port = server.engine.resolvedConnectors().first().port
-            val connection = KtorWebSocketClientConnection("ws://localhost:$port/test")
+            connection = KtorWebSocketClientConnection("ws://localhost:$port/test")
 
             val connectJob = launch(Dispatchers.Default) { connection.connect() }
             withTimeout(5_000) {
                 connection.connectionState.first { it == ConnectionState.CONNECTED }
             }
 
-            // Collect slowly with periodic delays to exercise buffer fill/drain cycles.
-            // With BUFFERED (64, SUSPEND), the receive loop suspends when the buffer fills,
-            // then resumes as the consumer drains it. No messages should be dropped.
-            val consumed = mutableListOf<String>()
-            withTimeout(30_000) {
-                connection.incoming.take(messageCount).collect { msg ->
-                    consumed.add(msg)
-                    if (consumed.size % 10 == 0) delay(50)
+            try {
+                // Collect slowly with periodic delays to exercise buffer fill/drain cycles.
+                // With BUFFERED (64, SUSPEND), the receive loop suspends when the buffer fills,
+                // then resumes as the consumer drains it. No messages should be dropped.
+                val consumed = mutableListOf<String>()
+                withTimeout(30_000) {
+                    connection.incoming.take(messageCount).collect { msg ->
+                        consumed.add(msg)
+                        if (consumed.size % 10 == 0) delay(50)
+                    }
                 }
-            }
 
-            assertEquals(messageCount, consumed.size)
-            for (i in 0 until messageCount) {
-                assertEquals("msg-$i", consumed[i], "Message $i out of order or missing")
+                assertEquals(messageCount, consumed.size)
+                for (i in 0 until messageCount) {
+                    assertEquals("msg-$i", consumed[i], "Message $i out of order or missing")
+                }
+            } finally {
+                connection.disconnect()
+                withTimeout(5_000) { connectJob.join() }
             }
-
-            connection.disconnect()
-            connectJob.join()
         } finally {
             server.stop(500, 1_000)
         }


### PR DESCRIPTION
## Summary

Closes #243

`Channel.BUFFERED` 전환(PR #242) 이후 버퍼 초과 시나리오에 대한 테스트 3건을 추가합니다:

1. **incoming backpressure**: 서버가 100개 메시지를 버퍼(64) 이상으로 빠르게 전송 → 모든 메시지 유실 없이 수신 확인
2. **outgoing backpressure**: 클라이언트가 100개 메시지를 빠르게 전송 → `send()`가 suspend되지만 서버에 모두 전달됨 확인
3. **slow consumer under sustained backpressure**: 서버가 200개 메시지 전송, 클라이언트가 느리게 소비 → 메시지 순서 보장 및 유실 없음 검증

## Test plan
- [x] `./gradlew :kotlin:flowdux-remote-ktor:jvmTest` — 20개 테스트 모두 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)