### PR TITLE
release: 1.18.0

### DIFF
--- a/.claude/commands/issue-auto.md
+++ b/.claude/commands/issue-auto.md
@@ -1,0 +1,188 @@
+---
+description: "이슈 자율 처리 — 분석 → 코드 수정 → PR 생성까지 확인 없이 자율 진행 (머지 제외)"
+argument-hint: <이슈번호>
+allowed-tools: [Bash, Read, Edit, Write, Glob, Grep, Task]
+---
+
+# 이슈 자율 처리 (Autonomous Mode)
+
+이슈 번호: `$ARGUMENTS`
+
+> **자율 모드**: 사용자 확인 없이 자율 진행합니다. **머지는 수행하지 않습니다.**
+
+---
+
+## Phase 1: 사전 검증
+
+### 1-1. 인자 확인
+
+`$ARGUMENTS`가 비어있거나 양의 정수가 아니면 사용자에게 올바른 이슈 번호를 요청하고 중단하세요.
+
+### 1-2. Git Workflow 규칙 로드
+
+`docs/dev/git-workflow.md`를 Read하여 규칙을 확인하세요.
+
+### 1-3. GitHub 계정 확인
+
+```bash
+gh auth status
+```
+
+`chibimoons` 계정이 Active가 아니면:
+
+```bash
+gh auth switch -u chibimoons
+```
+
+### 1-4. 이슈 상태 확인
+
+```bash
+gh issue view $ARGUMENTS --repo chibimoons/flowdux --json state,title,body,labels,comments
+```
+
+- **CLOSED** → "이슈 #$ARGUMENTS는 이미 닫혀 있습니다." 출력 후 종료
+- **OPEN** → Phase 2로 진행
+
+---
+
+## Phase 2: 이슈 분석 & 계획
+
+### 2-1. 이슈 정보 수집
+
+이슈 제목, 본문, 라벨, 코멘트를 읽고 아래를 판단:
+
+- **이슈 유형**: 라벨과 제목/본문으로 판단
+
+| 유형 | 브랜치 접두사 | 커밋 접두사 |
+|------|-------------|------------|
+| 기능 추가 | `feature/` | `feat` |
+| 버그 수정 | `fix/` | `fix` |
+| 테스트 | `feature/` | `test` |
+| 문서 | `docs/` | `docs` |
+| 리팩터링 | `feature/` | `refactor` |
+| 성능 개선 | `feature/` | `perf` |
+| 보안 수정 | `fix/` | `security` |
+| 기타 | `feature/` | `chore` |
+
+> **참고**: `test`, `refactor`, `perf`, `chore` 작업은 `feature/` 브랜치를 사용합니다.
+
+- **브랜치명**: `{prefix}/{issue-number}-{short-description}` (영문 kebab-case)
+  - 단, **문서 작업(`docs/`)** 은 `docs/{short-description}` 형태로 이슈 번호 없이 생성
+- **커밋 스코프**: 수정 대상 모듈명 사용
+  - `flowdux`, `remote-core`, `remote-client`, `remote-server`, `remote-ktor`, `remote-serialization`, `remote-auth`, `remote-multiplexer`, `remote-node-mediator`, `timetravel`
+  - 여러 모듈에 걸치면 `remote` 등 상위 스코프 사용
+  - 샘플/문서만 수정 시 `sample`, `docs` 사용
+- **타겟 브랜치**: `develop` (이슈 기반 작업은 모두 develop 타겟, main 직접 반영이 필요한 문서는 별도 `/pr` 워크플로우 사용)
+
+### 2-2. 관련 코드 탐색
+
+Task(Explore) 서브에이전트로 이슈에서 요구하는 수정 범위를 파악하세요:
+- 어떤 파일을 수정해야 하는지
+- 기존 코드 구조와 패턴 파악
+- 영향 범위 분석
+
+### 2-3. 수정 계획 출력 (확인 없이 진행)
+
+분석 결과를 아래 표 형태로 **출력만** 하고 바로 Phase 3으로 진행합니다:
+
+```
+이슈 #{번호}: {제목}
+
+브랜치: {prefix}/{issue-number}-{description} (문서 작업: docs/{short-description})
+타겟: develop
+유형: {feat/fix/test/refactor/perf/security/docs/chore}
+스코프: {모듈명}
+
+| # | 수정 파일 | 변경 내용 | 이유 |
+|---|----------|----------|------|
+| 1 | kotlin/remote/... | ... | ... |
+| 2 | kotlin/flowdux/... | ... | ... |
+
+→ 자율 모드: 바로 진행합니다.
+```
+
+---
+
+## Phase 3: 브랜치 생성 & 코드 수정
+
+### 3-1. develop 최신화 & 브랜치 생성
+
+```bash
+git fetch origin develop
+git checkout -b {branch-name} origin/develop
+```
+
+### 3-2. 코드 수정
+
+Phase 2에서 출력한 계획에 따라 코드를 수정합니다.
+
+### 3-3. 테스트 실행
+
+수정한 모듈에 해당하는 테스트를 실행합니다:
+
+```bash
+# 모듈별 JVM 테스트
+./gradlew :kotlin:flowdux:jvmTest
+./gradlew :kotlin:flowdux-remote-core:jvmTest
+./gradlew :kotlin:flowdux-remote-client:jvmTest
+./gradlew :kotlin:flowdux-remote-server:jvmTest
+./gradlew :kotlin:flowdux-remote-ktor:jvmTest
+./gradlew :kotlin:flowdux-remote-serialization:jvmTest
+./gradlew :kotlin:flowdux-remote-auth:jvmTest
+./gradlew :kotlin:flowdux-remote-multiplexer:jvmTest
+./gradlew :kotlin:flowdux-remote-node-mediator:jvmTest
+./gradlew :kotlin:flowdux-timetravel:jvmTest
+
+# 수정 범위가 넓을 때 전체 테스트
+./gradlew jvmTest
+```
+
+- 실패 시 → 원인 분석 → 수정 → 재실행 (최초 실행 포함 최대 3회)
+- 3회 실패 시 아래 형식으로 보고하고 **워크플로우를 중단하세요. PR을 생성하거나 푸시하지 않습니다.**
+
+```
+이슈 #$ARGUMENTS 처리 실패 (자율 모드):
+- 브랜치: {branch-name}
+- 실패 원인: {테스트 실패 내역 요약}
+- 시도 횟수: 3회
+- 수동 확인이 필요합니다.
+```
+
+### 3-4. 커밋 & 푸시
+
+```bash
+git add {수정된 파일들}
+git commit -m "$(cat <<'EOF'
+{type}({scope}): {description}
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+EOF
+)"
+git push -u origin {branch-name}
+```
+
+---
+
+## Phase 4: PR 생성 & 리뷰 대응
+
+`.claude/commands/pr.md` 워크플로우를 따릅니다. 단, 자율 모드 규칙을 적용합니다:
+
+- **타겟 브랜치**: `develop` (모든 이슈 유형이 develop을 타겟으로 함 — git-workflow.md 규칙, 사용자 확인 불필요)
+- **PR body의 Summary 섹션에 `Closes #$ARGUMENTS` 포함**
+- **로컬 코드 리뷰 (pr.md section 1-5)**: CRITICAL은 자동 수정 (최대 2회), WARNING은 로그만 남기고 진행
+- **Copilot 리뷰 대응 (pr.md Phase 2 — 코드리뷰 & CI 대응 루프)**: 코멘트 자동 분석 → 수정 필요하면 자동 수정 & 답글, 불필요하면 사유 답글을 사용자 확인 없이 자동 수행
+- **머지는 수행하지 않음** — pr.md Phase 3(완료)에서 머지 준비 완료만 보고
+
+---
+
+## Phase 5: 완료 보고
+
+```
+PR #{pr-number} 머지 준비 완료 (자율 모드):
+- PR: {pr-url}
+- 이슈: #$ARGUMENTS
+- 브랜치: {branch-name}
+- CI: 통과 여부
+- 코드리뷰: 대응 완료 여부
+- 머지가 필요하면 수동으로 진행하세요.
+```

--- a/.claude/commands/pr-respond.md
+++ b/.claude/commands/pr-respond.md
@@ -69,8 +69,11 @@ gh run view <run-id> --repo chibimoons/flowdux --log-failed
 
 ### 5-1. 재요청
 
+> **주의**: `gh pr edit --add-reviewer copilot`은 이미 등록된 리뷰어에게 재트리거되지 않습니다. Copilot 재리뷰를 트리거할 때에는 `requested_reviewers` API를 사용하세요. Copilot은 GitHub App 봇이라 응답이나 `requested_reviewers` 목록에 나타나지 않으므로, 리뷰 도착 확인은 아래 5-3 단계처럼 **reviews API 폴링**으로 해야 합니다.
+
 ```bash
-gh pr edit <pr-number> --repo chibimoons/flowdux --add-reviewer copilot
+gh api repos/chibimoons/flowdux/pulls/<pr-number>/requested_reviewers \
+  -X POST -f 'reviewers[]=copilot-pull-request-reviewer[bot]'
 ```
 
 ### 5-2. 최신 커밋 SHA 확인

--- a/.claude/commands/pr-respond.md
+++ b/.claude/commands/pr-respond.md
@@ -7,22 +7,22 @@
 ## 1. PR 상태 확인
 
 ```bash
-gh pr view <pr-number> --json title,state,headRefName,baseRefName
-gh pr checks <pr-number>
+gh pr view <pr-number> --repo chibimoons/flowdux --json title,state,headRefName,baseRefName
+gh pr checks <pr-number> --repo chibimoons/flowdux
 ```
 
 ## 2. 리뷰 코멘트 확인
 
 ```bash
-gh api repos/chibimoons/flowdux/pulls/<pr-number>/comments | jq '.[] | {id, path, body, line, in_reply_to_id}'
+gh api repos/chibimoons/flowdux/pulls/<pr-number>/comments --jq '.[] | {id, path, body, line, in_reply_to_id}'
 ```
 
 미답변 코멘트만 필터:
 
 ```bash
-gh api repos/chibimoons/flowdux/pulls/<pr-number>/comments | jq '
+gh api repos/chibimoons/flowdux/pulls/<pr-number>/comments --jq '
   ( [.[].in_reply_to_id] | unique ) as $replied_ids
-  | [ .[] | select(.in_reply_to_id == null and (.id | IN($replied_ids[]) | not)) ]
+  | [ .[] | select(.in_reply_to_id == null and (.id as $id | $replied_ids | index($id) | not)) ]
 '
 ```
 
@@ -33,14 +33,14 @@ gh api repos/chibimoons/flowdux/pulls/<pr-number>/comments | jq '
    - 코드 수정
    - 테스트 실행하여 통과 확인
    - 커밋 & 푸시
-   - 해당 코멘트에 답글: 어떻게 수정했는지 명시 (커밋 해시 포함)
+   - 해당 코멘트에 답글: 어떻게 수정했는지 명시
 3. **수정이 불필요한 경우:**
    - 해당 코멘트에 답글: 수정하지 않는 이유 설명
 
 ```bash
 # 리뷰 코멘트에 답글
 gh api repos/chibimoons/flowdux/pulls/<pr-number>/comments/<comment-id>/replies \
-  -f body="Fixed in <commit-hash>. <설명>"
+  -X POST -f body="Fixed. <설명>"
 ```
 
 **중요: 모든 리뷰 코멘트에 반드시 답글을 남기세요. 수정 여부와 관계없이.**
@@ -50,27 +50,66 @@ gh api repos/chibimoons/flowdux/pulls/<pr-number>/comments/<comment-id>/replies 
 CI가 실패했으면:
 
 ```bash
-gh run view <run-id> --log-failed
+# PR의 CI 상태 요약 확인
+gh pr checks <pr-number> --repo chibimoons/flowdux
+
+# 관련 GitHub Actions run 목록 확인 (run-id 확인용)
+gh run list --repo chibimoons/flowdux --limit 10
+
+# 실패한 run의 로그 터미널에서 바로 확인
+gh run view <run-id> --repo chibimoons/flowdux --log-failed
 ```
 
 실패 원인 분석 → 수정 → 테스트 확인 → 커밋 & 푸시
 
-## 5. Copilot 코드리뷰 재요청
+## 5. Copilot 코드리뷰 재요청 & 대기
 
-푸시 후 Copilot에게 코드리뷰를 재요청합니다:
+3~4단계에서 코드를 푸시했으면 Copilot에게 코드리뷰를 재요청하고 **리뷰가 도착할 때까지 대기**합니다.
+코드 수정/푸시가 없었으면 이 단계를 건너뜁니다.
+
+### 5-1. 재요청
 
 ```bash
-gh api repos/chibimoons/flowdux/pulls/<pr-number>/requested_reviewers \
-  --method POST -f 'reviewers[]=Copilot'
+gh pr edit <pr-number> --repo chibimoons/flowdux --add-reviewer copilot
 ```
+
+### 5-2. 최신 커밋 SHA 확인
+
+```bash
+LATEST_COMMIT=$(gh pr view <pr-number> --repo chibimoons/flowdux --json headRefOid --jq '.headRefOid')
+```
+
+### 5-3. Copilot 리뷰 도착 대기
+
+최신 커밋(`$LATEST_COMMIT`)에 대한 Copilot 리뷰가 제출될 때까지 10초 간격으로 폴링합니다 (최대 10분).
+
+```bash
+count=0
+for i in $(seq 1 60); do
+  count=$(gh api repos/chibimoons/flowdux/pulls/<pr-number>/reviews \
+    --jq "[.[] | select(.user.login == \"copilot-pull-request-reviewer[bot]\" and .commit_id == \"$LATEST_COMMIT\")] | length")
+  count=${count:-0}
+  if [ "$count" -gt 0 ]; then
+    echo "Copilot review received"
+    break
+  fi
+  echo "Waiting for Copilot review... (${i}0s)"
+  sleep 10
+done
+if [ "$count" -eq 0 ]; then
+  echo "Timed out waiting for Copilot review (10min). Proceeding without it."
+fi
+```
+
+> Copilot은 GitHub App 봇(`copilot-pull-request-reviewer[bot]`)이라 `requested_reviewers`에 나타나지 않습니다. reviews API로 확인해야 합니다.
 
 ## 6. 상태 재확인
 
 ```bash
-gh pr checks <pr-number>
-gh api repos/chibimoons/flowdux/pulls/<pr-number>/comments | jq '
+gh pr checks <pr-number> --repo chibimoons/flowdux
+gh api repos/chibimoons/flowdux/pulls/<pr-number>/comments --jq '
   ( [.[].in_reply_to_id] | unique ) as $replied_ids
-  | [ .[] | select(.in_reply_to_id == null and (.id | IN($replied_ids[]) | not)) ]
+  | [ .[] | select(.in_reply_to_id == null and (.id as $id | $replied_ids | index($id) | not)) ]
   | length
 '
 ```

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -53,6 +53,7 @@ PR 생성 전에 전체 변경사항을 리뷰합니다. Task(general-purpose) �
 3. 프로젝트 컨벤션 위반 — CLAUDE.md의 규칙과 기존 코드 패턴 참조
 4. 불필요한 코드 — 미사용 import, 데드코드, 불필요한 주석
 5. 누락된 에러 처리 — 예외 미처리, 경계값 미검증
+6. 프로젝트 리뷰 규칙 위반 — `.github/copilot-instructions.md`를 Read하여 이번 변경에 해당하는 항목을 모두 대조
 
 결과를 severity별로 정리하세요:
 - [CRITICAL] 반드시 수정 필요

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -27,7 +27,7 @@ gh auth switch -u chibimoons
 - 현재 브랜치명 확인
 - 타겟 브랜치 결정:
   - `main` 타겟: 브랜치명이 `release/*`, `hotfix/*`, `docs/*` 인지 확인 (아니면 CI fail)
-  - `develop` 타겟: 제한 없음
+  - `develop` 타겟: feature, fix, chore, refactor, test 등
 - 사용자에게 타겟 브랜치를 확인받으세요
 
 ### 1-4. 변경 사항 파악
@@ -45,7 +45,7 @@ PR 생성 전에 전체 변경사항을 리뷰합니다. Task(general-purpose) �
 ```
 코드 리뷰를 수행하세요. 수정은 하지 마세요.
 
-대상: `git diff <base-branch>...HEAD`로 변경 파일 목록을 확인하고, 각 파일을 Read로 읽어서 변경 부분 중심으로 리뷰
+대상: `git diff --name-only <base-branch>...HEAD`로 변경 파일 목록을 확인하고, 각 파일을 Read로 읽어서 변경 부분 중심으로 리뷰
 
 리뷰 관점:
 1. 버그/논리 오류 — 의도와 다르게 동작할 수 있는 코드
@@ -70,7 +70,7 @@ PR 생성 전에 전체 변경사항을 리뷰합니다. Task(general-purpose) �
 ### 1-6. PR 생성
 
 ```bash
-gh pr create --base <target> --title "<title>" --body "$(cat <<'EOF'
+gh pr create --repo chibimoons/flowdux --base <target> --title "<title>" --body "$(cat <<'EOF'
 ## Summary
 <변경 내용 요약>
 
@@ -82,6 +82,35 @@ EOF
 )"
 ```
 
+### 1-7. Copilot 리뷰 요청 & 대기
+
+```bash
+gh pr edit <pr-number> --repo chibimoons/flowdux --add-reviewer copilot
+```
+
+최신 커밋에 대한 Copilot 리뷰가 도착할 때까지 10초 간격으로 폴링합니다 (최대 10분):
+
+```bash
+LATEST_COMMIT=$(gh pr view <pr-number> --repo chibimoons/flowdux --json headRefOid --jq '.headRefOid')
+count=0
+for i in $(seq 1 60); do
+  count=$(gh api repos/chibimoons/flowdux/pulls/<pr-number>/reviews \
+    --jq "[.[] | select(.user.login == \"copilot-pull-request-reviewer[bot]\" and .commit_id == \"$LATEST_COMMIT\")] | length")
+  count=${count:-0}
+  if [ "$count" -gt 0 ]; then
+    echo "Copilot review received"
+    break
+  fi
+  echo "Waiting for Copilot review... (${i}0s)"
+  sleep 10
+done
+if [ "$count" -eq 0 ]; then
+  echo "Timed out waiting for Copilot review (10min). Proceeding without it."
+fi
+```
+
+> Copilot은 GitHub App 봇(`copilot-pull-request-reviewer[bot]`)이라 `requested_reviewers`에 나타나지 않습니다. reviews API로 확인해야 합니다.
+
 ---
 
 ## Phase 2: 코드리뷰 & CI 대응 (반복)
@@ -91,8 +120,8 @@ PR 생성 후 아래 루프를 코드리뷰와 CI가 모두 완료될 때까지 
 ### 2-1. CI & 리뷰 상태 확인
 
 ```bash
-gh pr checks <pr-number>
-gh api repos/chibimoons/flowdux/pulls/<pr-number>/comments | jq '.[] | {id, path, body, line}'
+gh pr checks <pr-number> --repo chibimoons/flowdux
+gh api repos/chibimoons/flowdux/pulls/<pr-number>/comments --jq '.[] | {id, path, body, line}'
 ```
 
 ### 2-2. 코드리뷰 대응
@@ -104,14 +133,14 @@ gh api repos/chibimoons/flowdux/pulls/<pr-number>/comments | jq '.[] | {id, path
    - 코드 수정
    - 테스트 실행하여 통과 확인
    - 커밋 & 푸시
-   - 해당 코멘트에 답글: 어떻게 수정했는지 명시 (커밋 해시 포함)
+   - 해당 코멘트에 답글: 어떻게 수정했는지 명시
 3. **수정이 불필요한 경우:**
    - 해당 코멘트에 답글: 수정하지 않는 이유 설명
 
 ```bash
 # 리뷰 코멘트에 답글
 gh api repos/chibimoons/flowdux/pulls/<pr-number>/comments/<comment-id>/replies \
-  -f body="Fixed in <commit-hash>. <설명>"
+  -X POST -f body="Fixed. <설명>"
 ```
 
 **중요: 모든 리뷰 코멘트에 반드시 답글을 남기세요. 수정 여부와 관계없이.**
@@ -121,27 +150,55 @@ gh api repos/chibimoons/flowdux/pulls/<pr-number>/comments/<comment-id>/replies 
 CI가 실패했으면:
 
 ```bash
-gh run view <run-id> --log-failed
+# PR의 CI 상태 요약 확인
+gh pr checks <pr-number> --repo chibimoons/flowdux
+
+# 관련 GitHub Actions run 목록 확인 (run-id 확인용)
+gh run list --repo chibimoons/flowdux --limit 10
+
+# 실패한 run의 로그 터미널에서 바로 확인
+gh run view <run-id> --repo chibimoons/flowdux --log-failed
 ```
 
 실패 원인 분석 → 수정 → 커밋 & 푸시
 
-### 2-4. Copilot 코드리뷰 재요청
+### 2-4. Copilot 코드리뷰 재요청 & 대기
 
-푸시 후 Copilot에게 코드리뷰를 재요청합니다:
+2-2~2-3에서 코드를 푸시했으면 Copilot에게 코드리뷰를 재요청하고 **리뷰가 도착할 때까지 대기**합니다.
+코드 수정/푸시가 없었으면 이 단계를 건너뜁니다.
 
 ```bash
-gh api repos/chibimoons/flowdux/pulls/<pr-number>/requested_reviewers \
-  --method POST -f 'reviewers[]=Copilot'
+gh pr edit <pr-number> --repo chibimoons/flowdux --add-reviewer copilot
+```
+
+최신 커밋에 대한 Copilot 리뷰가 도착할 때까지 10초 간격으로 폴링합니다 (최대 10분):
+
+```bash
+LATEST_COMMIT=$(gh pr view <pr-number> --repo chibimoons/flowdux --json headRefOid --jq '.headRefOid')
+count=0
+for i in $(seq 1 60); do
+  count=$(gh api repos/chibimoons/flowdux/pulls/<pr-number>/reviews \
+    --jq "[.[] | select(.user.login == \"copilot-pull-request-reviewer[bot]\" and .commit_id == \"$LATEST_COMMIT\")] | length")
+  count=${count:-0}
+  if [ "$count" -gt 0 ]; then
+    echo "Copilot review received"
+    break
+  fi
+  echo "Waiting for Copilot review... (${i}0s)"
+  sleep 10
+done
+if [ "$count" -eq 0 ]; then
+  echo "Timed out waiting for Copilot review (10min). Proceeding without it."
+fi
 ```
 
 ### 2-5. 상태 재확인
 
 ```bash
-gh pr checks <pr-number>
-gh api repos/chibimoons/flowdux/pulls/<pr-number>/comments | jq '
+gh pr checks <pr-number> --repo chibimoons/flowdux
+gh api repos/chibimoons/flowdux/pulls/<pr-number>/comments --jq '
   ( [.[].in_reply_to_id] | unique ) as $replied_ids
-  | [ .[] | select(.in_reply_to_id == null and (.id | IN($replied_ids[]) | not)) ]
+  | [ .[] | select(.in_reply_to_id == null and (.id as $id | $replied_ids | index($id) | not)) ]
   | length
 '
 ```

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -167,8 +167,11 @@ gh run view <run-id> --repo chibimoons/flowdux --log-failed
 2-2~2-3에서 코드를 푸시했으면 Copilot에게 코드리뷰를 재요청하고 **리뷰가 도착할 때까지 대기**합니다.
 코드 수정/푸시가 없었으면 이 단계를 건너뜁니다.
 
+> **주의**: 재요청 시 `gh pr edit --add-reviewer copilot`은 이미 등록된 리뷰어에게 재트리거되지 않습니다. Copilot 재리뷰를 트리거할 때에는 `requested_reviewers` API를 사용하세요. Copilot은 GitHub App 봇이라 응답이나 `requested_reviewers` 목록에 나타나지 않으므로, 리뷰 도착 확인은 아래 **reviews API 폴링**으로 해야 합니다.
+
 ```bash
-gh pr edit <pr-number> --repo chibimoons/flowdux --add-reviewer copilot
+gh api repos/chibimoons/flowdux/pulls/<pr-number>/requested_reviewers \
+  -X POST -f 'reviewers[]=copilot-pull-request-reviewer[bot]'
 ```
 
 최신 커밋에 대한 Copilot 리뷰가 도착할 때까지 10초 간격으로 폴링합니다 (최대 10분):

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -84,8 +84,11 @@ EOF
 
 ### 1-7. Copilot 리뷰 요청 & 대기
 
+> **주의**: `gh pr edit --add-reviewer copilot`은 재요청 시 트리거되지 않습니다. 초기/재요청 모두 `requested_reviewers` API를 사용하세요. Copilot은 GitHub App 봇이라 `requested_reviewers` 목록에 나타나지 않으므로, 리뷰 도착 확인은 **reviews API 폴링**으로 해야 합니다.
+
 ```bash
-gh pr edit <pr-number> --repo chibimoons/flowdux --add-reviewer copilot
+gh api repos/chibimoons/flowdux/pulls/<pr-number>/requested_reviewers \
+  -X POST -f 'reviewers[]=copilot-pull-request-reviewer[bot]'
 ```
 
 최신 커밋에 대한 Copilot 리뷰가 도착할 때까지 10초 간격으로 폴링합니다 (최대 10분):
@@ -108,8 +111,6 @@ if [ "$count" -eq 0 ]; then
   echo "Timed out waiting for Copilot review (10min). Proceeding without it."
 fi
 ```
-
-> Copilot은 GitHub App 봇(`copilot-pull-request-reviewer[bot]`)이라 `requested_reviewers`에 나타나지 않습니다. reviews API로 확인해야 합니다.
 
 ---
 

--- a/.claude/rules/api-compatibility.md
+++ b/.claude/rules/api-compatibility.md
@@ -1,0 +1,10 @@
+---
+paths:
+  - "kotlin/**/src/*Main/**/*.kt"
+---
+
+# API Compatibility Rules
+
+- public/protected 메서드 제거 시 `@Deprecated(message = "Use the replacement API instead", level = DeprecationLevel.WARNING)` 래퍼를 먼저 추가 — 즉시 삭제 금지
+- interface에 새 메서드 추가 시 반드시 default 구현 제공 (외부 구현체 Breaking Change 방지)
+- commonMain 라이브러리 코드에서 `println` 금지 — injectable callback (`onEvent`, `onError`) 또는 sealed event class로 대체

--- a/.claude/rules/docs-consistency.md
+++ b/.claude/rules/docs-consistency.md
@@ -1,0 +1,12 @@
+---
+paths:
+  - "**/*.md"
+  - "kotlin/**/*.kt"
+---
+
+# Documentation Consistency Rules
+
+- PR 생성 후 구현이 변경되면 PR description도 최종 구현에 맞게 갱신
+- KDoc 코드 예시는 실제 컴파일 가능한 시그니처와 파라미터 사용 (특히 파라미터 추가/삭제 후 예시 점검)
+- 버전 변경(gradle.properties) 시 docs/ 하위 문서의 버전 참조도 함께 갱신
+- 동일 문서 내에서 용어, API 플래그 스타일(예: `-X POST` vs `--method POST`) 통일

--- a/.claude/rules/kotlin-concurrency.md
+++ b/.claude/rules/kotlin-concurrency.md
@@ -1,0 +1,15 @@
+---
+paths:
+  - "kotlin/**/*.kt"
+---
+
+# Kotlin Concurrency Rules
+
+- `catch (e: Exception)` 사용 시 반드시 `CancellationException`을 먼저 rethrow할 것
+  ```kotlin
+  try { ... } catch (e: CancellationException) { throw e } catch (e: Exception) { ... }
+  ```
+- 여러 스레드/디스패처에서 동시에 접근하는 mutable 프로퍼티에는 `@Volatile` 또는 `Atomic*` 사용
+- 공유 `Channel`은 close하면 재사용 불가 — 재연결이 필요한 경우 Job 취소 또는 per-connect Channel 생성
+- `trySend()` 결과를 무시하지 말 것 — 실패 시 로깅 또는 이벤트 콜백으로 처리
+- `Channel.UNLIMITED` 지양 — `Channel.BUFFERED` 사용하고 backpressure 동작을 KDoc에 문서화

--- a/.claude/rules/kotlin-test.md
+++ b/.claude/rules/kotlin-test.md
@@ -1,0 +1,17 @@
+---
+paths:
+  - "kotlin/**/src/*Test/**/*.kt"
+  - "kotlin/**/*Test.kt"
+  - "kotlin/**/*Tests.kt"
+---
+
+# Kotlin Test Rules
+
+- Connection, HttpClient 등 리소스 생성 시 반드시 `try/finally { resource.disconnect() }` 패턴 사용
+- 동시성/Race condition 테스트는 기본적으로 `runBlocking` + `Dispatchers.Default` 사용 권장 (`runTest`는 기본 단일 스레드 테스트 스케줄러를 사용하므로 실제 멀티스레드 race-condition 재현에는 적합하지 않음; 필요 시 실제 디스패처를 조합한 고급 사용은 신중히 적용)
+- 고정 `delay()`로 타이밍 대기 금지 — 다음 패턴 사용:
+  ```kotlin
+  withTimeout(5_000) { while (!condition) { delay(10) } }
+  ```
+- 테스트 이름은 실제 검증 내용을 정확히 기술 (이름과 assert가 불일치하면 안 됨)
+- 코드 변경에는 반드시 대응하는 테스트가 포함되어야 함 — 특히 race condition 수정, 새 파라미터 추가, 에러 핸들링 변경

--- a/.claude/rules/library-quality.md
+++ b/.claude/rules/library-quality.md
@@ -1,0 +1,10 @@
+---
+paths:
+  - "kotlin/**/src/commonMain/**/*.kt"
+---
+
+# Library Code Quality Rules
+
+- `println` / `System.out` 금지 — injectable `onEvent: ((Event) -> Unit)?` 콜백 또는 sealed event class 사용
+- behavioral change(예: unbounded → bounded channel) 시 KDoc에 동작 변경 사항 문서화
+- `Channel.send()` 또는 `Flow.emit()`이 suspend할 수 있는 경우 KDoc에 명시

--- a/.claude/rules/scripts.md
+++ b/.claude/rules/scripts.md
@@ -1,0 +1,14 @@
+---
+paths:
+  - "**/*.sh"
+  - ".github/**/*.yml"
+  - "**/*.yml"
+  - "**/*.yaml"
+  - ".claude/**/*.sh"
+---
+
+# Script & CI Rules
+
+- 셸 스크립트에서 API 호출(gh api 등) 결과에 반드시 fallback 제공: `count=${count:-0}`
+- CI 워크플로에서 JDK distribution(temurin, zulu 등)은 프로젝트 전체에서 통일
+- 셸 스크립트에서 외부 도구(jq, gh 등) 사용 전 `command -v` 로 존재 확인

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,31 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{kt,kts}]
+indent_size = 4
+max_line_length = 120
+
+[*.{yaml,yml}]
+indent_size = 2
+
+[*.{json,toml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{xml,html}]
+indent_size = 2
+
+[*.dart]
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+COMMIT_MSG_FILE="$1"
+COMMIT_MSG=$(head -1 "$COMMIT_MSG_FILE")
+
+# Allow merge and revert commits
+if echo "$COMMIT_MSG" | grep -qE '^(Merge|Revert) '; then
+    exit 0
+fi
+
+# Conventional commit pattern
+PATTERN='^(feat|fix|docs|chore|refactor|test|style|perf|build|ci)(\([a-zA-Z0-9_-]+\))?!?: .+'
+
+if ! echo "$COMMIT_MSG" | grep -qE "$PATTERN"; then
+    echo ""
+    echo "❌ Commit message does not follow Conventional Commits format."
+    echo ""
+    echo "   Expected: <type>(<scope>): <description>"
+    echo "   Examples:"
+    echo "     feat(store): add middleware chaining"
+    echo "     fix(remote): handle reconnection timeout"
+    echo "     docs: update README"
+    echo "     chore(build): bump Kotlin version"
+    echo ""
+    exit 1
+fi

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Check if any staged files are Kotlin sources
+STAGED_KT=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(kt|kts)$' || true)
+
+if [ -z "$STAGED_KT" ]; then
+    exit 0
+fi
+
+echo "🔍 Running spotlessCheck for Kotlin formatting..."
+if ! ./gradlew spotlessCheck --quiet; then
+    echo ""
+    echo "❌ Formatting check failed."
+    echo "   Run: ./gradlew spotlessApply"
+    echo "   Then re-stage and commit."
+    exit 1
+fi
+
+echo "✅ Formatting check passed."

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "🔍 Running pre-push checks..."
+
+echo "  → detekt (static analysis)..."
+if ! ./gradlew detekt --quiet ; then
+    echo "❌ detekt failed. Fix issues before pushing."
+    exit 1
+fi
+
+echo "  → compileKotlinJvm (build check)..."
+if ! ./gradlew compileKotlinJvm --quiet ; then
+    echo "❌ Compilation failed. Fix errors before pushing."
+    exit 1
+fi
+
+echo "✅ Pre-push checks passed."

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -249,6 +249,17 @@ class FetchDataAction with FlowHolderAction {
 4. **`trySend()` result ignored**: When `trySend()` fails (buffer full), the message is silently dropped. Check the result and report via logging or event callback.
 5. **TOCTOU race with `isClosed` / boolean flags**: `if (!closed) { doSomething() }` has a race window. Use `AtomicBoolean.compareAndSet()` for check-and-act patterns.
 6. **`Channel.UNLIMITED` memory risk**: Unbounded channels can cause OOM under load. Prefer `Channel.BUFFERED` and document backpressure behavior in KDoc.
+7. **Callback/lambda invocation safety**: External callbacks invoked inline inside coroutines can throw and disrupt protocol flow. Wrap in try-catch and rethrow `CancellationException` to preserve structured concurrency.
+   ```kotlin
+   // Bad: callback exception aborts auth handshake
+   onAuthError?.invoke(detail)
+
+   // Good: safe invocation
+   try {
+       onAuthError?.invoke(detail)
+   } catch (e: CancellationException) { throw e }
+   catch (e: Exception) { /* log and continue */ }
+   ```
 
 ### Performance Issues
 
@@ -262,6 +273,19 @@ class FetchDataAction with FlowHolderAction {
 1. **Removing public/protected methods without `@Deprecated`**: Always add `@Deprecated(message = "Scheduled for removal in a future release", level = DeprecationLevel.WARNING)` wrapper before removing. Direct deletion is a breaking change for external consumers.
 2. **Adding methods to interface without default implementation**: External implementors will fail to compile. Always provide a default.
 3. **`println` in commonMain library code**: Library code must not use `println`. Use injectable `onEvent` callback or sealed event class.
+4. **Constructor parameter ABI changes**: Adding parameters to a public class constructor (even with defaults) is binary-incompatible on JVM/Kotlin. Provide a secondary constructor or overload to preserve the old signature.
+   ```kotlin
+   // Bad: adding onError to primary constructor breaks existing binaries
+   class MyConnection(val delegate: Connection, val onError: ((String) -> Unit)? = null)
+
+   // Good: keep old primary, add secondary
+   class MyConnection(val delegate: Connection) {
+       private var onError: ((String) -> Unit)? = null
+       constructor(delegate: Connection, onError: ((String) -> Unit)?) : this(delegate) {
+           this.onError = onError
+       }
+   }
+   ```
 
 ### Code Quality Issues
 
@@ -269,6 +293,7 @@ class FetchDataAction with FlowHolderAction {
 2. **Magic strings/numbers**: Use constants or enums
 3. **Overly complex FlowHolderAction**: Consider splitting into multiple actions
 4. **Missing error handling**: Unhandled exceptions in middleware
+5. **Inconsistent callback invocation across paths**: If a callback is documented to fire on a condition (e.g., `onAuthError` on auth failure), ensure **all** code paths that satisfy that condition invoke it — not just exception paths but also logical rejection paths
 
 ---
 
@@ -335,6 +360,15 @@ class FetchDataAction with FlowHolderAction {
 4. **Test name does not match assertion**: If a test is named `factoryCreateBuildsCorrectWsUrl` but only asserts `connectionState == DISCONNECTED`, the name is misleading. Test names must accurately describe what is verified.
 
 5. **Missing test coverage for code changes**: Every behavioral change (race condition fix, new parameter, error handling path) should have a corresponding test that exercises the specific path.
+6. **Missing negative assertions for security/sanitization**: When testing that error messages are sanitized or sensitive data is masked, assert that the sensitive detail is **absent**, not just that a generic message is **present**.
+   ```kotlin
+   // Bad: only checks generic message exists
+   assertTrue(response.contains("auth_error"))
+
+   // Good: also checks sensitive detail is absent
+   assertTrue(response.contains("auth_error"))
+   assertFalse(response.contains("Access denied"))
+   ```
 
 ### Test Patterns
 
@@ -379,7 +413,8 @@ fun `middleware emits correct actions`() = runTest {
 6. **Cross-Platform Consistency**: Do Kotlin and Dart implementations match in behavior?
 7. **Concurrency Safety**: Are shared mutable fields protected with `@Volatile`/`Atomic*`? Is `CancellationException` handled correctly?
 8. **Test Reliability**: Are tests using `runBlocking`+`Dispatchers.Default` for concurrency? No fixed `delay()` for timing?
-9. **API Compatibility**: Are public method removals preceded by `@Deprecated`? Do new interface methods have defaults?
+9. **API Compatibility**: Are public method removals preceded by `@Deprecated`? Do new interface methods have defaults? Do constructor changes preserve binary compatibility?
+10. **Callback Safety & Consistency**: Are external callbacks wrapped in try-catch? Are they invoked on all documented failure paths?
 
 ---
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -235,12 +235,33 @@ class FetchDataAction with FlowHolderAction {
 3. **Race conditions**: Multiple concurrent operations modifying shared state
 4. **Wrong strategy**: FlowHolderAction using wrong execution strategy for its use case
 
+### Concurrency & Thread Safety (Frequently Caught in Past PRs)
+
+1. **CancellationException swallowed in `catch (e: Exception)`**: Must rethrow `CancellationException` before handling other exceptions. This breaks structured concurrency.
+   ```kotlin
+   // Bad
+   try { ... } catch (e: Exception) { handleError(e) }
+   // Good
+   try { ... } catch (e: CancellationException) { throw e } catch (e: Exception) { handleError(e) }
+   ```
+2. **Missing thread-safety for mutable properties accessed from multiple threads**: Any `var` that may be read/written from different threads (for example via `Dispatchers.Default`, `Dispatchers.IO`, or custom threads) requires proper synchronization. Use `@Volatile` only for simple visibility of independent reads/writes; for read-modify-write operations (like increment, check-and-act, etc.) use `Atomic*` or other synchronization primitives instead.
+3. **Closing shared `Channel` breaks reconnect**: A `val channel = Channel<T>()` created once cannot be reused after `close()`. For reconnectable components, use per-connect channel creation or cancel the consumer Job instead.
+4. **`trySend()` result ignored**: When `trySend()` fails (buffer full), the message is silently dropped. Check the result and report via logging or event callback.
+5. **TOCTOU race with `isClosed` / boolean flags**: `if (!closed) { doSomething() }` has a race window. Use `AtomicBoolean.compareAndSet()` for check-and-act patterns.
+6. **`Channel.UNLIMITED` memory risk**: Unbounded channels can cause OOM under load. Prefer `Channel.BUFFERED` and document backpressure behavior in KDoc.
+
 ### Performance Issues
 
 1. **Unnecessary state updates**: Emitting same state repeatedly
 2. **Missing execution strategy**: Search/autocomplete without `takeLatest()`
 3. **Blocking operations**: Synchronous I/O in stream handlers
 4. **Excessive middleware chain**: Too many middlewares processing every action
+
+### API Compatibility (Frequently Caught in Past PRs)
+
+1. **Removing public/protected methods without `@Deprecated`**: Always add `@Deprecated(message = "Scheduled for removal in a future release", level = DeprecationLevel.WARNING)` wrapper before removing. Direct deletion is a breaking change for external consumers.
+2. **Adding methods to interface without default implementation**: External implementors will fail to compile. Always provide a default.
+3. **`println` in commonMain library code**: Library code must not use `println`. Use injectable `onEvent` callback or sealed event class.
 
 ### Code Quality Issues
 
@@ -264,6 +285,56 @@ class FetchDataAction with FlowHolderAction {
 - [ ] Store tests: Full flow from dispatch to state update
 - [ ] FlowHolderAction tests: Stream completion and cancellation
 - [ ] Error handling tests: Error processor behavior
+
+### Test Quality (Frequently Caught in Past PRs)
+
+1. **Resource leak in tests**: Connection, HttpClient, and other resources must be cleaned up in `finally` blocks — even if the test fails or the connection attempt itself fails.
+   ```kotlin
+   // Bad
+   @Test fun `test something`() = runTest {
+       val connection = KtorWebSocketClientConnection(...)
+       connection.connect()
+       // ... assertions — if test fails, connection leaks
+   }
+
+   // Good
+   @Test fun `test something`() = runTest {
+       val connection = KtorWebSocketClientConnection(...)
+       try {
+           connection.connect()
+           // ... assertions
+       } finally {
+           connection.disconnect()
+       }
+   }
+   ```
+
+2. **`runTest` used for race-condition tests**: `runTest` uses a test scheduler that does not provide real multi-threaded parallelism by default, making it unsuitable for reproducing race conditions. For tests that require actual concurrent thread execution, use `runBlocking` + `Dispatchers.Default` instead.
+   ```kotlin
+   // Bad: Single-threaded, no real concurrency
+   @Test fun `concurrent close is safe`() = runTest {
+       repeat(100) { launch { store.close() } }
+   }
+
+   // Good: Real multi-threaded execution
+   @Test fun `concurrent close is safe`() = runBlocking {
+       repeat(100) { launch(Dispatchers.Default) { store.close() } }
+   }
+   ```
+
+3. **Fixed `delay()` for timing**: Tests using `delay(500)` to wait for async results are flaky on slow CI. Use condition-based polling with timeout.
+   ```kotlin
+   // Bad
+   delay(500)
+   assertTrue(serverClosed.get())
+
+   // Good
+   withTimeout(5_000) { while (!serverClosed.get()) { delay(10) } }
+   ```
+
+4. **Test name does not match assertion**: If a test is named `factoryCreateBuildsCorrectWsUrl` but only asserts `connectionState == DISCONNECTED`, the name is misleading. Test names must accurately describe what is verified.
+
+5. **Missing test coverage for code changes**: Every behavioral change (race condition fix, new parameter, error handling path) should have a corresponding test that exercises the specific path.
 
 ### Test Patterns
 
@@ -290,6 +361,14 @@ fun `middleware emits correct actions`() = runTest {
 
 ---
 
+## Documentation Consistency (Frequently Caught in Past PRs)
+
+1. **KDoc code examples must compile**: After adding/removing parameters, verify that all KDoc `@sample` and inline code examples use the correct signatures.
+2. **Version references in docs/**: When bumping version in `gradle.properties`, also update version strings in `docs/` guides, `README.md`, and sample `build.gradle.kts` files.
+3. **Consistent terminology within a document**: Do not mix `-X POST` and `--method POST`, or "may not appear" and "does not appear" in the same document.
+
+---
+
 ## PR Review Focus Areas
 
 1. **Architecture Compliance**: Does the code follow unidirectional data flow?
@@ -298,6 +377,9 @@ fun `middleware emits correct actions`() = runTest {
 4. **Resource Management**: Are streams/subscriptions properly cleaned up?
 5. **Test Coverage**: Are new features adequately tested?
 6. **Cross-Platform Consistency**: Do Kotlin and Dart implementations match in behavior?
+7. **Concurrency Safety**: Are shared mutable fields protected with `@Volatile`/`Atomic*`? Is `CancellationException` handled correctly?
+8. **Test Reliability**: Are tests using `runBlocking`+`Dispatchers.Default` for concurrency? No fixed `delay()` for timing?
+9. **API Compatibility**: Are public method removals preceded by `@Deprecated`? Do new interface methods have defaults?
 
 ---
 

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -5,12 +5,15 @@ on:
     branches: [main]
     paths:
       - 'dart/**'
+      - '.github/workflows/dart.yml'
   pull_request:
     paths:
       - 'dart/**'
+      - '.github/workflows/dart.yml'
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   test-flowdux:
@@ -28,13 +31,42 @@ jobs:
         working-directory: dart/flowdux
         run: dart pub get
 
+      - name: Check formatting
+        working-directory: dart/flowdux
+        run: dart format --set-exit-if-changed .
+
       - name: Analyze
         working-directory: dart/flowdux
         run: dart analyze
 
-      - name: Run tests
+      - name: Run tests with coverage
         working-directory: dart/flowdux
-        run: dart test
+        run: dart test --coverage=coverage
+
+      - name: Convert coverage to LCOV
+        working-directory: dart/flowdux
+        run: |
+          dart pub global activate coverage 1.7.2
+          dart pub global run coverage:format_coverage \
+            --lcov \
+            --in=coverage \
+            --out=coverage/lcov.info \
+            --report-on=lib
+
+      - name: Add coverage report to PR
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        uses: romeovs/lcov-reporter-action@v0.4.0
+        with:
+          lcov-file: dart/flowdux/coverage/lcov.info
+          title: Dart Coverage
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dart-coverage
+          path: dart/flowdux/coverage/
 
   test-flowdux-flutter:
     runs-on: ubuntu-latest
@@ -52,10 +84,29 @@ jobs:
         working-directory: dart/flowdux_flutter
         run: flutter pub get
 
+      - name: Check formatting
+        working-directory: dart/flowdux_flutter
+        run: dart format --set-exit-if-changed .
+
       - name: Analyze
         working-directory: dart/flowdux_flutter
         run: flutter analyze --no-fatal-warnings
 
-      - name: Run tests
+      - name: Run tests with coverage
         working-directory: dart/flowdux_flutter
-        run: flutter test
+        run: flutter test --coverage
+
+      - name: Add coverage report to PR
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        uses: romeovs/lcov-reporter-action@v0.4.0
+        with:
+          lcov-file: dart/flowdux_flutter/coverage/lcov.info
+          title: Flutter Coverage
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: flutter-coverage
+          path: dart/flowdux_flutter/coverage/

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -9,6 +9,9 @@ on:
       - 'build.gradle.kts'
       - 'settings.gradle.kts'
       - 'gradle.properties'
+      - 'detekt.yml'
+      - 'detekt-baseline.xml'
+      - '.editorconfig'
   pull_request:
     paths:
       - 'kotlin/**'
@@ -16,13 +19,41 @@ on:
       - 'build.gradle.kts'
       - 'settings.gradle.kts'
       - 'gradle.properties'
+      - 'detekt.yml'
+      - 'detekt-baseline.xml'
+      - '.editorconfig'
 
 permissions:
   contents: read
   pull-requests: write
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Run spotlessCheck
+        run: ./gradlew spotlessCheck
+
+      - name: Run detekt
+        run: ./gradlew detekt
+
   test:
+    needs: lint
     runs-on: ubuntu-latest
 
     steps:
@@ -93,6 +124,7 @@ jobs:
   # iOS/Native compilation check — catches issues like missing imports
   # that only surface on non-JVM targets (e.g. kotlin.concurrent.Volatile)
   compile-native:
+    needs: lint
     runs-on: macos-latest
 
     steps:

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -69,6 +69,16 @@ jobs:
       - name: Run flowdux-remote-node-mediator tests
         run: ./gradlew :kotlin:flowdux-remote-node-mediator:jvmTest
 
+      - name: Generate coverage report
+        run: ./gradlew koverXmlReport koverHtmlReport
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: build/reports/kover/
+
   # iOS/Native compilation check — catches issues like missing imports
   # that only surface on non-JVM targets (e.g. kotlin.concurrent.Volatile)
   compile-native:

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -19,6 +19,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   test:
@@ -71,6 +72,16 @@ jobs:
 
       - name: Generate coverage report
         run: ./gradlew koverXmlReport koverHtmlReport
+
+      - name: Add coverage report to PR
+        if: github.event_name == 'pull_request'
+        uses: mi-kas/kover-report@v1
+        with:
+          path: build/reports/kover/report.xml
+          title: Code Coverage
+          update-comment: true
+          min-coverage-overall: 0
+          min-coverage-changed-files: 0
 
       - name: Upload coverage report
         if: always()

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -53,3 +53,52 @@ jobs:
 
       - name: Run flowdux-remote-server tests
         run: ./gradlew :kotlin:flowdux-remote-server:jvmTest
+
+      - name: Run flowdux-remote-serialization tests
+        run: ./gradlew :kotlin:flowdux-remote-serialization:jvmTest
+
+      - name: Run flowdux-remote-ktor tests
+        run: ./gradlew :kotlin:flowdux-remote-ktor:jvmTest
+
+      - name: Run flowdux-remote-multiplexer tests
+        run: ./gradlew :kotlin:flowdux-remote-multiplexer:jvmTest
+
+      - name: Run flowdux-remote-auth tests
+        run: ./gradlew :kotlin:flowdux-remote-auth:jvmTest
+
+      - name: Run flowdux-remote-node-mediator tests
+        run: ./gradlew :kotlin:flowdux-remote-node-mediator:jvmTest
+
+  # iOS/Native compilation check — catches issues like missing imports
+  # that only surface on non-JVM targets (e.g. kotlin.concurrent.Volatile)
+  compile-native:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Compile iOS targets
+        run: |
+          ./gradlew \
+            :kotlin:flowdux:compileKotlinIosSimulatorArm64 \
+            :kotlin:flowdux-timetravel:compileKotlinIosSimulatorArm64 \
+            :kotlin:flowdux-remote-core:compileKotlinIosSimulatorArm64 \
+            :kotlin:flowdux-remote-client:compileKotlinIosSimulatorArm64 \
+            :kotlin:flowdux-remote-server:compileKotlinIosSimulatorArm64 \
+            :kotlin:flowdux-remote-serialization:compileKotlinIosSimulatorArm64 \
+            :kotlin:flowdux-remote-ktor:compileKotlinIosSimulatorArm64 \
+            :kotlin:flowdux-remote-multiplexer:compileKotlinIosSimulatorArm64 \
+            :kotlin:flowdux-remote-auth:compileKotlinIosSimulatorArm64 \
+            :kotlin:flowdux-remote-node-mediator:compileKotlinIosSimulatorArm64

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,48 +13,14 @@
    - 리뷰 코멘트 수정 완료 시 해당 코멘트에 답글 작성
    - 어떤 코멘트를 어떻게 대응했는지 명시
 
-2. **브랜치 네이밍**
-   - 기능: `feature/{issue-number}-{short-description}`
-   - 버그 수정: `fix/{issue-number}-{short-description}`
-   - 문서: `docs/{short-description}`
-   - 릴리즈: `release/{version}`
-   - 핫픽스: `hotfix/{short-description}`
-
-3. **커밋 메시지 포맷**
-   - HEREDOC 사용, Co-Authored-By 포함
-   ```bash
-   git commit -m "$(cat <<'EOF'
-   feat(module): description
-
-   Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
-   EOF
-   )"
-   ```
-
-4. **테스트 우선 (Red-Green-Refactor)**
+2. **테스트 우선 (Red-Green-Refactor)**
    - 가능하면 실패하는 테스트 먼저 작성
    - 수정 후 테스트 통과 확인
    - 전체 모듈 테스트 실행
 
-5. **GitHub 계정 확인**
-   - push 전 항상 `gh auth status` 확인
-   - `chibimoons` 계정 사용
-
-## Git/GitHub Multi-Account Setup
-
-This environment uses multiple GitHub accounts. **Before any git push operation**, always verify the active account:
-
-```bash
-gh auth status
-```
-
-If the wrong account is active, switch to the repository owner's account:
-
-```bash
-gh auth switch -u <owner-account>
-```
-
-Check `gh auth status` output to identify available accounts and ensure the correct one is active before pushing.
+3. **Git 작업 규칙**: `docs/dev/git-workflow.md` 참조
+   - 브랜치 네이밍, 커밋 메시지, GitHub 계정 확인, PR 타겟 브랜치, 릴리즈/핫픽스 프로세스 등 모든 Git 규칙이 정의되어 있음
+   - PR 생성, 릴리즈, push 전 반드시 Read할 것
 
 ## Project Structure
 
@@ -72,54 +38,11 @@ Check `gh auth status` output to identify available accounts and ensure the corr
 - `dart/` - Dart/Flutter implementation
   - `flowdux/` - Core library (published to pub.dev)
 
-## Branch Strategy
+## Release Publishing
 
-- **기본 타겟 브랜치**: `develop`
-- release, hotfix 브랜치 외 모든 작업(feature, fix, docs 등)은 `develop`으로 PR 생성
-- release, hotfix, docs 브랜치만 `main`으로 머지
-
-```
-feature/xxx  ─┐
-fix/xxx      ─┼─► develop ─► release/x.x.x ─► main ─► tag
-docs/xxx     ─┼─► develop (일반) / main (직접 반영 필요 시)
-              ┘
-hotfix/xxx   ─────────────────────────────► main ─► tag
-```
-
-### Main 브랜치 머지 규칙 (CI 강제)
-
-`.github/workflows/protect-main.yml`이 소스 브랜치명을 검증한다.
-**아래 패턴만 main에 머지 가능:**
-
-| 브랜치 패턴 | 용도 |
-|-------------|------|
-| `release/*` | 릴리즈 배포 |
-| `hotfix/*` | 긴급 수정 |
-| `docs/*` | 문서 업데이트 |
-
-- `sync/*`, `feature/*`, `fix/*` 등은 **CI에서 reject됨**
-- develop 내용을 main에 반영해야 할 때: `hotfix/*` 또는 `docs/*` 브랜치를 `origin/main`에서 생성 후 cherry-pick
-
-## Release Process
-
-### Kotlin (Maven Central — primary)
-- Git Flow: develop → release/x.x.x → main → tag
-- Tag format: `1.x.x` (no prefix)
-- groupId: `io.github.chibimoons`
-- Automated via GitHub Actions (`publish-maven-central.yml`): tag push triggers publish
-- Manual dry-run: workflow_dispatch with `dry_run: true`
-- Plugin: vanniktech/gradle-maven-publish-plugin 0.36.0
-- Version: managed in `gradle.properties` (`flowdux.version`)
-- See `docs/design/MAVEN_CENTRAL_PUBLISH.md` for full guide
-
-### Kotlin (JitPack — legacy)
-- Still supported for existing consumers
-- groupId: `com.github.chibimoons`
-- `jitpack.yml` builds with `JITPACK=true` (JVM-only artifacts)
-
-### Dart (pub.dev)
-- Tag format: `dart/x.x.x`
-- Publish: `dart pub publish` from `dart/flowdux/`
+- **Kotlin (Maven Central)**: `io.github.chibimoons`, tag push → GitHub Actions 자동 배포 (~25분). 상세: `docs/design/MAVEN_CENTRAL_PUBLISH.md`
+- **Kotlin (JitPack — legacy)**: `com.github.chibimoons`, `jitpack.yml`로 JVM-only 빌드
+- **Dart (pub.dev)**: tag `dart/x.x.x`, `dart pub publish` from `dart/flowdux/`
 
 ## Key Concepts
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: setup lint format
+
+setup:
+	git config core.hooksPath .githooks
+
+lint:
+	./gradlew spotlessCheck detekt
+
+format:
+	./gradlew spotlessApply

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Add the dependency to your KMP project's `build.gradle.kts`:
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            implementation("io.github.chibimoons:flowdux:1.13.0")
+            implementation("io.github.chibimoons:flowdux:1.17.0")
         }
     }
 }
@@ -45,7 +45,7 @@ If your project is not KMP, add the dependency directly:
 
 ```kotlin
 dependencies {
-    implementation("io.github.chibimoons:flowdux:1.13.0")
+    implementation("io.github.chibimoons:flowdux:1.17.0")
 }
 ```
 
@@ -58,15 +58,15 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             // Shared action markers (ServerSharedAction, ClientSharedAction)
-            implementation("io.github.chibimoons:flowdux-remote-core:1.13.0")
+            implementation("io.github.chibimoons:flowdux-remote-core:1.17.0")
             // Client middleware (SyncMiddleware)
-            implementation("io.github.chibimoons:flowdux-remote-client:1.13.0")
+            implementation("io.github.chibimoons:flowdux-remote-client:1.17.0")
             // Server middleware (SingleClientSyncMiddleware, MultiClientSyncMiddleware)
-            implementation("io.github.chibimoons:flowdux-remote-server:1.13.0")
+            implementation("io.github.chibimoons:flowdux-remote-server:1.17.0")
             // kotlinx.serialization codecs (ActionCodec, MessageCodec)
-            implementation("io.github.chibimoons:flowdux-remote-serialization:1.13.0")
+            implementation("io.github.chibimoons:flowdux-remote-serialization:1.17.0")
             // Ktor WebSocket transport (JVM, iOS, JS — WASM not supported)
-            implementation("io.github.chibimoons:flowdux-remote-ktor:1.13.0")
+            implementation("io.github.chibimoons:flowdux-remote-ktor:1.17.0")
         }
     }
 }
@@ -101,7 +101,7 @@ Add to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  flowdux: ^0.2.3
+  flowdux: ^0.3.2
 ```
 
 ### Flutter
@@ -110,8 +110,8 @@ Add to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  flowdux: ^0.2.3
-  flowdux_flutter: ^0.2.3
+  flowdux: ^0.3.2
+  flowdux_flutter: ^0.3.2
 ```
 
 ## Quick Start (Kotlin)
@@ -227,7 +227,7 @@ if (!store.isClosed) {
 
 ### Kotlin Version
 
-FlowDux 1.13.0 is built with **Kotlin 2.2.10**. For best compatibility, use the same Kotlin version in your project:
+FlowDux 1.17.0 is built with **Kotlin 2.2.10**. For best compatibility, use the same Kotlin version in your project:
 
 ```kotlin
 plugins {

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -3,4 +3,5 @@ plugins {
 }
 dependencies {
     implementation("com.vanniktech:gradle-maven-publish-plugin:0.36.0")
+    implementation("org.jetbrains.kotlinx:kover-gradle-plugin:0.9.1")
 }

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -2,6 +2,6 @@ plugins {
     `kotlin-dsl`
 }
 dependencies {
-    implementation("com.vanniktech:gradle-maven-publish-plugin:0.36.0")
-    implementation("org.jetbrains.kotlinx:kover-gradle-plugin:0.9.1")
+    implementation(libs.maven.publish.gradle.plugin)
+    implementation(libs.kover.gradle.plugin)
 }

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -3,5 +3,10 @@ dependencyResolutionManagement {
         mavenCentral()
         gradlePluginPortal()
     }
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
 }
 rootProject.name = "build-logic"

--- a/build-logic/src/main/kotlin/flowdux.publish-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/flowdux.publish-conventions.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("com.vanniktech.maven.publish")
+    id("org.jetbrains.kotlinx.kover")
 }
 
 mavenPublishing {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,8 @@ plugins {
     alias(libs.plugins.kotlinCompose) apply false
     alias(libs.plugins.mavenPublish) apply false
     alias(libs.plugins.kover)
+    alias(libs.plugins.spotless)
+    alias(libs.plugins.detekt)
 }
 
 dependencies {
@@ -20,4 +22,32 @@ dependencies {
     kover(project(":kotlin:flowdux-remote-multiplexer"))
     kover(project(":kotlin:flowdux-remote-auth"))
     kover(project(":kotlin:flowdux-remote-node-mediator"))
+}
+
+spotless {
+    kotlin {
+        target("kotlin/**/*.kt")
+        targetExclude("**/build/**")
+        ktlint().editorConfigOverride(
+            mapOf(
+                "ktlint_standard_no-wildcard-imports" to "disabled",
+                "ktlint_standard_filename" to "disabled",
+                "ktlint_standard_backing-property-naming" to "disabled",
+                "ktlint_standard_function-naming" to "disabled",
+            ),
+        )
+    }
+    kotlinGradle {
+        target("*.gradle.kts", "build-logic/**/*.gradle.kts", "kotlin/**/*.gradle.kts")
+        targetExclude("**/build/**")
+        ktlint()
+    }
+}
+
+detekt {
+    buildUponDefaultConfig = true
+    config.setFrom(files("detekt.yml"))
+    baseline = file("detekt-baseline.xml")
+    parallel = true
+    source.setFrom(files("kotlin/"))
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,4 +6,18 @@ plugins {
     alias(libs.plugins.androidLibrary) apply false
     alias(libs.plugins.kotlinCompose) apply false
     alias(libs.plugins.mavenPublish) apply false
+    alias(libs.plugins.kover)
+}
+
+dependencies {
+    kover(project(":kotlin:flowdux"))
+    kover(project(":kotlin:flowdux-timetravel"))
+    kover(project(":kotlin:flowdux-remote-core"))
+    kover(project(":kotlin:flowdux-remote-client"))
+    kover(project(":kotlin:flowdux-remote-server"))
+    kover(project(":kotlin:flowdux-remote-serialization"))
+    kover(project(":kotlin:flowdux-remote-ktor"))
+    kover(project(":kotlin:flowdux-remote-multiplexer"))
+    kover(project(":kotlin:flowdux-remote-auth"))
+    kover(project(":kotlin:flowdux-remote-node-mediator"))
 }

--- a/dart/flowdux/example/example.dart
+++ b/dart/flowdux/example/example.dart
@@ -146,14 +146,18 @@ CounterState counterReducer(CounterState state, CounterAction action) {
     DecrementAction() => state.copyWith(count: state.count - 1),
     AddAction(:final value) => state.copyWith(count: state.count + value),
     ResetAction() => CounterState(),
-    SetCountAction(:final value, :final source) =>
-      state.copyWith(count: value, source: source),
-    SetLoadingAction(:final isLoading) =>
-      state.copyWith(isLoading: isLoading),
-    SearchResultAction(:final results) =>
-      state.copyWith(searchResults: results),
-    FetchSuccessAction(:final id, :final value) =>
-      state.copyWith(count: value, source: 'fetch-$id'),
+    SetCountAction(:final value, :final source) => state.copyWith(
+        count: value,
+        source: source,
+      ),
+    SetLoadingAction(:final isLoading) => state.copyWith(isLoading: isLoading),
+    SearchResultAction(:final results) => state.copyWith(
+        searchResults: results,
+      ),
+    FetchSuccessAction(:final id, :final value) => state.copyWith(
+        count: value,
+        source: 'fetch-$id',
+      ),
     SubmitSuccessAction() => state.copyWith(source: 'submitted'),
     // Actions handled by middleware or FlowHolderMiddleware, not reducer
     ObserveCountAction() => state,
@@ -179,8 +183,10 @@ class ExecutionStrategyMiddleware
     });
 
     // debounce: Wait 200ms of no input before executing
-    apply(debounce(const Duration(milliseconds: 200)))
-        .on<FetchDataAction>((state, action) async* {
+    apply(debounce(const Duration(milliseconds: 200))).on<FetchDataAction>((
+      state,
+      action,
+    ) async* {
       print('    [debounce] Fetching data: ${action.id}');
       await Future<void>.delayed(const Duration(milliseconds: 100));
       yield FetchSuccessAction(action.id, 42);

--- a/dart/flowdux/lib/src/error_processor.dart
+++ b/dart/flowdux/lib/src/error_processor.dart
@@ -18,5 +18,6 @@ class DefaultErrorProcessor<A extends Action> implements ErrorProcessor<A> {
   DefaultErrorProcessor();
 
   @override
-  Stream<A> process(Object error, StackTrace stackTrace) => const Stream.empty();
+  Stream<A> process(Object error, StackTrace stackTrace) =>
+      const Stream.empty();
 }

--- a/dart/flowdux/lib/src/flow_holder_middleware.dart
+++ b/dart/flowdux/lib/src/flow_holder_middleware.dart
@@ -63,11 +63,14 @@ class FlowHolderMiddleware<S, A extends Action> extends Middleware<S, A> {
   }
 
   /// Gets or creates a wrapped processor for the given FlowHolderAction type.
-  Stream<A> Function(S, A) _getOrCreateWrappedProcessor(FlowHolderAction action) {
+  Stream<A> Function(S, A) _getOrCreateWrappedProcessor(
+    FlowHolderAction action,
+  ) {
     return _wrappedProcessors.putIfAbsent(action.runtimeType, () {
       Stream<A> baseProcessor(S state, A a) {
         return (a as FlowHolderAction).toStreamAction().cast<A>();
       }
+
       return action.strategy.wrap<S, A, A>(baseProcessor);
     });
   }

--- a/dart/flowdux/lib/src/store.dart
+++ b/dart/flowdux/lib/src/store.dart
@@ -130,7 +130,8 @@ class Store<S, A extends Action> {
     final previousState = _currentState;
     final newState = _reducer(previousState, action);
     _currentState = newState;
-    if (_isLoggingEnabled) _logger.onStateReduced(action, previousState, newState);
+    if (_isLoggingEnabled)
+      _logger.onStateReduced(action, previousState, newState);
     return newState;
   }
 

--- a/dart/flowdux/lib/src/strategy/chained_strategy.dart
+++ b/dart/flowdux/lib/src/strategy/chained_strategy.dart
@@ -22,8 +22,7 @@ class DuplicateCategoryException implements Exception {
   });
 
   @override
-  String toString() =>
-      'Cannot chain strategies of the same category. '
+  String toString() => 'Cannot chain strategies of the same category. '
       'Conflicting category: $category. '
       'First: $firstName, Second: $secondName';
 }
@@ -84,7 +83,8 @@ class ChainedStrategy implements ExecutionStrategy {
     final secondCategories = _collectCategories(second);
 
     for (final category in firstCategories) {
-      if (category != StrategyCategory.chained && secondCategories.contains(category)) {
+      if (category != StrategyCategory.chained &&
+          secondCategories.contains(category)) {
         throw DuplicateCategoryException(
           category: category,
           firstName: _getStrategyName(first, category),
@@ -109,7 +109,10 @@ class ChainedStrategy implements ExecutionStrategy {
   }
 
   /// Gets the name of the strategy with the given category.
-  static String _getStrategyName(ExecutionStrategy strategy, StrategyCategory category) {
+  static String _getStrategyName(
+    ExecutionStrategy strategy,
+    StrategyCategory category,
+  ) {
     if (strategy is ChainedStrategy) {
       // Search in nested strategies
       final firstName = _tryGetStrategyName(strategy.first, category);
@@ -125,7 +128,10 @@ class ChainedStrategy implements ExecutionStrategy {
     return strategy.runtimeType.toString();
   }
 
-  static String? _tryGetStrategyName(ExecutionStrategy strategy, StrategyCategory category) {
+  static String? _tryGetStrategyName(
+    ExecutionStrategy strategy,
+    StrategyCategory category,
+  ) {
     if (strategy is ChainedStrategy) {
       final firstName = _tryGetStrategyName(strategy.first, category);
       if (firstName != null) return firstName;

--- a/dart/flowdux/lib/src/strategy/retry.dart
+++ b/dart/flowdux/lib/src/strategy/retry.dart
@@ -147,7 +147,4 @@ ExecutionStrategy retry(
   int maxAttempts, {
   bool Function(Object error)? retryIf,
 }) =>
-    RetryStrategy(
-      maxAttempts: maxAttempts,
-      retryIf: retryIf,
-    );
+    RetryStrategy(maxAttempts: maxAttempts, retryIf: retryIf);

--- a/dart/flowdux/lib/src/strategy/retry_with_backoff.dart
+++ b/dart/flowdux/lib/src/strategy/retry_with_backoff.dart
@@ -83,7 +83,10 @@ class RetryWithBackoffStrategy implements ExecutionStrategy {
     Random? random,
   })  : assert(maxAttempts >= 1, 'maxAttempts must be >= 1'),
         assert(factor >= 1.0, 'factor must be >= 1.0'),
-        assert(jitter >= 0.0 && jitter <= 1.0, 'jitter must be between 0.0 and 1.0'),
+        assert(
+          jitter >= 0.0 && jitter <= 1.0,
+          'jitter must be between 0.0 and 1.0',
+        ),
         maxDelay = maxDelay ?? const Duration(days: 365 * 100),
         retryIf = retryIf ?? ((_) => true),
         _random = random ?? Random();
@@ -112,13 +115,15 @@ class RetryWithBackoffStrategy implements ExecutionStrategy {
 
   Duration _calculateDelay(int attemptNumber) {
     // baseDelay = initialDelay * (factor ^ attempt)
-    final baseDelayMs = initialDelay.inMicroseconds * pow(factor, attemptNumber);
+    final baseDelayMs =
+        initialDelay.inMicroseconds * pow(factor, attemptNumber);
 
     // cappedDelay = min(baseDelay, maxDelay)
     final cappedDelayMs = min(baseDelayMs, maxDelay.inMicroseconds.toDouble());
 
     // jitterAmount = cappedDelay * jitter * random(-1, 1)
-    final jitterAmount = cappedDelayMs * jitter * (_random.nextDouble() * 2 - 1);
+    final jitterAmount =
+        cappedDelayMs * jitter * (_random.nextDouble() * 2 - 1);
 
     // finalDelay = max(cappedDelay + jitterAmount, 0)
     final finalDelayMs = max(cappedDelayMs + jitterAmount, 0);

--- a/dart/flowdux/test/delivery_mode_test.dart
+++ b/dart/flowdux/test/delivery_mode_test.dart
@@ -63,7 +63,9 @@ class CounterState {
 class CounterReducer extends ReducerBase<CounterState, Action> {
   CounterReducer() {
     on<IncrementAction>((state, _) => state.copyWith(count: state.count + 1));
-    on<AddAction>((state, action) => state.copyWith(count: state.count + action.value));
+    on<AddAction>(
+      (state, action) => state.copyWith(count: state.count + action.value),
+    );
   }
 }
 
@@ -121,43 +123,46 @@ void main() {
       await store.close();
     });
 
-    test('explicit Dispatch delivery sends inner actions through full middleware pipeline',
-        () async {
-      final trackingMiddleware = TrackingMiddleware();
-      final store = createStore<CounterState, Action>(
-        initialState: CounterState(0),
-        reducer: reducer,
-        middlewares: [trackingMiddleware],
-      );
+    test(
+      'explicit Dispatch delivery sends inner actions through full middleware pipeline',
+      () async {
+        final trackingMiddleware = TrackingMiddleware();
+        final store = createStore<CounterState, Action>(
+          initialState: CounterState(0),
+          reducer: reducer,
+          middlewares: [trackingMiddleware],
+        );
 
-      final controller = StreamController<int>();
+        final controller = StreamController<int>();
 
-      store.dispatch(DispatchDeliveryStreamAction(controller.stream));
+        store.dispatch(DispatchDeliveryStreamAction(controller.stream));
 
-      controller.add(5);
-      await Future.delayed(const Duration(milliseconds: 50));
-      expect(store.currentState, CounterState(5));
+        controller.add(5);
+        await Future.delayed(const Duration(milliseconds: 50));
+        expect(store.currentState, CounterState(5));
 
-      controller.add(3);
-      await Future.delayed(const Duration(milliseconds: 50));
-      expect(store.currentState, CounterState(8));
+        controller.add(3);
+        await Future.delayed(const Duration(milliseconds: 50));
+        expect(store.currentState, CounterState(8));
 
-      await controller.close();
+        await controller.close();
 
-      // Inner AddAction should pass through the tracking middleware
-      final innerActions =
-          trackingMiddleware.processedActions.whereType<AddAction>().toList();
-      expect(
-        innerActions,
-        isNotEmpty,
-        reason: 'Dispatch delivery should send inner actions through middlewares',
-      );
-      expect(innerActions.length, 2);
-      expect(innerActions[0].value, 5);
-      expect(innerActions[1].value, 3);
+        // Inner AddAction should pass through the tracking middleware
+        final innerActions =
+            trackingMiddleware.processedActions.whereType<AddAction>().toList();
+        expect(
+          innerActions,
+          isNotEmpty,
+          reason:
+              'Dispatch delivery should send inner actions through middlewares',
+        );
+        expect(innerActions.length, 2);
+        expect(innerActions[0].value, 5);
+        expect(innerActions[1].value, 3);
 
-      await store.close();
-    });
+        await store.close();
+      },
+    );
 
     test('FlowHolderAction has default delivery of Emit', () {
       final action = StreamConnectedAction(const Stream.empty());

--- a/dart/flowdux/test/duplicate_state_emission_test.dart
+++ b/dart/flowdux/test/duplicate_state_emission_test.dart
@@ -103,41 +103,43 @@ void main() {
       await store.close();
     });
 
-    test('store does not emit when reducer returns same state reference',
-        () async {
-      final emissions = <int>[];
+    test(
+      'store does not emit when reducer returns same state reference',
+      () async {
+        final emissions = <int>[];
 
-      final store = createStore<CounterState, CounterAction>(
-        initialState: const CounterState(count: 0),
-        reducer: CounterReducer().reducer,
-      );
+        final store = createStore<CounterState, CounterAction>(
+          initialState: const CounterState(count: 0),
+          reducer: CounterReducer().reducer,
+        );
 
-      final subscription = store.state.listen((state) {
-        emissions.add(state.count);
-      });
+        final subscription = store.state.listen((state) {
+          emissions.add(state.count);
+        });
 
-      // Wait for initial state emission
-      await Future.delayed(const Duration(milliseconds: 50));
-      expect(emissions, [0]);
+        // Wait for initial state emission
+        await Future.delayed(const Duration(milliseconds: 50));
+        expect(emissions, [0]);
 
-      // FetchData returns state unchanged
-      store.dispatch(FetchDataAction('test'));
-      await Future.delayed(const Duration(milliseconds: 50));
-      expect(emissions, [0], reason: 'Should not emit when state unchanged');
+        // FetchData returns state unchanged
+        store.dispatch(FetchDataAction('test'));
+        await Future.delayed(const Duration(milliseconds: 50));
+        expect(emissions, [0], reason: 'Should not emit when state unchanged');
 
-      // NoOpAction also returns state unchanged
-      store.dispatch(NoOpAction());
-      await Future.delayed(const Duration(milliseconds: 50));
-      expect(emissions, [0], reason: 'Should not emit when state unchanged');
+        // NoOpAction also returns state unchanged
+        store.dispatch(NoOpAction());
+        await Future.delayed(const Duration(milliseconds: 50));
+        expect(emissions, [0], reason: 'Should not emit when state unchanged');
 
-      // Actual state change should emit
-      store.dispatch(IncrementAction());
-      await Future.delayed(const Duration(milliseconds: 50));
-      expect(emissions, [0, 1]);
+        // Actual state change should emit
+        store.dispatch(IncrementAction());
+        await Future.delayed(const Duration(milliseconds: 50));
+        expect(emissions, [0, 1]);
 
-      await subscription.cancel();
-      await store.close();
-    });
+        await subscription.cancel();
+        await store.close();
+      },
+    );
 
     test('consecutive identical state updates are deduplicated', () async {
       final emissions = <int>[];
@@ -169,7 +171,13 @@ void main() {
       await Future.delayed(const Duration(milliseconds: 50));
 
       // Only initial, first change, and final change should be recorded
-      expect(emissions, [0, 10, 20],
+      expect(
+          emissions,
+          [
+            0,
+            10,
+            20,
+          ],
           reason: 'Consecutive identical states should be deduplicated');
 
       await subscription.cancel();

--- a/dart/flowdux/test/infinite_stream_test.dart
+++ b/dart/flowdux/test/infinite_stream_test.dart
@@ -56,129 +56,146 @@ class AppReducer extends ReducerBase<AppState, Action> {
 
 void main() {
   group('Infinite Stream Tests', () {
-    test('other actions are processed while infinite stream is running', () async {
-      // Simulates WebSocket-like infinite stream
-      final streamController = StreamController<int>.broadcast();
+    test(
+      'other actions are processed while infinite stream is running',
+      () async {
+        // Simulates WebSocket-like infinite stream
+        final streamController = StreamController<int>.broadcast();
 
-      final middleware = _InfiniteStreamMiddleware(streamController.stream);
-      final store = createStore<AppState, Action>(
-        initialState: AppState(),
-        reducer: AppReducer().reducer,
-        middlewares: [middleware],
-      );
+        final middleware = _InfiniteStreamMiddleware(streamController.stream);
+        final store = createStore<AppState, Action>(
+          initialState: AppState(),
+          reducer: AppReducer().reducer,
+          middlewares: [middleware],
+        );
 
-      // Start infinite stream subscription
-      store.dispatch(SubscribeAction('price'));
-      await Future.delayed(Duration(milliseconds: 10));
+        // Start infinite stream subscription
+        store.dispatch(SubscribeAction('price'));
+        await Future.delayed(Duration(milliseconds: 10));
 
-      // Send data through stream
-      streamController.add(100);
-      await Future.delayed(Duration(milliseconds: 10));
+        // Send data through stream
+        streamController.add(100);
+        await Future.delayed(Duration(milliseconds: 10));
 
-      // While stream is running, dispatch other actions
-      // These should NOT be blocked by the infinite stream
-      store.dispatch(IncrementAction());
-      store.dispatch(IncrementAction());
-      store.dispatch(IncrementAction());
-      await Future.delayed(Duration(milliseconds: 10));
+        // While stream is running, dispatch other actions
+        // These should NOT be blocked by the infinite stream
+        store.dispatch(IncrementAction());
+        store.dispatch(IncrementAction());
+        store.dispatch(IncrementAction());
+        await Future.delayed(Duration(milliseconds: 10));
 
-      // Verify both stream data and increment actions were processed
-      expect(store.currentState.count, 3);
-      expect(store.currentState.channelData['price'], contains(100));
+        // Verify both stream data and increment actions were processed
+        expect(store.currentState.count, 3);
+        expect(store.currentState.channelData['price'], contains(100));
 
-      // Send more data through stream
-      streamController.add(200);
-      await Future.delayed(Duration(milliseconds: 10));
-      expect(store.currentState.channelData['price'], contains(200));
+        // Send more data through stream
+        streamController.add(200);
+        await Future.delayed(Duration(milliseconds: 10));
+        expect(store.currentState.channelData['price'], contains(200));
 
-      // Dispatch more actions while stream continues
-      store.dispatch(SetValueAction(42));
-      await Future.delayed(Duration(milliseconds: 10));
-      expect(store.currentState.count, 42);
+        // Dispatch more actions while stream continues
+        store.dispatch(SetValueAction(42));
+        await Future.delayed(Duration(milliseconds: 10));
+        expect(store.currentState.count, 42);
 
-      await streamController.close();
-      await store.close();
-    });
+        await streamController.close();
+        await store.close();
+      },
+    );
 
-    test('takeLatest cancels previous stream - only latest result reaches reducer', () async {
-      // In Dart, async generators continue running after subscription cancellation,
-      // but their yielded values are discarded. The key behavior is that only
-      // the latest action's result reaches the reducer.
+    test(
+      'takeLatest cancels previous stream - only latest result reaches reducer',
+      () async {
+        // In Dart, async generators continue running after subscription cancellation,
+        // but their yielded values are discarded. The key behavior is that only
+        // the latest action's result reaches the reducer.
 
-      final middleware = _TakeLatestDelayedMiddleware();
+        final middleware = _TakeLatestDelayedMiddleware();
 
-      final store = createStore<AppState, Action>(
-        initialState: AppState(),
-        reducer: AppReducer().reducer,
-        middlewares: [middleware],
-      );
+        final store = createStore<AppState, Action>(
+          initialState: AppState(),
+          reducer: AppReducer().reducer,
+          middlewares: [middleware],
+        );
 
-      // Subscribe to first channel - starts processing
-      store.dispatch(SubscribeAction('btc'));
-      await Future.delayed(Duration(milliseconds: 10)); // Short wait, btc still processing
+        // Subscribe to first channel - starts processing
+        store.dispatch(SubscribeAction('btc'));
+        await Future.delayed(
+          Duration(milliseconds: 10),
+        ); // Short wait, btc still processing
 
-      // Subscribe to second channel while first is still processing
-      // takeLatest should cancel first's output
-      store.dispatch(SubscribeAction('eth'));
-      await Future.delayed(Duration(milliseconds: 10));
+        // Subscribe to second channel while first is still processing
+        // takeLatest should cancel first's output
+        store.dispatch(SubscribeAction('eth'));
+        await Future.delayed(Duration(milliseconds: 10));
 
-      // Subscribe to third channel
-      store.dispatch(SubscribeAction('sol'));
+        // Subscribe to third channel
+        store.dispatch(SubscribeAction('sol'));
 
-      // Wait for all processing to complete
-      await Future.delayed(Duration(milliseconds: 150));
+        // Wait for all processing to complete
+        await Future.delayed(Duration(milliseconds: 150));
 
-      // Only the LAST subscription's result should be in state
-      // btc and eth's yields were discarded due to takeLatest
-      expect(store.currentState.channelData.keys, contains('sol'));
-      expect(store.currentState.channelData.keys, isNot(contains('btc')));
-      expect(store.currentState.channelData.keys, isNot(contains('eth')));
+        // Only the LAST subscription's result should be in state
+        // btc and eth's yields were discarded due to takeLatest
+        expect(store.currentState.channelData.keys, contains('sol'));
+        expect(store.currentState.channelData.keys, isNot(contains('btc')));
+        expect(store.currentState.channelData.keys, isNot(contains('eth')));
 
-      await store.close();
-    });
+        await store.close();
+      },
+    );
 
-    test('multiple infinite streams can run concurrently without blocking', () async {
-      final stream1Controller = StreamController<int>.broadcast();
-      final stream2Controller = StreamController<int>.broadcast();
+    test(
+      'multiple infinite streams can run concurrently without blocking',
+      () async {
+        final stream1Controller = StreamController<int>.broadcast();
+        final stream2Controller = StreamController<int>.broadcast();
 
-      final middleware = _MultiStreamMiddleware({
-        'price': stream1Controller.stream,
-        'orderbook': stream2Controller.stream,
-      });
+        final middleware = _MultiStreamMiddleware({
+          'price': stream1Controller.stream,
+          'orderbook': stream2Controller.stream,
+        });
 
-      final store = createStore<AppState, Action>(
-        initialState: AppState(),
-        reducer: AppReducer().reducer,
-        middlewares: [middleware],
-      );
+        final store = createStore<AppState, Action>(
+          initialState: AppState(),
+          reducer: AppReducer().reducer,
+          middlewares: [middleware],
+        );
 
-      // Subscribe to both streams concurrently
-      store.dispatch(SubscribeAction('price'));
-      store.dispatch(SubscribeAction('orderbook'));
-      await Future.delayed(Duration(milliseconds: 20));
+        // Subscribe to both streams concurrently
+        store.dispatch(SubscribeAction('price'));
+        store.dispatch(SubscribeAction('orderbook'));
+        await Future.delayed(Duration(milliseconds: 20));
 
-      // Send data to both streams
-      stream1Controller.add(100);
-      stream2Controller.add(1);
-      await Future.delayed(Duration(milliseconds: 20));
+        // Send data to both streams
+        stream1Controller.add(100);
+        stream2Controller.add(1);
+        await Future.delayed(Duration(milliseconds: 20));
 
-      stream1Controller.add(101);
-      stream2Controller.add(2);
-      await Future.delayed(Duration(milliseconds: 20));
+        stream1Controller.add(101);
+        stream2Controller.add(2);
+        await Future.delayed(Duration(milliseconds: 20));
 
-      // Verify both streams are being processed
-      expect(store.currentState.channelData['price'], containsAll([100, 101]));
-      expect(store.currentState.channelData['orderbook'], containsAll([1, 2]));
+        // Verify both streams are being processed
+        expect(
+          store.currentState.channelData['price'],
+          containsAll([100, 101]),
+        );
+        expect(
+          store.currentState.channelData['orderbook'],
+          containsAll([1, 2]),
+        );
 
-      // Other actions should still work (not blocked)
-      store.dispatch(IncrementAction());
-      await Future.delayed(Duration(milliseconds: 10));
-      expect(store.currentState.count, 1);
+        // Other actions should still work (not blocked)
+        store.dispatch(IncrementAction());
+        await Future.delayed(Duration(milliseconds: 10));
+        expect(store.currentState.count, 1);
 
-      await stream1Controller.close();
-      await stream2Controller.close();
-      await store.close();
-    });
+        await stream1Controller.close();
+        await stream2Controller.close();
+        await store.close();
+      },
+    );
 
     test('concurrent default: actions do not block each other', () async {
       // This test verifies FlowDux's default concurrent behavior
@@ -204,7 +221,10 @@ void main() {
       await Future.delayed(Duration(milliseconds: 50));
 
       // Fast actions should complete before slow action
-      expect(results.where((r) => r.contains('Increment')).length, 4); // 2 start + 2 end
+      expect(
+        results.where((r) => r.contains('Increment')).length,
+        4,
+      ); // 2 start + 2 end
 
       await Future.delayed(Duration(milliseconds: 100));
       expect(results.last, 'slow-end');
@@ -255,125 +275,174 @@ void main() {
   });
 
   group('FlowHolderAction Strategy Tests', () {
-    test('TakeLatest FlowHolderAction cancels previous stream when new one is dispatched', () async {
-      final store = createStore<AppState, Action>(
-        initialState: AppState(),
-        reducer: ExtendedAppReducer().reducer,
-      );
+    test(
+      'TakeLatest FlowHolderAction cancels previous stream when new one is dispatched',
+      () async {
+        final store = createStore<AppState, Action>(
+          initialState: AppState(),
+          reducer: ExtendedAppReducer().reducer,
+        );
 
-      // Start first infinite stream
-      store.dispatch(InfiniteStreamFlowAction('stream1', emitInterval: Duration(milliseconds: 50)));
+        // Start first infinite stream
+        store.dispatch(
+          InfiniteStreamFlowAction(
+            'stream1',
+            emitInterval: Duration(milliseconds: 50),
+          ),
+        );
 
-      // Wait for a few emissions
-      await Future.delayed(Duration(milliseconds: 120));
-      final countAfterFirstStream = store.currentState.count;
-      expect(countAfterFirstStream, greaterThanOrEqualTo(2));
+        // Wait for a few emissions
+        await Future.delayed(Duration(milliseconds: 120));
+        final countAfterFirstStream = store.currentState.count;
+        expect(countAfterFirstStream, greaterThanOrEqualTo(2));
 
-      final countBeforeNewStream = store.currentState.count;
+        final countBeforeNewStream = store.currentState.count;
 
-      // Start second stream - should cancel the first
-      store.dispatch(InfiniteStreamFlowAction('stream2', emitInterval: Duration(milliseconds: 50)));
+        // Start second stream - should cancel the first
+        store.dispatch(
+          InfiniteStreamFlowAction(
+            'stream2',
+            emitInterval: Duration(milliseconds: 50),
+          ),
+        );
 
-      // Wait for emissions from the new stream
-      await Future.delayed(Duration(milliseconds: 180));
+        // Wait for emissions from the new stream
+        await Future.delayed(Duration(milliseconds: 180));
 
-      final countAfter = store.currentState.count;
+        final countAfter = store.currentState.count;
 
-      // If both streams were running, count would increase much faster
-      // Should have roughly countBeforeNewStream + 3 emissions (not double)
-      expect(
-        countAfter,
-        lessThanOrEqualTo(countBeforeNewStream + 5),
-        reason: 'Expected count to be around ${countBeforeNewStream + 3}, but was $countAfter. '
-            'Both streams might be running concurrently.',
-      );
+        // If both streams were running, count would increase much faster
+        // Should have roughly countBeforeNewStream + 3 emissions (not double)
+        expect(
+          countAfter,
+          lessThanOrEqualTo(countBeforeNewStream + 5),
+          reason:
+              'Expected count to be around ${countBeforeNewStream + 3}, but was $countAfter. '
+              'Both streams might be running concurrently.',
+        );
 
-      await store.close();
-    });
+        await store.close();
+      },
+    );
 
-    test('Concurrent FlowHolderAction allows multiple streams to run concurrently', () async {
-      final store = createStore<AppState, Action>(
-        initialState: AppState(),
-        reducer: ExtendedAppReducer().reducer,
-      );
+    test(
+      'Concurrent FlowHolderAction allows multiple streams to run concurrently',
+      () async {
+        final store = createStore<AppState, Action>(
+          initialState: AppState(),
+          reducer: ExtendedAppReducer().reducer,
+        );
 
-      // Start two concurrent streams
-      // stream1: adds 1 three times = 3
-      // stream2: adds 10 three times = 30
-      // Total: 33
-      store.dispatch(ConcurrentAdditiveFlowAction('stream1', addValue: 1, count: 3, delayBetween: Duration(milliseconds: 30)));
-      store.dispatch(ConcurrentAdditiveFlowAction('stream2', addValue: 10, count: 3, delayBetween: Duration(milliseconds: 30)));
+        // Start two concurrent streams
+        // stream1: adds 1 three times = 3
+        // stream2: adds 10 three times = 30
+        // Total: 33
+        store.dispatch(
+          ConcurrentAdditiveFlowAction(
+            'stream1',
+            addValue: 1,
+            count: 3,
+            delayBetween: Duration(milliseconds: 30),
+          ),
+        );
+        store.dispatch(
+          ConcurrentAdditiveFlowAction(
+            'stream2',
+            addValue: 10,
+            count: 3,
+            delayBetween: Duration(milliseconds: 30),
+          ),
+        );
 
-      // Wait for both streams to complete
-      await Future.delayed(Duration(milliseconds: 200));
+        // Wait for both streams to complete
+        await Future.delayed(Duration(milliseconds: 200));
 
-      expect(
-        store.currentState.count,
-        equals(33),
-        reason: 'Expected both streams to contribute (33), but got ${store.currentState.count}',
-      );
+        expect(
+          store.currentState.count,
+          equals(33),
+          reason:
+              'Expected both streams to contribute (33), but got ${store.currentState.count}',
+        );
 
-      await store.close();
-    });
+        await store.close();
+      },
+    );
 
-    test('TakeLatest FlowHolderAction is cancelled when store is closed', () async {
-      final store = createStore<AppState, Action>(
-        initialState: AppState(),
-        reducer: ExtendedAppReducer().reducer,
-      );
+    test(
+      'TakeLatest FlowHolderAction is cancelled when store is closed',
+      () async {
+        final store = createStore<AppState, Action>(
+          initialState: AppState(),
+          reducer: ExtendedAppReducer().reducer,
+        );
 
-      // Start infinite stream
-      store.dispatch(InfiniteStreamFlowAction('stream1', emitInterval: Duration(milliseconds: 50)));
+        // Start infinite stream
+        store.dispatch(
+          InfiniteStreamFlowAction(
+            'stream1',
+            emitInterval: Duration(milliseconds: 50),
+          ),
+        );
 
-      // Wait for a few emissions
-      await Future.delayed(Duration(milliseconds: 120));
-      expect(store.currentState.count, greaterThanOrEqualTo(2));
+        // Wait for a few emissions
+        await Future.delayed(Duration(milliseconds: 120));
+        expect(store.currentState.count, greaterThanOrEqualTo(2));
 
-      final countBeforeClose = store.currentState.count;
+        final countBeforeClose = store.currentState.count;
 
-      // Close the store
-      await store.close();
+        // Close the store
+        await store.close();
 
-      // Give some time for any pending emissions
-      await Future.delayed(Duration(milliseconds: 200));
+        // Give some time for any pending emissions
+        await Future.delayed(Duration(milliseconds: 200));
 
-      // Count should not have increased significantly after close
-      expect(
-        store.currentState.count,
-        lessThanOrEqualTo(countBeforeClose + 1),
-        reason: 'Stream should have been cancelled on store close',
-      );
-    });
+        // Count should not have increased significantly after close
+        expect(
+          store.currentState.count,
+          lessThanOrEqualTo(countBeforeClose + 1),
+          reason: 'Stream should have been cancelled on store close',
+        );
+      },
+    );
 
-    test('other actions are processed while TakeLatest infinite stream is running', () async {
-      final store = createStore<AppState, Action>(
-        initialState: AppState(),
-        reducer: ExtendedAppReducer().reducer,
-      );
+    test(
+      'other actions are processed while TakeLatest infinite stream is running',
+      () async {
+        final store = createStore<AppState, Action>(
+          initialState: AppState(),
+          reducer: ExtendedAppReducer().reducer,
+        );
 
-      // Start infinite stream
-      store.dispatch(InfiniteStreamFlowAction('stream1', emitInterval: Duration(milliseconds: 100)));
+        // Start infinite stream
+        store.dispatch(
+          InfiniteStreamFlowAction(
+            'stream1',
+            emitInterval: Duration(milliseconds: 100),
+          ),
+        );
 
-      // Wait for first emission
-      await Future.delayed(Duration(milliseconds: 120));
-      expect(store.currentState.count, greaterThanOrEqualTo(1));
+        // Wait for first emission
+        await Future.delayed(Duration(milliseconds: 120));
+        expect(store.currentState.count, greaterThanOrEqualTo(1));
 
-      // Dispatch a regular action while stream is running
-      store.dispatch(SetValueAction(100));
+        // Dispatch a regular action while stream is running
+        store.dispatch(SetValueAction(100));
 
-      // Wait a bit
-      await Future.delayed(Duration(milliseconds: 50));
+        // Wait a bit
+        await Future.delayed(Duration(milliseconds: 50));
 
-      // The SetValueAction should have been processed
-      // Stream emissions will continue adding, so count should be >= 100
-      expect(
-        store.currentState.count,
-        greaterThanOrEqualTo(100),
-        reason: 'Regular action should be processed while infinite stream is running',
-      );
+        // The SetValueAction should have been processed
+        // Stream emissions will continue adding, so count should be >= 100
+        expect(
+          store.currentState.count,
+          greaterThanOrEqualTo(100),
+          reason:
+              'Regular action should be processed while infinite stream is running',
+        );
 
-      await store.close();
-    });
+        await store.close();
+      },
+    );
   });
 }
 
@@ -439,7 +508,10 @@ class _ConcurrentTestMiddleware extends Middleware<AppState, Action> {
 
 /// Middleware that counts stream data
 class _CountingStreamMiddleware extends Middleware<AppState, Action> {
-  _CountingStreamMiddleware(Stream<int> dataStream, {required void Function() onData}) {
+  _CountingStreamMiddleware(
+    Stream<int> dataStream, {
+    required void Function() onData,
+  }) {
     on<SubscribeAction>((state, action) async* {
       await for (final value in dataStream) {
         onData();
@@ -457,7 +529,10 @@ class InfiniteStreamFlowAction with FlowHolderAction {
   final String id;
   final Duration emitInterval;
 
-  InfiniteStreamFlowAction(this.id, {this.emitInterval = const Duration(milliseconds: 50)});
+  InfiniteStreamFlowAction(
+    this.id, {
+    this.emitInterval = const Duration(milliseconds: 50),
+  });
 
   @override
   Stream<Action> toStreamAction() async* {
@@ -466,6 +541,7 @@ class InfiniteStreamFlowAction with FlowHolderAction {
       yield IncrementAction();
     }
   }
+
   // Uses default TakeLatestStrategy
 }
 
@@ -530,7 +606,9 @@ class ExtendedAppReducer extends ReducerBase<AppState, Action> {
   ExtendedAppReducer() {
     on<IncrementAction>((state, _) => state.copyWith(count: state.count + 1));
     on<SetValueAction>((state, action) => state.copyWith(count: action.value));
-    on<_AddAction>((state, action) => state.copyWith(count: state.count + action.value));
+    on<_AddAction>(
+      (state, action) => state.copyWith(count: state.count + action.value),
+    );
     on<DataReceivedAction>((state, action) {
       final newData = Map<String, List<int>>.from(state.channelData);
       final channelList = List<int>.from(newData[action.channel] ?? []);

--- a/dart/flowdux/test/middleware_emit_flow_holder_action_test.dart
+++ b/dart/flowdux/test/middleware_emit_flow_holder_action_test.dart
@@ -29,7 +29,10 @@ class InfiniteObserverFlowAction with FlowHolderAction {
   final String id;
   final Duration emitInterval;
 
-  InfiniteObserverFlowAction(this.id, {this.emitInterval = const Duration(milliseconds: 50)});
+  InfiniteObserverFlowAction(
+    this.id, {
+    this.emitInterval = const Duration(milliseconds: 50),
+  });
 
   @override
   Stream<Action> toStreamAction() async* {
@@ -45,7 +48,10 @@ class SecondaryObserverFlowAction with FlowHolderAction {
   final String id;
   final Duration emitInterval;
 
-  SecondaryObserverFlowAction(this.id, {this.emitInterval = const Duration(milliseconds: 50)});
+  SecondaryObserverFlowAction(
+    this.id, {
+    this.emitInterval = const Duration(milliseconds: 50),
+  });
 
   @override
   Stream<Action> toStreamAction() async* {
@@ -74,7 +80,9 @@ class AppReducer extends ReducerBase<AppState, Action> {
 
   AppReducer() {
     on<IncrementAction>((state, _) => state.copyWith(count: state.count + 1));
-    on<AddAction>((state, action) => state.copyWith(count: state.count + action.value));
+    on<AddAction>(
+      (state, action) => state.copyWith(count: state.count + action.value),
+    );
     on<SetupCompleteAction>((state, action) {
       setupCompleteReceived = true;
       return state;
@@ -88,11 +96,17 @@ class MultiObserverMiddleware extends Middleware<AppState, Action> {
   MultiObserverMiddleware() {
     on<StartMultipleObserversAction>((state, action) async* {
       // Emit first infinite FlowHolderAction
-      yield InfiniteObserverFlowAction('observer1', emitInterval: Duration(milliseconds: 50));
+      yield InfiniteObserverFlowAction(
+        'observer1',
+        emitInterval: Duration(milliseconds: 50),
+      );
 
       // Emit second infinite FlowHolderAction
       // With flatMap, this executes concurrently (not blocked by first yield)
-      yield SecondaryObserverFlowAction('observer2', emitInterval: Duration(milliseconds: 50));
+      yield SecondaryObserverFlowAction(
+        'observer2',
+        emitInterval: Duration(milliseconds: 50),
+      );
 
       // Emit a marker action to indicate setup is complete
       // With flatMap, this also executes without blocking
@@ -103,48 +117,51 @@ class MultiObserverMiddleware extends Middleware<AppState, Action> {
 
 void main() {
   group('Middleware Emit FlowHolderAction Tests', () {
-    test('emitting multiple FlowHolderActions from middleware should not block', () async {
-      final appReducer = AppReducer();
-      final store = createStore<AppState, Action>(
-        initialState: AppState(),
-        reducer: appReducer.reducer,
-        middlewares: [MultiObserverMiddleware()],
-      );
+    test(
+      'emitting multiple FlowHolderActions from middleware should not block',
+      () async {
+        final appReducer = AppReducer();
+        final store = createStore<AppState, Action>(
+          initialState: AppState(),
+          reducer: appReducer.reducer,
+          middlewares: [MultiObserverMiddleware()],
+        );
 
-      // Dispatch action that triggers multiple FlowHolderAction emissions
-      store.dispatch(StartMultipleObserversAction());
+        // Dispatch action that triggers multiple FlowHolderAction emissions
+        store.dispatch(StartMultipleObserversAction());
 
-      // We should see emissions from BOTH streams
-      // InfiniteObserverFlowAction adds 1 per emission
-      // SecondaryObserverFlowAction adds 10 per emission
-      // If both are running, we should see both +1 and +10 increments
+        // We should see emissions from BOTH streams
+        // InfiniteObserverFlowAction adds 1 per emission
+        // SecondaryObserverFlowAction adds 10 per emission
+        // If both are running, we should see both +1 and +10 increments
 
-      var sawIncrementByOne = false;
-      var sawIncrementByTen = false;
-      var previousCount = 0;
+        var sawIncrementByOne = false;
+        var sawIncrementByTen = false;
+        var previousCount = 0;
 
-      // Listen to state changes
-      final subscription = store.state.listen((state) {
-        final increment = state.count - previousCount;
-        if (increment == 1) sawIncrementByOne = true;
-        if (increment == 10) sawIncrementByTen = true;
-        previousCount = state.count;
-      });
+        // Listen to state changes
+        final subscription = store.state.listen((state) {
+          final increment = state.count - previousCount;
+          if (increment == 1) sawIncrementByOne = true;
+          if (increment == 10) sawIncrementByTen = true;
+          previousCount = state.count;
+        });
 
-      // Wait for some emissions (with timeout to detect blocking)
-      await Future.delayed(Duration(milliseconds: 500));
+        // Wait for some emissions (with timeout to detect blocking)
+        await Future.delayed(Duration(milliseconds: 500));
 
-      await subscription.cancel();
-      await store.close();
+        await subscription.cancel();
+        await store.close();
 
-      expect(
-        sawIncrementByOne && sawIncrementByTen,
-        isTrue,
-        reason: 'Expected both FlowHolderActions to run concurrently. '
-            'sawIncrementByOne=$sawIncrementByOne, sawIncrementByTen=$sawIncrementByTen. '
-            'If only sawIncrementByOne=true, the second yield was blocked.',
-      );
-    });
+        expect(
+          sawIncrementByOne && sawIncrementByTen,
+          isTrue,
+          reason: 'Expected both FlowHolderActions to run concurrently. '
+              'sawIncrementByOne=$sawIncrementByOne, sawIncrementByTen=$sawIncrementByTen. '
+              'If only sawIncrementByOne=true, the second yield was blocked.',
+        );
+      },
+    );
 
     test('code after yielding FlowHolderAction should execute', () async {
       final appReducer = AppReducer();
@@ -164,7 +181,8 @@ void main() {
       expect(
         appReducer.setupCompleteReceived,
         isTrue,
-        reason: 'SetupCompleteAction should have been yielded after the FlowHolderActions, '
+        reason:
+            'SetupCompleteAction should have been yielded after the FlowHolderActions, '
             'but the code after yield was blocked.',
       );
     });

--- a/dart/flowdux/test/middleware_test.dart
+++ b/dart/flowdux/test/middleware_test.dart
@@ -41,8 +41,7 @@ class AppState {
 
   AppState({this.count = 0, this.loading = false, this.data});
 
-  AppState copyWith({int? count, bool? loading, String? data}) =>
-      AppState(
+  AppState copyWith({int? count, bool? loading, String? data}) => AppState(
         count: count ?? this.count,
         loading: loading ?? this.loading,
         data: data ?? this.data,
@@ -61,7 +60,8 @@ class AppState {
   int get hashCode => Object.hash(count, loading, data);
 
   @override
-  String toString() => 'AppState(count: $count, loading: $loading, data: $data)';
+  String toString() =>
+      'AppState(count: $count, loading: $loading, data: $data)';
 }
 
 // Test Middlewares using new DSL
@@ -170,8 +170,9 @@ class AppReducer extends ReducerBase<AppState, Action> {
     on<DecrementAction>((state, _) => state.copyWith(count: state.count - 1));
     on<SetValueAction>((state, action) => state.copyWith(count: action.value));
     on<LoadingAction>((state, _) => state.copyWith(loading: true));
-    on<DataLoadedAction>((state, action) =>
-        state.copyWith(loading: false, data: action.data));
+    on<DataLoadedAction>(
+      (state, action) => state.copyWith(loading: false, data: action.data),
+    );
     on<TransformedAction>((state, _) => state.copyWith(count: 999));
   }
 }
@@ -209,7 +210,10 @@ void main() {
       store.dispatch(TransformAction());
       await Future.delayed(Duration(milliseconds: 50));
 
-      expect(store.currentState.count, 999); // TransformedAction sets count to 999
+      expect(
+        store.currentState.count,
+        999,
+      ); // TransformedAction sets count to 999
 
       await store.close();
     });
@@ -233,7 +237,12 @@ void main() {
       final store = createStore<AppState, Action>(
         initialState: AppState(),
         reducer: reducer,
-        middlewares: [AsyncMiddleware(delay: Duration(milliseconds: 20), data: 'async data')],
+        middlewares: [
+          AsyncMiddleware(
+            delay: Duration(milliseconds: 20),
+            data: 'async data',
+          ),
+        ],
       );
 
       store.dispatch(FetchDataAction());
@@ -297,8 +306,14 @@ void main() {
       expect(store.currentState.count, 1);
 
       // Both middlewares should have processed
-      expect(logger.logs, contains('middleware:CounterMiddleware:IncrementAction'));
-      expect(logger.logs, contains('middleware:TransformMiddleware:IncrementAction'));
+      expect(
+        logger.logs,
+        contains('middleware:CounterMiddleware:IncrementAction'),
+      );
+      expect(
+        logger.logs,
+        contains('middleware:TransformMiddleware:IncrementAction'),
+      );
 
       await store.close();
     });
@@ -335,7 +350,9 @@ void main() {
 
       expect(
         exception.toString(),
-        contains("Processor for action type 'IncrementAction' is already registered"),
+        contains(
+          "Processor for action type 'IncrementAction' is already registered",
+        ),
       );
     });
   });
@@ -382,7 +399,10 @@ void main() {
   group('ErrorProcessor', () {
     test('DefaultErrorProcessor swallows errors', () async {
       final errorProcessor = DefaultErrorProcessor<Action>();
-      final stream = errorProcessor.process(Exception('test'), StackTrace.current);
+      final stream = errorProcessor.process(
+        Exception('test'),
+        StackTrace.current,
+      );
 
       final actions = await stream.toList();
       expect(actions, isEmpty);
@@ -390,7 +410,10 @@ void main() {
 
     test('custom ErrorProcessor can emit recovery actions', () async {
       final errorProcessor = _TestErrorProcessor();
-      final stream = errorProcessor.process(Exception('test'), StackTrace.current);
+      final stream = errorProcessor.process(
+        Exception('test'),
+        StackTrace.current,
+      );
 
       final actions = await stream.toList();
       expect(actions.length, 1);
@@ -410,13 +433,11 @@ class _StrategyMiddleware extends Middleware<AppState, Action> {
 
 class _GroupMiddleware extends Middleware<AppState, Action> {
   _GroupMiddleware() {
-    apply(_NoOpStrategy())
-        .on<IncrementAction>((state, action) async* {
-          yield action;
-        })
-        .on<DecrementAction>((state, action) async* {
-          yield action;
-        });
+    apply(_NoOpStrategy()).on<IncrementAction>((state, action) async* {
+      yield action;
+    }).on<DecrementAction>((state, action) async* {
+      yield action;
+    });
   }
 }
 

--- a/dart/flowdux/test/store_test.dart
+++ b/dart/flowdux/test/store_test.dart
@@ -27,13 +27,17 @@ class BatchAction with FlowHolderAction {
   Stream<Action> toStreamAction() => Stream.fromIterable(actions);
 
   @override
-  ExecutionStrategy get strategy => concurrent(); // Batch actions should not cancel each other
+  ExecutionStrategy get strategy =>
+      concurrent(); // Batch actions should not cancel each other
 }
 
 class AsyncBatchAction with FlowHolderAction {
   final List<Action> actions;
   final Duration delay;
-  AsyncBatchAction(this.actions, {this.delay = const Duration(milliseconds: 10)});
+  AsyncBatchAction(
+    this.actions, {
+    this.delay = const Duration(milliseconds: 10),
+  });
 
   @override
   Stream<Action> toStreamAction() async* {
@@ -44,7 +48,8 @@ class AsyncBatchAction with FlowHolderAction {
   }
 
   @override
-  ExecutionStrategy get strategy => concurrent(); // Batch actions should not cancel each other
+  ExecutionStrategy get strategy =>
+      concurrent(); // Batch actions should not cancel each other
 }
 
 class NestedFlowHolderAction with FlowHolderAction {
@@ -56,7 +61,8 @@ class NestedFlowHolderAction with FlowHolderAction {
   }
 
   @override
-  ExecutionStrategy get strategy => concurrent(); // Should complete all nested actions
+  ExecutionStrategy get strategy =>
+      concurrent(); // Should complete all nested actions
 }
 
 // Test State
@@ -69,7 +75,9 @@ class CounterState {
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      other is CounterState && runtimeType == other.runtimeType && count == other.count;
+      other is CounterState &&
+          runtimeType == other.runtimeType &&
+          count == other.count;
 
   @override
   int get hashCode => count.hashCode;
@@ -210,11 +218,13 @@ void main() {
           reducer: reducer,
         );
 
-        store.dispatch(BatchAction([
-          IncrementAction(),
-          IncrementAction(),
-          IncrementAction(),
-        ]));
+        store.dispatch(
+          BatchAction([
+            IncrementAction(),
+            IncrementAction(),
+            IncrementAction(),
+          ]),
+        );
 
         await Future.delayed(Duration(milliseconds: 50));
 
@@ -229,10 +239,12 @@ void main() {
           reducer: reducer,
         );
 
-        store.dispatch(AsyncBatchAction(
-          [IncrementAction(), IncrementAction()],
-          delay: Duration(milliseconds: 10),
-        ));
+        store.dispatch(
+          AsyncBatchAction([
+            IncrementAction(),
+            IncrementAction(),
+          ], delay: Duration(milliseconds: 10)),
+        );
 
         // Before delay completes
         await Future.delayed(Duration(milliseconds: 5));
@@ -301,10 +313,7 @@ void main() {
         store.dispatch(IncrementAction());
 
         expect(store.currentState, CounterState(0));
-        expect(
-          logger.logs,
-          contains('dispatchAfterClose:IncrementAction'),
-        );
+        expect(logger.logs, contains('dispatchAfterClose:IncrementAction'));
       });
 
       test('close() is idempotent', () async {
@@ -350,7 +359,9 @@ void main() {
 
         expect(
           logger.logs,
-          contains('reduced:IncrementAction:CounterState(count: 0)->CounterState(count: 1)'),
+          contains(
+            'reduced:IncrementAction:CounterState(count: 0)->CounterState(count: 1)',
+          ),
         );
 
         await store.close();

--- a/dart/flowdux/test/strategy/chaining_strategy_test.dart
+++ b/dart/flowdux/test/strategy/chaining_strategy_test.dart
@@ -29,14 +29,17 @@ void main() {
         final executionOrder = <String>[];
 
         // debounce(100ms) then takeLatest
-        final strategy = debounce(Duration(milliseconds: 100)).then(takeLatest());
+        final strategy = debounce(
+          Duration(milliseconds: 100),
+        ).then(takeLatest());
 
-        final wrappedProcessor = strategy.wrap<AppState, Action, FetchAction>(
-          (state, action) async* {
-            executionOrder.add('executed:${action.id}');
-            yield DataAction(action.id);
-          },
-        );
+        final wrappedProcessor = strategy.wrap<AppState, Action, FetchAction>((
+          state,
+          action,
+        ) async* {
+          executionOrder.add('executed:${action.id}');
+          yield DataAction(action.id);
+        });
 
         final state = AppState();
         final results = <int>[];
@@ -85,7 +88,10 @@ void main() {
         fail('Should have thrown DuplicateCategoryException');
       } on DuplicateCategoryException catch (e) {
         expect(e.category, StrategyCategory.concurrency);
-        expect(e.toString(), contains('Cannot chain strategies of the same category'));
+        expect(
+          e.toString(),
+          contains('Cannot chain strategies of the same category'),
+        );
         expect(e.toString(), contains('concurrency'));
         expect(e.toString(), contains('TakeLatestStrategy'));
         expect(e.toString(), contains('TakeLeadingStrategy'));
@@ -94,16 +100,18 @@ void main() {
 
     test('allows chaining different categories', () {
       // This should not throw
-      final strategy = debounce(Duration(milliseconds: 100))
-          .then(takeLatest())
-          .then(retry(3));
+      final strategy = debounce(
+        Duration(milliseconds: 100),
+      ).then(takeLatest()).then(retry(3));
 
       expect(strategy.category, StrategyCategory.chained);
     });
 
     test('validates nested chains for duplicate categories', () {
       // debounce -> takeLatest (OK)
-      final firstChain = debounce(Duration(milliseconds: 100)).then(takeLatest());
+      final firstChain = debounce(
+        Duration(milliseconds: 100),
+      ).then(takeLatest());
 
       // Trying to add another concurrency strategy should fail
       expect(
@@ -133,15 +141,18 @@ void main() {
 
         // Use debounce(100ms).then(takeLatest())
         // debounce is outer, so it should debounce first, then takeLatest applies
-        final strategy = debounce(Duration(milliseconds: 100)).then(takeLatest());
+        final strategy = debounce(
+          Duration(milliseconds: 100),
+        ).then(takeLatest());
 
-        final wrappedProcessor = strategy.wrap<AppState, Action, FetchAction>(
-          (state, action) async* {
-            debounceExecuted = true;
-            takeLatestExecuted = true;
-            yield DataAction(action.id);
-          },
-        );
+        final wrappedProcessor = strategy.wrap<AppState, Action, FetchAction>((
+          state,
+          action,
+        ) async* {
+          debounceExecuted = true;
+          takeLatestExecuted = true;
+          yield DataAction(action.id);
+        });
 
         final state = AppState();
 
@@ -279,16 +290,18 @@ void main() {
 // Test Reducer
 class _AppReducer extends ReducerBase<AppState, Action> {
   _AppReducer() {
-    on<DataAction>((state, action) =>
-        state.copyWith(results: [...state.results, action.id]));
+    on<DataAction>(
+      (state, action) => state.copyWith(results: [...state.results, action.id]),
+    );
   }
 }
 
 // Test Middlewares using new DSL
 class _DebounceTakeLatestMiddleware extends Middleware<AppState, Action> {
   _DebounceTakeLatestMiddleware() {
-    apply(debounce(Duration(milliseconds: 50)).then(takeLatest()))
-        .on<FetchAction>((state, action) async* {
+    apply(
+      debounce(Duration(milliseconds: 50)).then(takeLatest()),
+    ).on<FetchAction>((state, action) async* {
       yield DataAction(action.id);
     });
   }
@@ -296,18 +309,20 @@ class _DebounceTakeLatestMiddleware extends Middleware<AppState, Action> {
 
 class _ThrottleRetryMiddleware extends Middleware<AppState, Action> {
   _ThrottleRetryMiddleware({required void Function() onProcess}) {
-    apply(throttle(Duration(milliseconds: 100)).then(retry(3)))
-        .on<FetchAction>((state, action) async* {
-      onProcess();
-      yield DataAction(action.id);
-    });
+    apply(throttle(Duration(milliseconds: 100)).then(retry(3))).on<FetchAction>(
+      (state, action) async* {
+        onProcess();
+        yield DataAction(action.id);
+      },
+    );
   }
 }
 
 class _ThreeWayChainMiddleware extends Middleware<AppState, Action> {
   _ThreeWayChainMiddleware({required void Function() onProcess}) {
-    apply(debounce(Duration(milliseconds: 30)).then(takeLatest()).then(retry(2)))
-        .on<FetchAction>((state, action) async* {
+    apply(
+      debounce(Duration(milliseconds: 30)).then(takeLatest()).then(retry(2)),
+    ).on<FetchAction>((state, action) async* {
       onProcess();
       yield DataAction(action.id);
     });

--- a/dart/flowdux/test/strategy/concurrency_strategy_test.dart
+++ b/dart/flowdux/test/strategy/concurrency_strategy_test.dart
@@ -75,20 +75,25 @@ class AppState {
       );
 
   @override
-  String toString() => 'AppState(results: $results, submitting: $submitting, savedValues: $savedValues)';
+  String toString() =>
+      'AppState(results: $results, submitting: $submitting, savedValues: $savedValues)';
 }
 
 // Test Reducer
 class AppReducer extends ReducerBase<AppState, Action> {
   AppReducer() {
-    on<ResultAction>((state, action) =>
-        state.copyWith(results: [...state.results, action.id]));
+    on<ResultAction>(
+      (state, action) => state.copyWith(results: [...state.results, action.id]),
+    );
     on<SubmittingAction>((state, _) => state.copyWith(submitting: true));
     on<SubmittedAction>((state, _) => state.copyWith(submitting: false));
-    on<SavedAction>((state, action) =>
-        state.copyWith(savedValues: [...state.savedValues, action.value]));
-    on<SearchResultAction>((state, action) =>
-        state.copyWith(searchResults: action.results));
+    on<SavedAction>(
+      (state, action) =>
+          state.copyWith(savedValues: [...state.savedValues, action.value]),
+    );
+    on<SearchResultAction>(
+      (state, action) => state.copyWith(searchResults: action.results),
+    );
   }
 }
 
@@ -297,31 +302,40 @@ void main() {
       final executionOrder = <String>[];
 
       // Start three concurrent operations
-      unawaited(lock.synchronized(() async {
-        executionOrder.add('a:start');
-        await Future.delayed(Duration(milliseconds: 30));
-        executionOrder.add('a:end');
-      }));
+      unawaited(
+        lock.synchronized(() async {
+          executionOrder.add('a:start');
+          await Future.delayed(Duration(milliseconds: 30));
+          executionOrder.add('a:end');
+        }),
+      );
 
-      unawaited(lock.synchronized(() async {
-        executionOrder.add('b:start');
-        await Future.delayed(Duration(milliseconds: 20));
-        executionOrder.add('b:end');
-      }));
+      unawaited(
+        lock.synchronized(() async {
+          executionOrder.add('b:start');
+          await Future.delayed(Duration(milliseconds: 20));
+          executionOrder.add('b:end');
+        }),
+      );
 
-      unawaited(lock.synchronized(() async {
-        executionOrder.add('c:start');
-        await Future.delayed(Duration(milliseconds: 10));
-        executionOrder.add('c:end');
-      }));
+      unawaited(
+        lock.synchronized(() async {
+          executionOrder.add('c:start');
+          await Future.delayed(Duration(milliseconds: 10));
+          executionOrder.add('c:end');
+        }),
+      );
 
       await Future.delayed(Duration(milliseconds: 150));
 
       // Should execute in order: a complete, then b complete, then c complete
       expect(executionOrder, [
-        'a:start', 'a:end',
-        'b:start', 'b:end',
-        'c:start', 'c:end',
+        'a:start',
+        'a:end',
+        'b:start',
+        'b:end',
+        'c:start',
+        'c:end',
       ]);
     });
 
@@ -384,19 +398,17 @@ class _TakeLatestSingleMiddleware extends Middleware<AppState, Action> {
 class _TakeLatestGroupMiddleware extends Middleware<AppState, Action> {
   _TakeLatestGroupMiddleware(List<String> executionOrder) {
     final strategy = takeLatest();
-    apply(strategy)
-        .on<TestAction>((state, action) async* {
-          executionOrder.add('test:start:${action.id}');
-          await Future.delayed(Duration(milliseconds: 50));
-          executionOrder.add('test:end:${action.id}');
-          yield ResultAction(action.id);
-        })
-        .on<SearchAction>((state, action) async* {
-          executionOrder.add('search:start:${action.query}');
-          await Future.delayed(Duration(milliseconds: 50));
-          executionOrder.add('search:end:${action.query}');
-          yield SearchResultAction(action.query, [action.query]);
-        });
+    apply(strategy).on<TestAction>((state, action) async* {
+      executionOrder.add('test:start:${action.id}');
+      await Future.delayed(Duration(milliseconds: 50));
+      executionOrder.add('test:end:${action.id}');
+      yield ResultAction(action.id);
+    }).on<SearchAction>((state, action) async* {
+      executionOrder.add('search:start:${action.query}');
+      await Future.delayed(Duration(milliseconds: 50));
+      executionOrder.add('search:end:${action.query}');
+      yield SearchResultAction(action.query, [action.query]);
+    });
   }
 }
 

--- a/dart/flowdux/test/strategy/resilience_strategy_test.dart
+++ b/dart/flowdux/test/strategy/resilience_strategy_test.dart
@@ -46,24 +46,27 @@ void main() {
       var attemptCount = 0;
       final strategy = retry(3);
 
-      final wrappedProcessor = strategy.wrap<AppState, Action, FetchAction>(
-        (state, action) async* {
-          attemptCount++;
-          if (attemptCount < 3) {
-            throw NetworkException('Network error');
-          }
-          yield DataAction('success');
-        },
-      );
+      final wrappedProcessor = strategy.wrap<AppState, Action, FetchAction>((
+        state,
+        action,
+      ) async* {
+        attemptCount++;
+        if (attemptCount < 3) {
+          throw NetworkException('Network error');
+        }
+        yield DataAction('success');
+      });
 
       final state = AppState();
       final results = <String>[];
       Object? caughtError;
 
-      await wrappedProcessor(state, FetchAction()).listen(
-        (a) => results.add((a as DataAction).data),
-        onError: (e) => caughtError = e,
-      ).asFuture();
+      await wrappedProcessor(state, FetchAction())
+          .listen(
+            (a) => results.add((a as DataAction).data),
+            onError: (e) => caughtError = e,
+          )
+          .asFuture();
 
       expect(attemptCount, 3);
       expect(results, ['success']);
@@ -74,12 +77,13 @@ void main() {
       var attemptCount = 0;
       final strategy = retry(3);
 
-      final wrappedProcessor = strategy.wrap<AppState, Action, FetchAction>(
-        (state, action) async* {
-          attemptCount++;
-          throw NetworkException('Network error $attemptCount');
-        },
-      );
+      final wrappedProcessor = strategy.wrap<AppState, Action, FetchAction>((
+        state,
+        action,
+      ) async* {
+        attemptCount++;
+        throw NetworkException('Network error $attemptCount');
+      });
 
       final state = AppState();
       Object? caughtError;
@@ -107,12 +111,13 @@ void main() {
       var attemptCount = 0;
       final strategy = retry(3);
 
-      final wrappedProcessor = strategy.wrap<AppState, Action, FetchAction>(
-        (state, action) async* {
-          attemptCount++;
-          throw CancellationException('Operation cancelled');
-        },
-      );
+      final wrappedProcessor = strategy.wrap<AppState, Action, FetchAction>((
+        state,
+        action,
+      ) async* {
+        attemptCount++;
+        throw CancellationException('Operation cancelled');
+      });
 
       final state = AppState();
       Object? caughtError;
@@ -138,20 +143,18 @@ void main() {
 
     test('respects retryIf predicate', () async {
       var attemptCount = 0;
-      final strategy = retry(
-        3,
-        retryIf: (e) => e is NetworkException,
-      );
+      final strategy = retry(3, retryIf: (e) => e is NetworkException);
 
-      final wrappedProcessor = strategy.wrap<AppState, Action, FetchAction>(
-        (state, action) async* {
-          attemptCount++;
-          if (attemptCount == 1) {
-            throw NetworkException('Network error');
-          }
-          throw ValidationException('Validation error');
-        },
-      );
+      final wrappedProcessor = strategy.wrap<AppState, Action, FetchAction>((
+        state,
+        action,
+      ) async* {
+        attemptCount++;
+        if (attemptCount == 1) {
+          throw NetworkException('Network error');
+        }
+        throw ValidationException('Validation error');
+      });
 
       final state = AppState();
       Object? caughtError;
@@ -185,19 +188,21 @@ void main() {
       var attemptCount = 0;
       final strategy = retry(3);
 
-      final wrappedProcessor = strategy.wrap<AppState, Action, FetchAction>(
-        (state, action) async* {
-          attemptCount++;
-          yield DataAction('success');
-        },
-      );
+      final wrappedProcessor = strategy.wrap<AppState, Action, FetchAction>((
+        state,
+        action,
+      ) async* {
+        attemptCount++;
+        yield DataAction('success');
+      });
 
       final state = AppState();
       final results = <String>[];
 
-      await wrappedProcessor(state, FetchAction()).listen(
-        (a) => results.add((a as DataAction).data),
-      ).asFuture();
+      await wrappedProcessor(
+        state,
+        FetchAction(),
+      ).listen((a) => results.add((a as DataAction).data)).asFuture();
 
       expect(attemptCount, 1);
       expect(results, ['success']);
@@ -217,27 +222,29 @@ void main() {
           factor: 2.0,
         );
 
-        final wrappedProcessor = strategy.wrap<AppState, Action, FetchAction>(
-          (state, action) async* {
-            final now = DateTime.now();
-            if (attemptCount > 0) {
-              delays.add(now.difference(lastAttemptTime));
-            }
-            lastAttemptTime = now;
-            attemptCount++;
-            if (attemptCount < 4) {
-              throw NetworkException('Network error');
-            }
-            yield DataAction('success');
-          },
-        );
+        final wrappedProcessor = strategy.wrap<AppState, Action, FetchAction>((
+          state,
+          action,
+        ) async* {
+          final now = DateTime.now();
+          if (attemptCount > 0) {
+            delays.add(now.difference(lastAttemptTime));
+          }
+          lastAttemptTime = now;
+          attemptCount++;
+          if (attemptCount < 4) {
+            throw NetworkException('Network error');
+          }
+          yield DataAction('success');
+        });
 
         final state = AppState();
         final results = <String>[];
 
-        wrappedProcessor(state, FetchAction()).listen(
-          (a) => results.add((a as DataAction).data),
-        );
+        wrappedProcessor(
+          state,
+          FetchAction(),
+        ).listen((a) => results.add((a as DataAction).data));
 
         // First attempt immediately
         async.elapse(Duration.zero);
@@ -268,15 +275,16 @@ void main() {
           factor: 2.0,
         );
 
-        final wrappedProcessor = strategy.wrap<AppState, Action, FetchAction>(
-          (state, action) async* {
-            attemptCount++;
-            if (attemptCount < 5) {
-              throw NetworkException('Network error');
-            }
-            yield DataAction('success');
-          },
-        );
+        final wrappedProcessor = strategy.wrap<AppState, Action, FetchAction>((
+          state,
+          action,
+        ) async* {
+          attemptCount++;
+          if (attemptCount < 5) {
+            throw NetworkException('Network error');
+          }
+          yield DataAction('success');
+        });
 
         final state = AppState();
 
@@ -322,25 +330,23 @@ void main() {
     test('never retries CancellationException', () {
       fakeAsync((async) {
         var attemptCount = 0;
-        final strategy = retryWithBackoff(
-          3,
-          Duration(milliseconds: 100),
-        );
+        final strategy = retryWithBackoff(3, Duration(milliseconds: 100));
 
-        final wrappedProcessor = strategy.wrap<AppState, Action, FetchAction>(
-          (state, action) async* {
-            attemptCount++;
-            throw CancellationException('Cancelled');
-          },
-        );
+        final wrappedProcessor = strategy.wrap<AppState, Action, FetchAction>((
+          state,
+          action,
+        ) async* {
+          attemptCount++;
+          throw CancellationException('Cancelled');
+        });
 
         final state = AppState();
         Object? caughtError;
 
-        wrappedProcessor(state, FetchAction()).listen(
-          (_) {},
-          onError: (e) => caughtError = e,
-        );
+        wrappedProcessor(
+          state,
+          FetchAction(),
+        ).listen((_) {}, onError: (e) => caughtError = e);
 
         async.elapse(Duration.zero);
 
@@ -364,20 +370,20 @@ void main() {
           retryIf: (e) => e is NetworkException,
         );
 
-        final wrappedProcessor = strategy.wrap<AppState, Action, FetchAction>(
-          (state, action) async* {
-            attemptCount++;
-            throw ValidationException('Invalid');
-          },
-        );
+        final wrappedProcessor = strategy.wrap<AppState, Action, FetchAction>((
+          state,
+          action,
+        ) async* {
+          attemptCount++;
+          throw ValidationException('Invalid');
+        });
 
         final state = AppState();
 
-        wrappedProcessor(state, FetchAction()).listen(
-          (_) {},
-          onError: (e) => caughtError = e,
-          cancelOnError: false,
-        );
+        wrappedProcessor(
+          state,
+          FetchAction(),
+        ).listen((_) {}, onError: (e) => caughtError = e, cancelOnError: false);
 
         async.elapse(Duration.zero);
         expect(attemptCount, 1);
@@ -491,7 +497,10 @@ class _RetryMiddleware extends Middleware<AppState, Action> {
 
 class _RetryWithBackoffMiddleware extends Middleware<AppState, Action> {
   _RetryWithBackoffMiddleware({required void Function() onProcess}) {
-    apply(retryWithBackoff(3, Duration(milliseconds: 10))).on<FetchAction>((state, action) async* {
+    apply(retryWithBackoff(3, Duration(milliseconds: 10))).on<FetchAction>((
+      state,
+      action,
+    ) async* {
       onProcess();
       yield DataAction('success');
     });

--- a/dart/flowdux/test/strategy/timing_strategy_test.dart
+++ b/dart/flowdux/test/strategy/timing_strategy_test.dart
@@ -30,15 +30,9 @@ class AppState {
   final List<String> searchResults;
   final List<int> refreshResults;
 
-  AppState({
-    this.searchResults = const [],
-    this.refreshResults = const [],
-  });
+  AppState({this.searchResults = const [], this.refreshResults = const []});
 
-  AppState copyWith({
-    List<String>? searchResults,
-    List<int>? refreshResults,
-  }) =>
+  AppState copyWith({List<String>? searchResults, List<int>? refreshResults}) =>
       AppState(
         searchResults: searchResults ?? this.searchResults,
         refreshResults: refreshResults ?? this.refreshResults,
@@ -48,10 +42,14 @@ class AppState {
 // Test Reducer
 class AppReducer extends ReducerBase<AppState, Action> {
   AppReducer() {
-    on<SearchResultAction>((state, action) =>
-        state.copyWith(searchResults: [...state.searchResults, action.query]));
-    on<DataLoadedAction>((state, action) =>
-        state.copyWith(refreshResults: [...state.refreshResults, action.id]));
+    on<SearchResultAction>(
+      (state, action) =>
+          state.copyWith(searchResults: [...state.searchResults, action.query]),
+    );
+    on<DataLoadedAction>(
+      (state, action) =>
+          state.copyWith(refreshResults: [...state.refreshResults, action.id]),
+    );
   }
 }
 
@@ -68,12 +66,13 @@ void main() {
         final executionOrder = <String>[];
         final strategy = debounce(Duration(milliseconds: 100));
 
-        final wrappedProcessor = strategy.wrap<AppState, Action, SearchAction>(
-          (state, action) async* {
-            executionOrder.add('executed:${action.query}');
-            yield SearchResultAction(action.query);
-          },
-        );
+        final wrappedProcessor = strategy.wrap<AppState, Action, SearchAction>((
+          state,
+          action,
+        ) async* {
+          executionOrder.add('executed:${action.query}');
+          yield SearchResultAction(action.query);
+        });
 
         final state = AppState();
 
@@ -105,11 +104,12 @@ void main() {
         final results = <String>[];
         final strategy = debounce(Duration(milliseconds: 100));
 
-        final wrappedProcessor = strategy.wrap<AppState, Action, SearchAction>(
-          (state, action) async* {
-            yield SearchResultAction(action.query);
-          },
-        );
+        final wrappedProcessor = strategy.wrap<AppState, Action, SearchAction>((
+          state,
+          action,
+        ) async* {
+          yield SearchResultAction(action.query);
+        });
 
         final state = AppState();
 
@@ -141,11 +141,12 @@ void main() {
         final results = <String>[];
         final strategy = debounce(Duration(milliseconds: 100));
 
-        final wrappedProcessor = strategy.wrap<AppState, Action, SearchAction>(
-          (state, action) async* {
-            yield SearchResultAction(action.query);
-          },
-        );
+        final wrappedProcessor = strategy.wrap<AppState, Action, SearchAction>((
+          state,
+          action,
+        ) async* {
+          yield SearchResultAction(action.query);
+        });
 
         final state = AppState();
 
@@ -170,11 +171,12 @@ void main() {
         final results = <String>[];
         final strategy = debounceMs(50);
 
-        final wrappedProcessor = strategy.wrap<AppState, Action, SearchAction>(
-          (state, action) async* {
-            yield SearchResultAction(action.query);
-          },
-        );
+        final wrappedProcessor = strategy.wrap<AppState, Action, SearchAction>((
+          state,
+          action,
+        ) async* {
+          yield SearchResultAction(action.query);
+        });
 
         final state = AppState();
 
@@ -388,7 +390,10 @@ void main() {
 // Test Middlewares using new DSL
 class _DebounceMiddleware extends Middleware<AppState, Action> {
   _DebounceMiddleware() {
-    apply(debounce(Duration(milliseconds: 50))).on<SearchAction>((state, action) async* {
+    apply(debounce(Duration(milliseconds: 50))).on<SearchAction>((
+      state,
+      action,
+    ) async* {
       yield SearchResultAction(action.query);
     });
   }
@@ -396,7 +401,10 @@ class _DebounceMiddleware extends Middleware<AppState, Action> {
 
 class _ThrottleMiddleware extends Middleware<AppState, Action> {
   _ThrottleMiddleware() {
-    apply(throttle(Duration(milliseconds: 50))).on<RefreshAction>((state, action) async* {
+    apply(throttle(Duration(milliseconds: 50))).on<RefreshAction>((
+      state,
+      action,
+    ) async* {
       yield DataLoadedAction(action.id);
     });
   }

--- a/dart/flowdux_flutter/example/lib/actions/batch_actions.dart
+++ b/dart/flowdux_flutter/example/lib/actions/batch_actions.dart
@@ -10,7 +10,8 @@ class BatchIncrementAction with FlowHolderAction {
   BatchIncrementAction(this.count);
 
   @override
-  ExecutionStrategy get strategy => concurrent(); // Batch actions should complete fully
+  ExecutionStrategy get strategy =>
+      concurrent(); // Batch actions should complete fully
 
   @override
   Stream<Action> toStreamAction() async* {
@@ -26,10 +27,14 @@ class AsyncBatchIncrementAction with FlowHolderAction {
   final int count;
   final Duration delay;
 
-  AsyncBatchIncrementAction(this.count, {this.delay = const Duration(milliseconds: 200)});
+  AsyncBatchIncrementAction(
+    this.count, {
+    this.delay = const Duration(milliseconds: 200),
+  });
 
   @override
-  ExecutionStrategy get strategy => concurrent(); // Batch actions should complete fully
+  ExecutionStrategy get strategy =>
+      concurrent(); // Batch actions should complete fully
 
   @override
   Stream<Action> toStreamAction() async* {
@@ -47,7 +52,8 @@ class ResetAndSetAction with FlowHolderAction {
   ResetAndSetAction(this.value);
 
   @override
-  ExecutionStrategy get strategy => concurrent(); // Should complete both actions
+  ExecutionStrategy get strategy =>
+      concurrent(); // Should complete both actions
 
   @override
   Stream<Action> toStreamAction() async* {

--- a/dart/flowdux_flutter/example/lib/main.dart
+++ b/dart/flowdux_flutter/example/lib/main.dart
@@ -14,10 +14,5 @@ void main() {
     logger: DebugStoreLogger(tag: 'FlowDux'),
   );
 
-  runApp(
-    StoreProvider<AppState, Action>(
-      store: store,
-      child: const MyApp(),
-    ),
-  );
+  runApp(StoreProvider<AppState, Action>(store: store, child: const MyApp()));
 }

--- a/dart/flowdux_flutter/example/lib/pages/tabs/batch_tab.dart
+++ b/dart/flowdux_flutter/example/lib/pages/tabs/batch_tab.dart
@@ -48,14 +48,18 @@ class BatchTab extends StatelessWidget {
                 children: [
                   ElevatedButton(
                     onPressed: () {
-                      context.dispatch<AppState, Action>(BatchIncrementAction(3));
+                      context.dispatch<AppState, Action>(
+                        BatchIncrementAction(3),
+                      );
                     },
                     child: const Text('+3 (instant)'),
                   ),
                   const SizedBox(width: 8),
                   ElevatedButton(
                     onPressed: () {
-                      context.dispatch<AppState, Action>(BatchIncrementAction(5));
+                      context.dispatch<AppState, Action>(
+                        BatchIncrementAction(5),
+                      );
                     },
                     child: const Text('+5 (instant)'),
                   ),
@@ -75,7 +79,10 @@ class BatchTab extends StatelessWidget {
                   ElevatedButton(
                     onPressed: () {
                       context.dispatch<AppState, Action>(
-                        AsyncBatchIncrementAction(3, delay: const Duration(milliseconds: 300)),
+                        AsyncBatchIncrementAction(
+                          3,
+                          delay: const Duration(milliseconds: 300),
+                        ),
                       );
                     },
                     child: const Text('+3 (animated)'),
@@ -84,7 +91,10 @@ class BatchTab extends StatelessWidget {
                   ElevatedButton(
                     onPressed: () {
                       context.dispatch<AppState, Action>(
-                        AsyncBatchIncrementAction(5, delay: const Duration(milliseconds: 200)),
+                        AsyncBatchIncrementAction(
+                          5,
+                          delay: const Duration(milliseconds: 200),
+                        ),
                       );
                     },
                     child: const Text('+5 (animated)'),
@@ -111,7 +121,9 @@ class BatchTab extends StatelessWidget {
                   const SizedBox(width: 8),
                   ElevatedButton(
                     onPressed: () {
-                      context.dispatch<AppState, Action>(ResetAndSetAction(100));
+                      context.dispatch<AppState, Action>(
+                        ResetAndSetAction(100),
+                      );
                     },
                     child: const Text('Reset → 100'),
                   ),
@@ -157,10 +169,7 @@ class BatchTab extends StatelessWidget {
                     '    }\n'
                     '  }\n'
                     '}',
-                    style: TextStyle(
-                      fontFamily: 'monospace',
-                      fontSize: 12,
-                    ),
+                    style: TextStyle(fontFamily: 'monospace', fontSize: 12),
                   ),
                 ],
               ),
@@ -178,10 +187,7 @@ class BatchTab extends StatelessWidget {
   }) {
     return Column(
       children: [
-        Text(
-          title,
-          style: const TextStyle(fontWeight: FontWeight.bold),
-        ),
+        Text(title, style: const TextStyle(fontWeight: FontWeight.bold)),
         const SizedBox(height: 4),
         Text(
           description,

--- a/dart/flowdux_flutter/example/lib/pages/tabs/flow_holder_stream_tab.dart
+++ b/dart/flowdux_flutter/example/lib/pages/tabs/flow_holder_stream_tab.dart
@@ -233,10 +233,7 @@ class _SymbolButton extends StatelessWidget {
       ),
       child: Text(
         symbol,
-        style: const TextStyle(
-          fontSize: 16,
-          fontWeight: FontWeight.bold,
-        ),
+        style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
       ),
     );
   }
@@ -326,11 +323,7 @@ class _ChartPainter extends CustomPainter {
     final lastNormalized = (prices.last - minPrice) / effectiveRange;
     final lastY = size.height - (lastNormalized * size.height * 0.8) - 20;
 
-    canvas.drawCircle(
-      Offset(lastX, lastY),
-      5,
-      Paint()..color = lineColor,
-    );
+    canvas.drawCircle(Offset(lastX, lastY), 5, Paint()..color = lineColor);
   }
 
   @override

--- a/dart/flowdux_flutter/example/lib/pages/tabs/stream_tab.dart
+++ b/dart/flowdux_flutter/example/lib/pages/tabs/stream_tab.dart
@@ -210,10 +210,7 @@ class _SymbolButton extends StatelessWidget {
       ),
       child: Text(
         symbol,
-        style: const TextStyle(
-          fontSize: 16,
-          fontWeight: FontWeight.bold,
-        ),
+        style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
       ),
     );
   }
@@ -302,11 +299,7 @@ class _ChartPainter extends CustomPainter {
     final lastNormalized = (prices.last - minPrice) / effectiveRange;
     final lastY = size.height - (lastNormalized * size.height * 0.8) - 20;
 
-    canvas.drawCircle(
-      Offset(lastX, lastY),
-      5,
-      Paint()..color = lineColor,
-    );
+    canvas.drawCircle(Offset(lastX, lastY), 5, Paint()..color = lineColor);
   }
 
   @override

--- a/dart/flowdux_flutter/example/lib/state/app_state.dart
+++ b/dart/flowdux_flutter/example/lib/state/app_state.dart
@@ -63,7 +63,8 @@ class AppState {
       flowHolderSymbol: flowHolderSymbol ?? this.flowHolderSymbol,
       flowHolderPrice: flowHolderPrice ?? this.flowHolderPrice,
       flowHolderHistory: flowHolderHistory ?? this.flowHolderHistory,
-      isFlowHolderStreaming: isFlowHolderStreaming ?? this.isFlowHolderStreaming,
+      isFlowHolderStreaming:
+          isFlowHolderStreaming ?? this.isFlowHolderStreaming,
     );
   }
 

--- a/dart/flowdux_flutter/example/lib/store/app_middleware.dart
+++ b/dart/flowdux_flutter/example/lib/store/app_middleware.dart
@@ -29,8 +29,10 @@ class AppMiddleware extends Middleware<AppState, Action> {
 
     // Search with debounce strategy
     // Waits for user to stop typing before searching
-    apply(debounce(const Duration(milliseconds: 500)))
-        .on<SearchAction>((state, action) async* {
+    apply(debounce(const Duration(milliseconds: 500))).on<SearchAction>((
+      state,
+      action,
+    ) async* {
       if (action.query.isEmpty) {
         yield SearchResultsAction('', []);
         return;

--- a/dart/flowdux_flutter/example/lib/store/app_reducer.dart
+++ b/dart/flowdux_flutter/example/lib/store/app_reducer.dart
@@ -9,56 +9,73 @@ class AppReducer extends ReducerBase<AppState, Action> {
     on<IncrementAction>((state, _) => state.copyWith(count: state.count + 1));
     on<DecrementAction>((state, _) => state.copyWith(count: state.count - 1));
     on<AddAction>(
-        (state, action) => state.copyWith(count: state.count + action.value));
+      (state, action) => state.copyWith(count: state.count + action.value),
+    );
     on<SetCountAction>((state, action) => state.copyWith(count: action.value));
 
     // Async Fetch
     on<FetchStartedAction>(
-        (state, _) => state.copyWith(isLoading: true, error: null));
-    on<FetchSuccessAction>((state, action) =>
-        state.copyWith(isLoading: false, count: action.value));
-    on<FetchErrorAction>((state, action) =>
-        state.copyWith(isLoading: false, error: action.error));
+      (state, _) => state.copyWith(isLoading: true, error: null),
+    );
+    on<FetchSuccessAction>(
+      (state, action) => state.copyWith(isLoading: false, count: action.value),
+    );
+    on<FetchErrorAction>(
+      (state, action) => state.copyWith(isLoading: false, error: action.error),
+    );
 
     // Search
-    on<SearchResultsAction>((state, action) => state.copyWith(
-          searchQuery: action.query,
-          searchResults: action.results,
-          isLoading: false,
-        ));
+    on<SearchResultsAction>(
+      (state, action) => state.copyWith(
+        searchQuery: action.query,
+        searchResults: action.results,
+        isLoading: false,
+      ),
+    );
 
     // Messages
     on<ShowMessageAction>(
-        (state, action) => state.copyWith(message: action.message));
+      (state, action) => state.copyWith(message: action.message),
+    );
     on<ClearMessageAction>((state, _) => state.copyWith(message: null));
 
     // Stream (Middleware approach)
-    on<StreamingStartedAction>((state, action) => state.copyWith(
-          activeSymbol: action.symbol,
-          isStreaming: true,
-          priceHistory: [],
-        ));
-    on<PriceUpdateAction>((state, action) => state.copyWith(
-          currentPrice: action.price,
-          priceHistory: [...state.priceHistory, action.price].take(20).toList(),
-        ));
-    on<StreamingStoppedAction>((state, _) => state.copyWith(
-          isStreaming: false,
-        ));
+    on<StreamingStartedAction>(
+      (state, action) => state.copyWith(
+        activeSymbol: action.symbol,
+        isStreaming: true,
+        priceHistory: [],
+      ),
+    );
+    on<PriceUpdateAction>(
+      (state, action) => state.copyWith(
+        currentPrice: action.price,
+        priceHistory: [...state.priceHistory, action.price].take(20).toList(),
+      ),
+    );
+    on<StreamingStoppedAction>(
+      (state, _) => state.copyWith(isStreaming: false),
+    );
 
     // FlowHolder Stream
-    on<FlowHolderStreamStartedAction>((state, action) => state.copyWith(
-          flowHolderSymbol: action.symbol,
-          isFlowHolderStreaming: true,
-          flowHolderHistory: [],
-        ));
-    on<FlowHolderPriceUpdateAction>((state, action) => state.copyWith(
-          flowHolderPrice: action.price,
-          flowHolderHistory:
-              [...state.flowHolderHistory, action.price].take(20).toList(),
-        ));
-    on<FlowHolderStreamStoppedAction>((state, _) => state.copyWith(
-          isFlowHolderStreaming: false,
-        ));
+    on<FlowHolderStreamStartedAction>(
+      (state, action) => state.copyWith(
+        flowHolderSymbol: action.symbol,
+        isFlowHolderStreaming: true,
+        flowHolderHistory: [],
+      ),
+    );
+    on<FlowHolderPriceUpdateAction>(
+      (state, action) => state.copyWith(
+        flowHolderPrice: action.price,
+        flowHolderHistory: [
+          ...state.flowHolderHistory,
+          action.price,
+        ].take(20).toList(),
+      ),
+    );
+    on<FlowHolderStreamStoppedAction>(
+      (state, _) => state.copyWith(isFlowHolderStreaming: false),
+    );
   }
 }

--- a/dart/flowdux_flutter/lib/src/store_consumer.dart
+++ b/dart/flowdux_flutter/lib/src/store_consumer.dart
@@ -75,8 +75,7 @@ class _StoreConsumerState<S, A extends Action>
 
   @override
   Widget build(BuildContext context) {
-    final effectiveStore =
-        widget.store ?? StoreProvider.of<S, A>(context);
+    final effectiveStore = widget.store ?? StoreProvider.of<S, A>(context);
 
     return StreamBuilder<S>(
       stream: effectiveStore.state,
@@ -171,8 +170,9 @@ class _StoreListenerState<S, A extends Action>
           return widget.child;
         }
 
-        final shouldListen = widget.listenWhen?.call(_previousState as S, currentState) ??
-            (_previousState != currentState);
+        final shouldListen =
+            widget.listenWhen?.call(_previousState as S, currentState) ??
+                (_previousState != currentState);
 
         if (shouldListen) {
           WidgetsBinding.instance.addPostFrameCallback((_) {

--- a/dart/flowdux_flutter/lib/src/store_provider.dart
+++ b/dart/flowdux_flutter/lib/src/store_provider.dart
@@ -17,11 +17,7 @@ class StoreProvider<S, A extends Action> extends InheritedWidget {
   final Store<S, A> store;
 
   /// Creates a [StoreProvider] with the given [store].
-  const StoreProvider({
-    super.key,
-    required this.store,
-    required super.child,
-  });
+  const StoreProvider({super.key, required this.store, required super.child});
 
   /// Retrieves the [Store] from the nearest [StoreProvider] ancestor.
   ///

--- a/dart/flowdux_flutter/test/flowdux_flutter_test.dart
+++ b/dart/flowdux_flutter/test/flowdux_flutter_test.dart
@@ -24,8 +24,10 @@ class CounterState {
 
   CounterState({this.count = 0, this.message});
 
-  CounterState copyWith({int? count, String? message}) =>
-      CounterState(count: count ?? this.count, message: message ?? this.message);
+  CounterState copyWith({int? count, String? message}) => CounterState(
+        count: count ?? this.count,
+        message: message ?? this.message,
+      );
 
   @override
   bool operator ==(Object other) =>
@@ -46,7 +48,8 @@ class CounterReducer extends ReducerBase<CounterState, Action> {
     on<DecrementAction>((state, _) => state.copyWith(count: state.count - 1));
     on<SetValueAction>((state, action) => state.copyWith(count: action.value));
     on<SetMessageAction>(
-        (state, action) => state.copyWith(message: action.message));
+      (state, action) => state.copyWith(message: action.message),
+    );
   }
 }
 
@@ -75,8 +78,9 @@ void main() {
             store: store,
             child: Builder(
               builder: (context) {
-                final providedStore =
-                    StoreProvider.of<CounterState, Action>(context);
+                final providedStore = StoreProvider.of<CounterState, Action>(
+                  context,
+                );
                 return Text('Store: ${providedStore.currentState.count}');
               },
             ),
@@ -110,8 +114,7 @@ void main() {
         MaterialApp(
           home: Builder(
             builder: (context) {
-              foundStore =
-                  StoreProvider.maybeOf<CounterState, Action>(context);
+              foundStore = StoreProvider.maybeOf<CounterState, Action>(context);
               return const Text('Test');
             },
           ),
@@ -272,7 +275,9 @@ void main() {
   });
 
   group('StoreSelector optimization', () {
-    testWidgets('does not rebuild when unrelated state changes', (tester) async {
+    testWidgets('does not rebuild when unrelated state changes', (
+      tester,
+    ) async {
       var buildCount = 0;
 
       await tester.pumpWidget(

--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues></ManuallySuppressedIssues>
+  <CurrentIssues>
+    <ID>CyclomaticComplexMethod:Main.kt$fun main(args: Array&lt;String&gt;)</ID>
+    <ID>EmptyFunctionBlock:DefaultTypedConnectionTest.kt$DefaultTypedConnectionTest.MockClientConnection${}</ID>
+    <ID>EmptyFunctionBlock:DefaultTypedConnectionTest.kt$DefaultTypedConnectionTest.MockServerConnection${}</ID>
+    <ID>EmptyFunctionBlock:NodeMediatorTest.kt$NodeMediatorTest.&lt;no name provided&gt;${}</ID>
+    <ID>EmptyFunctionBlock:NodeRoomServerTest.kt$NodeRoomServerTest.&lt;no name provided&gt;${}</ID>
+    <ID>EmptyFunctionBlock:ScopeAndLifecycleTest.kt$ScopeAndLifecycleTest.&lt;no name provided&gt;${}</ID>
+    <ID>EmptyFunctionBlock:StoreLogger.kt$NoOpStoreLogger${}</ID>
+    <ID>EmptyFunctionBlock:SyncMiddlewareTest.kt$SyncMiddlewareTest.&lt;no name provided&gt;${}</ID>
+    <ID>EmptyWhileBlock:ConcurrencyTest.kt$ConcurrencyTest${ }</ID>
+    <ID>ImplicitDefaultLocale:BenchmarkResult.kt$BenchmarkResult$String.format("%,.0f", throughput)</ID>
+    <ID>ImplicitDefaultLocale:BenchmarkResult.kt$BenchmarkResult$String.format("%.1f", actionsPerFrame(60))</ID>
+    <ID>ImplicitDefaultLocale:BenchmarkResult.kt$BenchmarkResult$String.format("%.1f", maxSustainableFps())</ID>
+    <ID>ImplicitDefaultLocale:BenchmarkResult.kt$BenchmarkSummary$String.format( "%-30s %12.0f/s %15s %10s", r.name.take(30), r.throughput, r.avgLatency, if (r.canSustain60Fps()) "✅" else "❌", )</ID>
+    <ID>ImplicitDefaultLocale:BenchmarkResult.kt$BenchmarkSummary$String.format("%-30s %15s %15s %10s", "Benchmark", "Throughput", "Avg Latency", "60fps?")</ID>
+    <ID>ImplicitDefaultLocale:SerializationBenchmark.kt$SerializationBenchmark$String.format("%-15s %10s %10s", "Size", "ActionJSON", "Wire Msg")</ID>
+    <ID>ImplicitDefaultLocale:SerializationBenchmark.kt$SerializationBenchmark$String.format("%-15s %8dB %8dB", "Large", largeJson.length, largeWire.length)</ID>
+    <ID>ImplicitDefaultLocale:SerializationBenchmark.kt$SerializationBenchmark$String.format("%-15s %8dB %8dB", "Medium", mediumJson.length, mediumWire.length)</ID>
+    <ID>ImplicitDefaultLocale:SerializationBenchmark.kt$SerializationBenchmark$String.format("%-15s %8dB %8dB", "Small", smallJson.length, smallWire.length)</ID>
+    <ID>LongMethod:AuthServerConnection.kt$AuthServerConnection$@OptIn(ExperimentalCoroutinesApi::class) suspend fun awaitAuth(scope: CoroutineScope): AuthResult&lt;P&gt;</ID>
+    <ID>LongMethod:CounterScreen.kt$@Composable fun CounterScreen(viewModel: CounterViewModel = viewModel())</ID>
+    <ID>LongMethod:Main.kt$fun main()</ID>
+    <ID>LongMethod:Main.kt$fun main(args: Array&lt;String&gt;)</ID>
+    <ID>LongMethod:ResilienceStrategyTest.kt$ResilienceStrategyTest$@Test fun `retryWithBackoff jitter causes variation in delays across multiple runs`()</ID>
+    <ID>LongMethod:SerializationBenchmark.kt$SerializationBenchmark$fun runAll(): List&lt;BenchmarkResult&gt;</ID>
+    <ID>LongParameterList:CreateClientStore.kt$( initialState: S, syncMiddleware: SyncMiddleware&lt;S, A&gt;, additionalMiddlewares: List&lt;Middleware&lt;S, A&gt;&gt; = emptyList(), reducer: Reducer&lt;S, A&gt;, errorProcessor: ErrorProcessor&lt;A&gt; = DefaultErrorProcessor(), logger: StoreLogger&lt;S, A&gt; = NoOpStoreLogger(), scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default), concurrency: Int = 16, )</ID>
+    <ID>LongParameterList:CreateServerStore.kt$( initialState: S, syncMiddleware: Middleware&lt;S, A&gt;, additionalMiddlewares: List&lt;Middleware&lt;S, A&gt;&gt; = emptyList(), reducer: Reducer&lt;S, A&gt;, errorProcessor: ErrorProcessor&lt;A&gt; = DefaultErrorProcessor(), logger: StoreLogger&lt;S, A&gt; = NoOpStoreLogger(), scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default), concurrency: Int = 16, )</ID>
+    <ID>LongParameterList:ExecutionStrategy.kt$( maxAttempts: Int, initialDelay: Duration, maxDelay: Duration = Duration.INFINITE, factor: Double = 2.0, jitter: Double = 0.0, retryIf: (Throwable) -&gt; Boolean = { true }, )</ID>
+    <ID>LongParameterList:MultiClientStore.kt$( initialState: S, reducer: Reducer&lt;S, A&gt;, broadcaster: SessionBroadcaster&lt;A&gt;, processors: ActionProcessorMap&lt;S, A&gt; = emptyMap(), errorProcessor: ErrorProcessor&lt;A&gt; = DefaultErrorProcessor(), logger: StoreLogger&lt;S, A&gt; = NoOpStoreLogger(), scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default), )</ID>
+    <ID>LongParameterList:PerClientServer.kt$( initialStateFactory: (sessionId: String) -&gt; S, reducer: Reducer&lt;S, A&gt;, stateMapper: (S) -&gt; A, processors: ActionProcessorMap&lt;S, A&gt; = emptyMap(), errorProcessor: ErrorProcessor&lt;A&gt; = DefaultErrorProcessor(), logger: StoreLogger&lt;S, A&gt; = NoOpStoreLogger(), scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default), )</ID>
+    <ID>LongParameterList:RoomServer.kt$( initialStateFactory: (roomId: String) -&gt; S, reducer: Reducer&lt;S, A&gt;, stateMapper: (S) -&gt; A, processors: ActionProcessorMap&lt;S, A&gt; = emptyMap(), sessionRegistryFactory: () -&gt; SessionRegistry&lt;A&gt; = { InMemorySessionRegistry() }, broadcastConfig: BroadcastConfig = BroadcastConfig.Sequential, errorProcessor: ErrorProcessor&lt;A&gt; = DefaultErrorProcessor(), logger: StoreLogger&lt;S, A&gt; = NoOpStoreLogger(), scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default), )</ID>
+    <ID>LongParameterList:RoomServer.kt$( initialStateFactory: (roomId: String, sessionId: String) -&gt; S, reducer: Reducer&lt;S, A&gt;, stateMapper: (S) -&gt; A, processors: ActionProcessorMap&lt;S, A&gt; = emptyMap(), errorProcessor: ErrorProcessor&lt;A&gt; = DefaultErrorProcessor(), logger: StoreLogger&lt;S, A&gt; = NoOpStoreLogger(), scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default), )</ID>
+    <ID>LongParameterList:SharedStateServer.kt$( initialState: S, reducer: Reducer&lt;S, A&gt;, sessionStateMapper: (S, String) -&gt; A?, processors: ActionProcessorMap&lt;S, A&gt; = emptyMap(), sessionRegistry: SessionRegistry&lt;A&gt; = InMemorySessionRegistry(), broadcastConfig: BroadcastConfig = BroadcastConfig.Sequential, errorProcessor: ErrorProcessor&lt;A&gt; = DefaultErrorProcessor(), logger: StoreLogger&lt;S, A&gt; = NoOpStoreLogger(), scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default), )</ID>
+    <ID>LongParameterList:SharedStateServer.kt$( initialState: S, reducer: Reducer&lt;S, A&gt;, stateMapper: (S) -&gt; A, processors: ActionProcessorMap&lt;S, A&gt; = emptyMap(), sessionRegistry: SessionRegistry&lt;A&gt; = InMemorySessionRegistry(), broadcastConfig: BroadcastConfig = BroadcastConfig.Sequential, errorProcessor: ErrorProcessor&lt;A&gt; = DefaultErrorProcessor(), logger: StoreLogger&lt;S, A&gt; = NoOpStoreLogger(), scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default), )</ID>
+    <ID>LongParameterList:SingleClientServer.kt$( initialState: S, reducer: Reducer&lt;S, A&gt;, connection: TypedServerConnection&lt;A&gt;, processors: ActionProcessorMap&lt;S, A&gt; = emptyMap(), errorProcessor: ErrorProcessor&lt;A&gt; = DefaultErrorProcessor(), logger: StoreLogger&lt;S, A&gt; = NoOpStoreLogger(), scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default), )</ID>
+    <ID>LongParameterList:Store.kt$( initialState: S, middlewares: List&lt;Middleware&lt;S, A&gt;&gt; = emptyList(), reducer: Reducer&lt;S, A&gt;, errorProcessor: ErrorProcessor&lt;A&gt; = DefaultErrorProcessor(), logger: StoreLogger&lt;S, A&gt; = NoOpStoreLogger(), scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default), concurrency: Int = DEFAULT_CONCURRENCY, )</ID>
+    <ID>LongParameterList:TimeTravelStore.kt$( initialHistory: List&lt;StateSnapshot&lt;S, A&gt;&gt;, reducer: Reducer&lt;S, A&gt;, middlewares: List&lt;Middleware&lt;S, A&gt;&gt; = emptyList(), errorProcessor: ErrorProcessor&lt;A&gt; = DefaultErrorProcessor(), maxHistorySize: Int = 100, scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default), )</ID>
+    <ID>LongParameterList:TimeTravelStore.kt$( initialState: S, reducer: Reducer&lt;S, A&gt;, middlewares: List&lt;Middleware&lt;S, A&gt;&gt; = emptyList(), errorProcessor: ErrorProcessor&lt;A&gt; = DefaultErrorProcessor(), maxHistorySize: Int = 100, scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default), )</ID>
+    <ID>LongParameterList:TimeTravelStore.kt$( initialState: S?, initialHistory: List&lt;StateSnapshot&lt;S, A&gt;&gt;?, reducer: Reducer&lt;S, A&gt;, middlewares: List&lt;Middleware&lt;S, A&gt;&gt;, errorProcessor: ErrorProcessor&lt;A&gt;, maxHistorySize: Int, scope: CoroutineScope, )</ID>
+    <ID>LoopWithTooManyJumpStatements:Main.kt$while</ID>
+    <ID>MatchingDeclarationName:FlowUtils.kt$MainScope : CoroutineScope</ID>
+    <ID>MatchingDeclarationName:RemoteMessage.kt$ServerResponse</ID>
+    <ID>MaxLineLength:FlowHolderActionTest.kt$FlowHolderActionTest$"Default Emit delivery should bypass user middlewares, but found inner actions: $innerActionsInMiddleware"</ID>
+    <ID>MaxLineLength:Main.kt$" Now at index ${timeTravelStore.currentIndex}, canUndo=${timeTravelStore.canUndo}, canRedo=${timeTravelStore.canRedo}"</ID>
+    <ID>MaxLineLength:Main.kt$" [$userId] devices=${state.connectedDevices}, notes=${state.notes.size}, edits=${state.totalEdits}"</ID>
+    <ID>MaxLineLength:SerializationBenchmark.kt$SerializationBenchmark.BenchActionCodec$"""{"type":"Large","userId":"${action.userId}","items":[$items],"scores":[$scores],"nested":"${action.nested}"}"""</ID>
+    <ID>MaxLineLength:SerializationBenchmark.kt$SerializationBenchmark.BenchActionCodec$"""{"type":"Medium","userId":"${action.userId}","message":"${action.message}","timestamp":${action.timestamp},"metadata":"${action.metadata}"}"""</ID>
+    <ID>RethrowCaughtException:ExecutionStrategy.kt$TakeLatest$throw e</ID>
+    <ID>ReturnCount:AuthClientConnection.kt$AuthClientConnection$private suspend fun tryRefresh(): Boolean</ID>
+    <ID>ThrowsCount:NodeMediator.kt$NodeMediator$private fun startRouting()</ID>
+    <ID>ThrowsCount:ServerConnectionMultiplexer.kt$ServerConnectionMultiplexer$private fun startRouting()</ID>
+    <ID>TooGenericExceptionThrown:AuthClientConnectionTest.kt$AuthClientConnectionTest$throw RuntimeException("Refresh server down")</ID>
+    <ID>TooGenericExceptionThrown:AuthResultTest.kt$AuthResultTest$throw RuntimeException("stop")</ID>
+    <ID>TooGenericExceptionThrown:CentralNodeManagerTest.kt$CentralNodeManagerTest$throw RuntimeException("callback error")</ID>
+    <ID>TooGenericExceptionThrown:CentralNodeManagerTest.kt$CentralNodeManagerTest.&lt;no name provided&gt;$throw RuntimeException("send failed")</ID>
+    <ID>TooGenericExceptionThrown:ConcurrencyStrategyTest.kt$ConcurrencyStrategyTest.SequentialTests.&lt;no name provided&gt;$throw RuntimeException("Action 2 fails")</ID>
+    <ID>TooGenericExceptionThrown:DefaultTypedConnectionTest.kt$DefaultTypedConnectionTest.FailingActionCodec$throw RuntimeException("decode failed")</ID>
+    <ID>TooGenericExceptionThrown:DefaultTypedConnectionTest.kt$DefaultTypedConnectionTest.FailingActionCodec$throw RuntimeException("encode failed")</ID>
+    <ID>TooGenericExceptionThrown:DefaultTypedConnectionTest.kt$DefaultTypedConnectionTest.FailingMessageCodec$throw RuntimeException("message decode failed")</ID>
+    <ID>TooGenericExceptionThrown:DefaultTypedConnectionTest.kt$DefaultTypedConnectionTest.FailingMessageCodec$throw RuntimeException("server message decode failed")</ID>
+    <ID>TooGenericExceptionThrown:ErrorHandlingTest.kt$ErrorHandlingTest$throw RuntimeException("Immediate error!")</ID>
+    <ID>TooGenericExceptionThrown:ErrorHandlingTest.kt$ErrorHandlingTest$throw RuntimeException("Negative value error!")</ID>
+    <ID>TooGenericExceptionThrown:ErrorHandlingTest.kt$ErrorHandlingTest.&lt;no name provided&gt;$throw RuntimeException("Failed!")</ID>
+    <ID>TooGenericExceptionThrown:ErrorHandlingTest.kt$ErrorHandlingTest.&lt;no name provided&gt;$throw RuntimeException("IO Exception!")</ID>
+    <ID>TooGenericExceptionThrown:MultiClientSyncMiddlewareTest.kt$MultiClientSyncMiddlewareTest.&lt;no name provided&gt;$throw RuntimeException("Connection failed")</ID>
+    <ID>TooGenericExceptionThrown:NodeMediatorTest.kt$NodeMediatorTest$throw RuntimeException("event callback error")</ID>
+    <ID>TooGenericExceptionThrown:NodeMediatorTest.kt$NodeMediatorTest$throw RuntimeException("handler error")</ID>
+    <ID>TooGenericExceptionThrown:NodeMediatorTest.kt$NodeMediatorTest$throw RuntimeException("unknown room callback error")</ID>
+    <ID>TooGenericExceptionThrown:NodeMediatorTest.kt$NodeMediatorTest.&lt;no name provided&gt;$throw RuntimeException("transport error")</ID>
+    <ID>TooGenericExceptionThrown:NodeRoomServerTest.kt$NodeRoomServerTest.&lt;no name provided&gt;$throw RuntimeException("Central unreachable")</ID>
+    <ID>TooGenericExceptionThrown:ResilienceStrategyTest.kt$ResilienceStrategyTest.&lt;no name provided&gt;$throw RuntimeException("Always fails")</ID>
+    <ID>TooGenericExceptionThrown:ResilienceStrategyTest.kt$ResilienceStrategyTest.&lt;no name provided&gt;$throw RuntimeException("Simulated failure $attempt")</ID>
+    <ID>TooGenericExceptionThrown:ServerConnectionMultiplexerTest.kt$ServerConnectionMultiplexerTest$throw RuntimeException("callback error")</ID>
+    <ID>TooGenericExceptionThrown:SessionAwareSharedStateServerTest.kt$SessionAwareSharedStateServerTest.&lt;no name provided&gt;$throw RuntimeException("Connection failed")</ID>
+    <ID>TooGenericExceptionThrown:SessionBroadcasterTest.kt$SessionBroadcasterTest.&lt;no name provided&gt;$throw RuntimeException("Connection $id failed")</ID>
+    <ID>TooGenericExceptionThrown:StoreLoggerTest.kt$StoreLoggerTest.&lt;no name provided&gt;$throw RuntimeException("test error")</ID>
+    <ID>TooGenericExceptionThrown:StrategyChainingTest.kt$StrategyChainingTest.ChainedExecutionTests.&lt;no name provided&gt;$throw RuntimeException("First attempt fails")</ID>
+    <ID>TooGenericExceptionThrown:StrategyGroupTest.kt$StrategyGroupTest.&lt;no name provided&gt;$throw RuntimeException("Simulated failure $count")</ID>
+    <ID>TooGenericExceptionThrown:SyncMiddlewareTest.kt$SyncMiddlewareTest.&lt;no name provided&gt;$throw RuntimeException("Connection failed")</ID>
+    <ID>TooGenericExceptionThrown:TestFixtures.kt$throw RuntimeException("JWT decode failed")</ID>
+    <ID>UnusedPrivateProperty:KtorWebSocketServerConnectionTest.kt$KtorWebSocketServerConnectionTest$frame</ID>
+    <ID>UnusedPrivateProperty:NodeMediator.kt$NodeMediator$private val nodeId: String</ID>
+    <ID>UnusedPrivateProperty:build.gradle.kts$val jsMain by getting { dependencies { implementation(project(":kotlin:flowdux")) implementation(libs.kotlinx.coroutines.core) } }</ID>
+    <ID>UnusedPrivateProperty:build.gradle.kts$val wasmJsMain by getting { dependencies { implementation(project(":kotlin:flowdux")) implementation(libs.kotlinx.coroutines.core) implementation(libs.kotlinx.browser) } }</ID>
+    <ID>UseCheckOrError:KtorWebSocketClientConnection.kt$KtorWebSocketClientConnection$throw IllegalStateException("Cannot send message: WebSocket connection was closed")</ID>
+    <ID>UseCheckOrError:KtorWebSocketClientConnection.kt$KtorWebSocketClientConnection$throw IllegalStateException("Cannot send message: WebSocket is not connected")</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/detekt.yml
+++ b/detekt.yml
@@ -1,0 +1,50 @@
+build:
+  maxIssues: 0
+
+complexity:
+  LongMethod:
+    active: true
+    threshold: 60
+  LongParameterList:
+    active: true
+    functionThreshold: 6
+    constructorThreshold: 8
+  TooManyFunctions:
+    active: true
+    thresholdInFiles: 30
+    thresholdInClasses: 30
+    thresholdInInterfaces: 15
+
+style:
+  MagicNumber:
+    active: false
+  WildcardImport:
+    active: false
+  MaxLineLength:
+    active: true
+    maxLineLength: 120
+    excludeCommentStatements: true
+  ForbiddenComment:
+    active: false
+  ReturnCount:
+    active: true
+    max: 5
+
+naming:
+  FunctionNaming:
+    active: true
+    ignoreAnnotated:
+      - 'Composable'
+
+exceptions:
+  TooGenericExceptionCaught:
+    active: true
+    exceptionNames:
+      - 'ArrayIndexOutOfBoundsException'
+      - 'Error'
+      - 'IllegalMonitorStateException'
+      - 'IndexOutOfBoundsException'
+      - 'NullPointerException'
+      - 'RuntimeException'
+  TooGenericExceptionThrown:
+    active: true

--- a/docs/dev/git-workflow.md
+++ b/docs/dev/git-workflow.md
@@ -24,7 +24,22 @@ gh auth switch -u chibimoons  # 아니면 전환
 | 작업 유형 | 타겟 브랜치 |
 |----------|------------|
 | feature, fix, docs (일반) | `develop` |
-| release, hotfix, docs (main 직접 반영) | `main` |
+| release, docs (main 직접 반영) | `main` |
+| hotfix | `main` + `develop` (양쪽 모두) |
+
+## 핫픽스 프로세스
+
+1. `origin/main`에서 `hotfix/{short-description}` 브랜치 생성
+2. 수정 → 커밋
+3. `main`으로 PR 생성 → CI 통과 → 머지
+4. **같은 브랜치**에서 `develop`으로도 PR 생성 → 머지
+5. 필요 시 패치 태그 생성 (e.g. `1.17.1`)
+
+```
+hotfix/xxx
+  ├── PR → main   (긴급 수정 반영)
+  └── PR → develop (develop에도 동기화)
+```
 
 ## 릴리즈 프로세스
 

--- a/docs/dev/git-workflow.md
+++ b/docs/dev/git-workflow.md
@@ -71,3 +71,37 @@ Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
 EOF
 )"
 ```
+
+## Git Hooks 설정
+
+프로젝트에 코드 품질을 강제하는 git hooks가 포함되어 있다.
+
+### 설치 (1회)
+
+```bash
+make setup
+# 또는 직접: git config core.hooksPath .githooks
+```
+
+### Hook 목록
+
+| Hook | 시점 | 검증 내용 |
+|------|------|----------|
+| `pre-commit` | 커밋 전 | `.kt`/`.kts` 파일이 staged 시 `spotlessCheck` 실행 |
+| `commit-msg` | 커밋 메시지 작성 후 | Conventional Commits 형식 검증 |
+| `pre-push` | 푸시 전 | `detekt` + `compileKotlinJvm` 실행 |
+
+### 유용한 명령어
+
+```bash
+make lint      # spotlessCheck + detekt
+make format    # spotlessApply (자동 포맷팅)
+```
+
+### 포맷팅 실패 시
+
+```bash
+./gradlew spotlessApply   # 자동 수정
+git add -u                # 수정된 파일 재스테이지
+git commit                # 다시 커밋
+```

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,0 +1,289 @@
+# Getting Started
+
+FlowDux 시작 가이드입니다. 기본 Store 생성부터 Middleware, Remote 동기화까지 단계별로 안내합니다.
+
+## 1. 설치
+
+### Kotlin Multiplatform (Maven Central)
+
+`build.gradle.kts`에 의존성을 추가합니다:
+
+```kotlin
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            implementation("io.github.chibimoons:flowdux:1.17.0")
+        }
+    }
+}
+```
+
+Gradle이 각 타겟(JVM, iOS, JS, WASM)에 맞는 아티팩트를 자동으로 해석합니다.
+
+### 단일 플랫폼 (JVM / Android)
+
+KMP가 아닌 프로젝트에서는 직접 추가합니다:
+
+```kotlin
+dependencies {
+    implementation("io.github.chibimoons:flowdux:1.17.0")
+}
+```
+
+## 2. 첫 번째 Store 만들기
+
+FlowDux의 핵심 개념 세 가지: **State**, **Action**, **Reducer**.
+
+### State 정의
+
+State는 앱의 현재 상태를 나타내는 불변 데이터 클래스입니다:
+
+```kotlin
+import io.flowdux.State
+
+data class CounterState(val count: Int = 0) : State
+```
+
+### Action 정의
+
+Action은 상태 변경 요청입니다. `sealed interface`로 정의하면 타입 안전성을 보장합니다:
+
+```kotlin
+import io.flowdux.Action
+
+sealed interface CounterAction : Action {
+    object Increment : CounterAction
+    object Decrement : CounterAction
+    data class Add(val value: Int) : CounterAction
+}
+```
+
+### Reducer 정의
+
+Reducer는 현재 State와 Action을 받아 새로운 State를 반환하는 순수 함수입니다:
+
+```kotlin
+import io.flowdux.buildReducer
+
+val counterReducer = buildReducer<CounterState, CounterAction> {
+    on<CounterAction.Increment> { state, _ ->
+        state.copy(count = state.count + 1)
+    }
+    on<CounterAction.Decrement> { state, _ ->
+        state.copy(count = state.count - 1)
+    }
+    on<CounterAction.Add> { state, action ->
+        state.copy(count = state.count + action.value)
+    }
+}
+```
+
+> 등록되지 않은 Action은 자동으로 현재 State를 그대로 반환합니다.
+
+### Store 생성 및 사용
+
+```kotlin
+import io.flowdux.createStore
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+
+fun main() = runBlocking {
+    val store = createStore(
+        initialState = CounterState(),
+        reducer = counterReducer,
+    )
+
+    // 상태 관찰
+    println("초기: ${store.currentState}")  // CounterState(count=0)
+
+    // 액션 디스패치
+    store.dispatch(CounterAction.Increment)
+    store.state.first { it.count == 1 }
+    println("증가: ${store.currentState}")  // CounterState(count=1)
+
+    store.dispatch(CounterAction.Add(10))
+    store.state.first { it.count == 11 }
+    println("추가: ${store.currentState}")  // CounterState(count=11)
+
+    store.close()
+}
+```
+
+**핵심 API:**
+- `store.currentState` — 현재 상태 동기적 접근
+- `store.state` — `StateFlow<State>`로 반응형 관찰
+- `store.dispatch(action)` — 액션 전송
+- `store.close()` — 리소스 해제
+
+## 3. Middleware 추가
+
+Middleware는 API 호출, 로깅 같은 사이드 이펙트를 처리합니다. Action이 Reducer에 도달하기 전에 가로채서 변환, 필터, 또는 새 Action을 발행할 수 있습니다.
+
+```kotlin
+import io.flowdux.Middleware
+
+class LoggingMiddleware : Middleware<CounterState, CounterAction> {
+    override val processors = buildProcessors {
+        on<CounterAction.Increment> { state, action ->
+            println("  [LOG] Increment 수신 (현재: ${state.count})")
+            emit(action)  // 다음 단계로 전달
+        }
+    }
+}
+```
+
+**Middleware 동작 규칙:**
+- `emit(action)` — 다음 단계로 액션을 전달
+- `emit(otherAction)` — 다른 액션으로 변환
+- 아무것도 emit하지 않으면 — 액션을 차단
+- 여러 번 emit하면 — 하나의 액션을 여러 개로 분리
+
+등록되지 않은 Action 타입은 자동으로 통과(pass-through)합니다.
+
+### Middleware를 Store에 등록
+
+```kotlin
+val store = createStore(
+    initialState = CounterState(),
+    reducer = counterReducer,
+    middlewares = listOf(LoggingMiddleware()),
+)
+```
+
+### 비동기 API 호출 예제
+
+```kotlin
+sealed interface TodoAction : Action {
+    object LoadTodos : TodoAction
+    data class TodosLoaded(val items: List<String>) : TodoAction
+    data class LoadFailed(val error: String) : TodoAction
+}
+
+class TodoMiddleware : Middleware<TodoState, TodoAction> {
+    override val processors = buildProcessors {
+        on<TodoAction.LoadTodos> { _, _ ->
+            try {
+                val todos = api.fetchTodos()  // suspend 함수 직접 호출 가능
+                emit(TodoAction.TodosLoaded(todos))
+            } catch (e: Exception) {
+                emit(TodoAction.LoadFailed(e.message ?: "Unknown error"))
+            }
+        }
+    }
+}
+```
+
+### Execution Strategy
+
+동시성 제어가 필요한 경우 전략을 지정합니다:
+
+```kotlin
+override val processors = buildProcessors {
+    // 이전 검색을 취소하고 최신 검색만 실행
+    on<SearchAction>(takeLatest()) { _, action ->
+        val results = api.search(action.query)
+        emit(SearchResult(results))
+    }
+
+    // 200ms 동안 입력이 없을 때만 실행
+    on<TypeAhead>(debounce(200.milliseconds)) { _, action ->
+        emit(SuggestionsLoaded(api.suggest(action.text)))
+    }
+
+    // 처리 중에는 추가 요청 무시
+    on<SubmitForm>(takeLeading()) { _, _ ->
+        api.submit()
+        emit(SubmitSuccess)
+    }
+}
+```
+
+사용 가능한 전략: `takeLatest()`, `takeLeading()`, `sequential()`, `debounce(duration)`, `throttle(duration)`, `retry(n)`, `retryWithBackoff(...)`
+
+전략은 체이닝도 가능합니다: `debounce(300.ms) then takeLatest() then retry(3)`
+
+> 자세한 내용은 [Execution Strategies](execution-strategies.md) 가이드를 참고하세요.
+
+## 4. Remote 동기화 (기초)
+
+FlowDux Remote를 사용하면 클라이언트와 서버 간 실시간 상태 동기화를 구현할 수 있습니다.
+
+### 추가 의존성
+
+```kotlin
+commonMain.dependencies {
+    implementation("io.github.chibimoons:flowdux:1.17.0")
+    implementation("io.github.chibimoons:flowdux-remote-core:1.17.0")
+    implementation("io.github.chibimoons:flowdux-remote-client:1.17.0")
+    implementation("io.github.chibimoons:flowdux-remote-server:1.17.0")
+    implementation("io.github.chibimoons:flowdux-remote-serialization:1.17.0")
+    implementation("io.github.chibimoons:flowdux-remote-ktor:1.17.0")
+}
+```
+
+### Shared Action 정의
+
+`ServerSharedAction`은 클라이언트에서 서버로, `ClientSharedAction`은 서버에서 클라이언트로 전송됩니다:
+
+```kotlin
+import io.flowdux.remote.ServerSharedAction
+import io.flowdux.remote.ClientSharedAction
+import kotlinx.serialization.Serializable
+
+@Serializable
+sealed interface ChatAction : Action {
+    // Client → Server
+    @Serializable
+    data class SendMessage(val text: String) : ChatAction, ServerSharedAction
+
+    // Server → Client
+    @Serializable
+    data class MessageReceived(val text: String, val sender: String) : ChatAction, ClientSharedAction
+
+    // Local only (전송되지 않음)
+    data class SetInput(val text: String) : ChatAction
+}
+```
+
+### 동작 흐름
+
+```
+Client                          Server
+  │                               │
+  ├─ dispatch(SendMessage) ──────►│ SyncMiddleware가 ServerSharedAction을 감지하여 전송
+  │                               ├─ Reducer가 상태 업데이트
+  │                               ├─ dispatch(MessageReceived)
+  │◄── ClientSharedAction ────────┤ SingleClientSyncMiddleware가 클라이언트에 전송
+  ├─ Reducer가 상태 업데이트       │
+```
+
+> 전체 설정 및 서버 패턴은 [Remote State Sync](remote.md) 가이드를 참고하세요.
+
+## 5. 다음 단계
+
+### 핵심 가이드
+
+| 가이드 | 설명 |
+|--------|------|
+| [Architecture](architecture.md) | Store 파이프라인, 액션 흐름, 컴포넌트 역할 |
+| [Execution Strategies](execution-strategies.md) | 동시성 전략 (takeLatest, debounce, retry 등) |
+| [Time Travel](timetravel.md) | Undo/Redo, 상태 히스토리 디버깅 |
+
+### Remote 가이드
+
+| 가이드 | 설명 |
+|--------|------|
+| [Remote State Sync](remote.md) | WebSocket 기반 클라이언트-서버 설정 |
+| [Server Patterns](server-patterns.md) | 4가지 서버 패턴 비교 및 선택 가이드 |
+| [Authentication](remote-authentication.md) | WebSocket 인증 연동 |
+| [Scaling](scaling.md) | 대규모 동시 연결 처리 |
+
+### 샘플 앱
+
+| 샘플 | 설명 |
+|------|------|
+| [JVM Console](samples.md#jvm-console-sample) | 핵심 기능 데모 (Store, Middleware, Strategy) |
+| [Remote Simple](samples.md#remote-simple-sample) | 1:1 WebSocket 클라이언트-서버 |
+| [Remote Multi-Client](samples.md#remote-multi-client-sample) | N 클라이언트가 하나의 Store 공유 |
+
+전체 샘플 목록은 [Sample Apps](samples.md)를 참고하세요.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -12,7 +12,7 @@ FlowDux 시작 가이드입니다. 기본 Store 생성부터 Middleware, Remote 
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            implementation("io.github.chibimoons:flowdux:1.17.0")
+            implementation("io.github.chibimoons:flowdux:1.18.0")
         }
     }
 }
@@ -26,7 +26,7 @@ KMP가 아닌 프로젝트에서는 직접 추가합니다:
 
 ```kotlin
 dependencies {
-    implementation("io.github.chibimoons:flowdux:1.17.0")
+    implementation("io.github.chibimoons:flowdux:1.18.0")
 }
 ```
 
@@ -212,12 +212,12 @@ FlowDux Remote를 사용하면 클라이언트와 서버 간 실시간 상태 �
 
 ```kotlin
 commonMain.dependencies {
-    implementation("io.github.chibimoons:flowdux:1.17.0")
-    implementation("io.github.chibimoons:flowdux-remote-core:1.17.0")
-    implementation("io.github.chibimoons:flowdux-remote-client:1.17.0")
-    implementation("io.github.chibimoons:flowdux-remote-server:1.17.0")
-    implementation("io.github.chibimoons:flowdux-remote-serialization:1.17.0")
-    implementation("io.github.chibimoons:flowdux-remote-ktor:1.17.0")
+    implementation("io.github.chibimoons:flowdux:1.18.0")
+    implementation("io.github.chibimoons:flowdux-remote-core:1.18.0")
+    implementation("io.github.chibimoons:flowdux-remote-client:1.18.0")
+    implementation("io.github.chibimoons:flowdux-remote-server:1.18.0")
+    implementation("io.github.chibimoons:flowdux-remote-serialization:1.18.0")
+    implementation("io.github.chibimoons:flowdux-remote-ktor:1.18.0")
 }
 ```
 

--- a/docs/guide/remote.md
+++ b/docs/guide/remote.md
@@ -55,6 +55,17 @@ kotlin {
 }
 ```
 
+> **WASM not supported**: `flowdux-remote-ktor` uses Ktor's WebSocket client, which does not support WASM targets. If your project targets WASM, implement `ClientConnection` / `ServerConnection` with a WASM-compatible WebSocket library and use `flowdux-remote-client` / `flowdux-remote-server` directly without the Ktor transport module.
+
+### Platform Support (flowdux-remote-ktor)
+
+| Platform | Status |
+|----------|--------|
+| JVM | Supported |
+| iOS | Supported |
+| JS | Supported |
+| WASM | Not supported (Ktor client unavailable) |
+
 ## Version Compatibility
 
 FlowDux remote modules require matching Kotlin and serialization versions:

--- a/docs/guide/remote.md
+++ b/docs/guide/remote.md
@@ -39,17 +39,17 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             // Shared action markers (ServerSharedAction, ClientSharedAction)
-            implementation("io.github.chibimoons:flowdux-remote-core:1.17.0")
+            implementation("io.github.chibimoons:flowdux-remote-core:1.18.0")
             // Client middleware (SyncMiddleware)
-            implementation("io.github.chibimoons:flowdux-remote-client:1.17.0")
+            implementation("io.github.chibimoons:flowdux-remote-client:1.18.0")
             // Server middleware (SingleClientSyncMiddleware, MultiClientSyncMiddleware)
-            implementation("io.github.chibimoons:flowdux-remote-server:1.17.0")
+            implementation("io.github.chibimoons:flowdux-remote-server:1.18.0")
             // kotlinx.serialization codecs (ActionCodec, MessageCodec)
-            implementation("io.github.chibimoons:flowdux-remote-serialization:1.17.0")
+            implementation("io.github.chibimoons:flowdux-remote-serialization:1.18.0")
             // Ktor WebSocket transport (JVM, iOS, JS — WASM not supported)
-            implementation("io.github.chibimoons:flowdux-remote-ktor:1.17.0")
+            implementation("io.github.chibimoons:flowdux-remote-ktor:1.18.0")
             // Optional: In-band WebSocket authentication
-            implementation("io.github.chibimoons:flowdux-remote-auth:1.17.0")
+            implementation("io.github.chibimoons:flowdux-remote-auth:1.18.0")
         }
     }
 }

--- a/docs/guide/remote.md
+++ b/docs/guide/remote.md
@@ -39,17 +39,17 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             // Shared action markers (ServerSharedAction, ClientSharedAction)
-            implementation("io.github.chibimoons:flowdux-remote-core:1.16.0")
+            implementation("io.github.chibimoons:flowdux-remote-core:1.17.0")
             // Client middleware (SyncMiddleware)
-            implementation("io.github.chibimoons:flowdux-remote-client:1.16.0")
+            implementation("io.github.chibimoons:flowdux-remote-client:1.17.0")
             // Server middleware (SingleClientSyncMiddleware, MultiClientSyncMiddleware)
-            implementation("io.github.chibimoons:flowdux-remote-server:1.16.0")
+            implementation("io.github.chibimoons:flowdux-remote-server:1.17.0")
             // kotlinx.serialization codecs (ActionCodec, MessageCodec)
-            implementation("io.github.chibimoons:flowdux-remote-serialization:1.16.0")
+            implementation("io.github.chibimoons:flowdux-remote-serialization:1.17.0")
             // Ktor WebSocket transport (JVM, iOS, JS — WASM not supported)
-            implementation("io.github.chibimoons:flowdux-remote-ktor:1.16.0")
+            implementation("io.github.chibimoons:flowdux-remote-ktor:1.17.0")
             // Optional: In-band WebSocket authentication
-            implementation("io.github.chibimoons:flowdux-remote-auth:1.16.0")
+            implementation("io.github.chibimoons:flowdux-remote-auth:1.17.0")
         }
     }
 }

--- a/docs/guide/timetravel.md
+++ b/docs/guide/timetravel.md
@@ -9,14 +9,14 @@ Time travel debugging is available as a separate module.
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            implementation("io.github.chibimoons:flowdux-timetravel:1.17.0")
+            implementation("io.github.chibimoons:flowdux-timetravel:1.18.0")
         }
     }
 }
 
 // build.gradle.kts (JVM / Android)
 dependencies {
-    implementation("io.github.chibimoons:flowdux-timetravel:1.17.0")
+    implementation("io.github.chibimoons:flowdux-timetravel:1.18.0")
 }
 ```
 

--- a/docs/guide/timetravel.md
+++ b/docs/guide/timetravel.md
@@ -9,14 +9,14 @@ Time travel debugging is available as a separate module.
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            implementation("io.github.chibimoons:flowdux-timetravel:1.16.0")
+            implementation("io.github.chibimoons:flowdux-timetravel:1.17.0")
         }
     }
 }
 
 // build.gradle.kts (JVM / Android)
 dependencies {
-    implementation("io.github.chibimoons:flowdux-timetravel:1.16.0")
+    implementation("io.github.chibimoons:flowdux-timetravel:1.17.0")
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,4 +17,4 @@ android.r8.optimizedResourceShrinking=false
 android.builtInKotlin=false
 android.newDsl=false
 
-flowdux.version=1.16.0
+flowdux.version=1.17.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,4 +17,4 @@ android.r8.optimizedResourceShrinking=false
 android.builtInKotlin=false
 android.newDsl=false
 
-flowdux.version=1.17.0
+flowdux.version=1.18.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 org.gradle.jvmargs=-Xmx4096m -XX:+HeapDumpOnOutOfMemoryError
-org.gradle.configuration-cache=false
+org.gradle.configuration-cache=true
 
 kotlin.code.style=official
 kotlin.mpp.androidSourceSetLayoutVersion=2

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,6 +41,9 @@ ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "kto
 ktor-client-js = { module = "io.ktor:ktor-client-js", version.ref = "ktor" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
 kotlinx-browser = { module = "org.jetbrains.kotlinx:kotlinx-browser", version.ref = "kotlinx-browser" }
+# Gradle plugin artifacts (for build-logic convention plugins)
+maven-publish-gradle-plugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "mavenPublish" }
+kover-gradle-plugin = { module = "org.jetbrains.kotlinx:kover-gradle-plugin", version.ref = "kover" }
 
 [plugins]
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+kover = "0.9.1"
 mavenPublish = "0.36.0"
 kotlin = "2.2.10"
 coroutines = "1.10.2"
@@ -49,4 +50,5 @@ androidApplication = { id = "com.android.application", version.ref = "agp" }
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
 kotlinCompose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,8 @@
 [versions]
+detekt = "1.23.7"
 kover = "0.9.1"
 mavenPublish = "0.36.0"
+spotless = "7.0.2"
 kotlin = "2.2.10"
 coroutines = "1.10.2"
 datetime = "0.5.0"
@@ -42,10 +44,12 @@ ktor-client-js = { module = "io.ktor:ktor-client-js", version.ref = "ktor" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
 kotlinx-browser = { module = "org.jetbrains.kotlinx:kotlinx-browser", version.ref = "kotlinx-browser" }
 # Gradle plugin artifacts (for build-logic convention plugins)
+detekt-gradle-plugin = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt" }
 maven-publish-gradle-plugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "mavenPublish" }
 kover-gradle-plugin = { module = "org.jetbrains.kotlinx:kover-gradle-plugin", version.ref = "kover" }
 
 [plugins]
+detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
@@ -55,3 +59,4 @@ kotlinCompose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kot
 kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish" }
+spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -17,5 +17,8 @@ install:
     :kotlin:flowdux-remote-server:publishToMavenLocal
     :kotlin:flowdux-remote-serialization:publishToMavenLocal
     :kotlin:flowdux-remote-ktor:publishToMavenLocal
+    :kotlin:flowdux-remote-auth:publishToMavenLocal
+    :kotlin:flowdux-remote-multiplexer:publishToMavenLocal
+    :kotlin:flowdux-remote-node-mediator:publishToMavenLocal
     -x kotlinNpmInstall -x kotlinStoreYarnLock
     -x jsTest -x wasmJsTest -x iosX64Test -x iosSimulatorArm64Test

--- a/kotlin/benchmark/src/main/kotlin/io/flowdux/benchmark/BenchmarkConfig.kt
+++ b/kotlin/benchmark/src/main/kotlin/io/flowdux/benchmark/BenchmarkConfig.kt
@@ -6,19 +6,14 @@ package io.flowdux.benchmark
 data class BenchmarkConfig(
     /** Number of warmup iterations before measuring */
     val warmupIterations: Int = 1000,
-
     /** Number of actions to dispatch per benchmark */
     val actionsPerBenchmark: Int = 10_000,
-
     /** Number of times to repeat each benchmark for averaging */
     val repeatCount: Int = 5,
-
     /** Number of concurrent dispatchers for concurrency test */
     val concurrentDispatchers: Int = 10,
-
     /** Number of middlewares to add for middleware overhead test */
     val middlewareCount: Int = 5,
-
     /** Target tick rate for game server simulation (ticks per second) */
     val targetTickRate: Int = 60,
 )

--- a/kotlin/benchmark/src/main/kotlin/io/flowdux/benchmark/BenchmarkResult.kt
+++ b/kotlin/benchmark/src/main/kotlin/io/flowdux/benchmark/BenchmarkResult.kt
@@ -18,7 +18,8 @@ data class BenchmarkResult(
     val throughput: Double, // actions per second
 ) {
     fun print() {
-        println("""
+        println(
+            """
             |
             |=== $name ===
             |  Total Actions:  $totalActions
@@ -37,7 +38,8 @@ data class BenchmarkResult(
             |    Can sustain 60 FPS:  ${if (canSustain60Fps()) "YES ✅" else "NO ❌"}
             |    Max sustainable FPS: ${String.format("%.1f", maxSustainableFps())}
             |    Actions per frame (60fps): ${String.format("%.1f", actionsPerFrame(60))}
-        """.trimMargin())
+            """.trimMargin(),
+        )
     }
 
     /** Check if average latency allows 60 FPS (16.67ms per frame) */
@@ -60,9 +62,7 @@ data class BenchmarkResult(
 /**
  * Summary of multiple benchmark runs.
  */
-data class BenchmarkSummary(
-    val results: List<BenchmarkResult>,
-) {
+data class BenchmarkSummary(val results: List<BenchmarkResult>) {
     fun print() {
         println("\n" + "=".repeat(60))
         println("FLOWDUX BENCHMARK SUMMARY")
@@ -76,13 +76,15 @@ data class BenchmarkSummary(
         println(String.format("%-30s %15s %15s %10s", "Benchmark", "Throughput", "Avg Latency", "60fps?"))
         println("-".repeat(70))
         results.forEach { r ->
-            println(String.format(
-                "%-30s %12.0f/s %15s %10s",
-                r.name.take(30),
-                r.throughput,
-                r.avgLatency,
-                if (r.canSustain60Fps()) "✅" else "❌"
-            ))
+            println(
+                String.format(
+                    "%-30s %12.0f/s %15s %10s",
+                    r.name.take(30),
+                    r.throughput,
+                    r.avgLatency,
+                    if (r.canSustain60Fps()) "✅" else "❌",
+                ),
+            )
         }
     }
 }

--- a/kotlin/benchmark/src/main/kotlin/io/flowdux/benchmark/FlowDuxBenchmark.kt
+++ b/kotlin/benchmark/src/main/kotlin/io/flowdux/benchmark/FlowDuxBenchmark.kt
@@ -16,15 +16,10 @@ import kotlin.time.measureTime
  * - Concurrent dispatch performance
  * - Middleware overhead
  */
-class FlowDuxBenchmark(
-    private val config: BenchmarkConfig = BenchmarkConfig(),
-) {
+class FlowDuxBenchmark(private val config: BenchmarkConfig = BenchmarkConfig()) {
     // -- Test Fixtures --
 
-    data class BenchState(
-        val counter: Int = 0,
-        val lastAction: String = "",
-    ) : State
+    data class BenchState(val counter: Int = 0, val lastAction: String = "") : State
 
     sealed interface BenchAction : Action {
         data class Increment(val amount: Int = 1) : BenchAction
@@ -36,11 +31,11 @@ class FlowDuxBenchmark(
         when (action) {
             is BenchAction.Increment -> state.copy(
                 counter = state.counter + action.amount,
-                lastAction = "Increment"
+                lastAction = "Increment",
             )
             is BenchAction.SetValue -> state.copy(
                 counter = action.value,
-                lastAction = "SetValue"
+                lastAction = "SetValue",
             )
             is BenchAction.Reset -> BenchState()
         }
@@ -53,9 +48,7 @@ class FlowDuxBenchmark(
     }
 
     /** Middleware that does some work (simulates real middleware) */
-    private class WorkingMiddleware(
-        private val workIterations: Int = 100
-    ) : Middleware<BenchState, BenchAction> {
+    private class WorkingMiddleware(private val workIterations: Int = 100) : Middleware<BenchState, BenchAction> {
         override val name = "Working"
         override val processors: ActionProcessorMap<BenchState, BenchAction> = emptyMap()
 
@@ -77,55 +70,45 @@ class FlowDuxBenchmark(
      * Benchmark 1: Baseline (No Middleware)
      * Measures raw dispatch-to-state performance without middleware.
      */
-    suspend fun benchmarkBaseline(): BenchmarkResult {
-        return runBenchmark(
-            name = "Baseline (No Middleware)",
-            middlewares = emptyList()
-        )
-    }
+    suspend fun benchmarkBaseline(): BenchmarkResult = runBenchmark(
+        name = "Baseline (No Middleware)",
+        middlewares = emptyList(),
+    )
 
     /**
      * Benchmark 2: With Pass-through Middlewares
      * Measures middleware chain overhead with minimal work.
      */
-    suspend fun benchmarkWithPassThroughMiddleware(): BenchmarkResult {
-        return runBenchmark(
-            name = "With ${config.middlewareCount} PassThrough Middlewares",
-            middlewares = List(config.middlewareCount) { PassThroughMiddleware() }
-        )
-    }
+    suspend fun benchmarkWithPassThroughMiddleware(): BenchmarkResult = runBenchmark(
+        name = "With ${config.middlewareCount} PassThrough Middlewares",
+        middlewares = List(config.middlewareCount) { PassThroughMiddleware() },
+    )
 
     /**
      * Benchmark 3: With Working Middlewares
      * Measures realistic middleware overhead.
      */
-    suspend fun benchmarkWithWorkingMiddleware(): BenchmarkResult {
-        return runBenchmark(
-            name = "With ${config.middlewareCount} Working Middlewares",
-            middlewares = List(config.middlewareCount) { WorkingMiddleware() }
-        )
-    }
+    suspend fun benchmarkWithWorkingMiddleware(): BenchmarkResult = runBenchmark(
+        name = "With ${config.middlewareCount} Working Middlewares",
+        middlewares = List(config.middlewareCount) { WorkingMiddleware() },
+    )
 
     /**
      * Benchmark 4: Concurrent Dispatches
      * Measures performance under concurrent dispatch load.
      */
-    suspend fun benchmarkConcurrentDispatch(): BenchmarkResult {
-        return runConcurrentBenchmark(
-            name = "Concurrent (${config.concurrentDispatchers} dispatchers)",
-            concurrency = config.concurrentDispatchers
-        )
-    }
+    suspend fun benchmarkConcurrentDispatch(): BenchmarkResult = runConcurrentBenchmark(
+        name = "Concurrent (${config.concurrentDispatchers} dispatchers)",
+        concurrency = config.concurrentDispatchers,
+    )
 
     /**
      * Benchmark 5: Game Server Simulation
      * Simulates game server tick with multiple actions per tick.
      */
-    suspend fun benchmarkGameServerSimulation(): BenchmarkResult {
-        return runGameServerBenchmark(
-            name = "Game Server Sim (${config.targetTickRate} tps)"
-        )
-    }
+    suspend fun benchmarkGameServerSimulation(): BenchmarkResult = runGameServerBenchmark(
+        name = "Game Server Sim (${config.targetTickRate} tps)",
+    )
 
     /**
      * Run all benchmarks and return summary.
@@ -203,10 +186,7 @@ class FlowDuxBenchmark(
         calculateResult(name, latencies)
     }
 
-    private suspend fun runConcurrentBenchmark(
-        name: String,
-        concurrency: Int,
-    ): BenchmarkResult = coroutineScope {
+    private suspend fun runConcurrentBenchmark(name: String, concurrency: Int): BenchmarkResult = coroutineScope {
         val latencies = mutableListOf<Duration>()
         val actionsPerDispatcher = config.actionsPerBenchmark / concurrency
 
@@ -250,9 +230,7 @@ class FlowDuxBenchmark(
         calculateResult(name, latencies)
     }
 
-    private suspend fun runGameServerBenchmark(
-        name: String,
-    ): BenchmarkResult = coroutineScope {
+    private suspend fun runGameServerBenchmark(name: String): BenchmarkResult = coroutineScope {
         val latencies = mutableListOf<Duration>()
         val tickDurationMs = 1000L / config.targetTickRate
         val actionsPerTick = 10 // Simulate 10 player actions per tick

--- a/kotlin/benchmark/src/main/kotlin/io/flowdux/benchmark/Main.kt
+++ b/kotlin/benchmark/src/main/kotlin/io/flowdux/benchmark/Main.kt
@@ -3,14 +3,15 @@ package io.flowdux.benchmark
 import kotlinx.coroutines.runBlocking
 
 fun main() = runBlocking {
-    val config = BenchmarkConfig(
-        warmupIterations = 1000,
-        actionsPerBenchmark = 10_000,
-        repeatCount = 3,
-        concurrentDispatchers = 10,
-        middlewareCount = 5,
-        targetTickRate = 60,
-    )
+    val config =
+        BenchmarkConfig(
+            warmupIterations = 1000,
+            actionsPerBenchmark = 10_000,
+            repeatCount = 3,
+            concurrentDispatchers = 10,
+            middlewareCount = 5,
+            targetTickRate = 60,
+        )
 
     // Store benchmarks
     val storeBenchmark = FlowDuxBenchmark(config)

--- a/kotlin/benchmark/src/main/kotlin/io/flowdux/benchmark/SerializationBenchmark.kt
+++ b/kotlin/benchmark/src/main/kotlin/io/flowdux/benchmark/SerializationBenchmark.kt
@@ -3,11 +3,10 @@ package io.flowdux.benchmark
 import io.flowdux.Action
 import io.flowdux.remote.ActionCodec
 import io.flowdux.remote.MessageCodec
-import io.flowdux.remote.serialization.JsonMessageCodec
 import io.flowdux.remote.ServerSharedAction
+import io.flowdux.remote.serialization.JsonMessageCodec
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.nanoseconds
-import kotlin.time.measureTime
 
 /**
  * Serialization performance benchmark for FlowDux remote modules.
@@ -18,30 +17,24 @@ import kotlin.time.measureTime
  * - Full round-trip (action → message → wire → message → action)
  * - Various payload sizes
  */
-class SerializationBenchmark(
-    private val config: BenchmarkConfig = BenchmarkConfig(),
-) {
+class SerializationBenchmark(private val config: BenchmarkConfig = BenchmarkConfig()) {
     // -- Test Fixtures --
 
     sealed interface BenchAction : Action {
         /** Small payload (~40 bytes) */
-        data class Small(val value: Int) : BenchAction, ServerSharedAction
+        data class Small(val value: Int) :
+            BenchAction,
+            ServerSharedAction
 
         /** Medium payload (~200 bytes) */
-        data class Medium(
-            val userId: String,
-            val message: String,
-            val timestamp: Long,
-            val metadata: String,
-        ) : BenchAction, ServerSharedAction
+        data class Medium(val userId: String, val message: String, val timestamp: Long, val metadata: String) :
+            BenchAction,
+            ServerSharedAction
 
         /** Large payload (~1KB+) */
-        data class Large(
-            val userId: String,
-            val items: List<String>,
-            val scores: List<Int>,
-            val nested: String,
-        ) : BenchAction, ServerSharedAction
+        data class Large(val userId: String, val items: List<String>, val scores: List<Int>, val nested: String) :
+            BenchAction,
+            ServerSharedAction
     }
 
     class BenchActionCodec : ActionCodec<BenchAction> {
@@ -91,13 +84,14 @@ class SerializationBenchmark(
         userId = "user-12345678",
         message = "Hello, this is a typical chat message with some content!",
         timestamp = 1706500000000L,
-        metadata = """{"platform":"android","version":"2.1.0","locale":"ko-KR"}"""
+        metadata = """{"platform":"android","version":"2.1.0","locale":"ko-KR"}""",
     )
     private val largeAction = BenchAction.Large(
         userId = "user-12345678",
         items = List(20) { "item-${it.toString().padStart(4, '0')}-abcdefghij" },
         scores = List(20) { it * 100 + 42 },
-        nested = """{"level":5,"experience":12500,"inventory":{"gold":9999,"gems":42},"achievements":["first_blood","veteran","master"]}"""
+        nested = """{"level":5,"experience":12500,"inventory":{"gold":9999,"gems":42},""" +
+            """"achievements":["first_blood","veteran","master"]}""",
     )
 
     // -- Benchmark Methods --
@@ -110,21 +104,27 @@ class SerializationBenchmark(
 
         // ActionCodec benchmarks
         print("  ActionCodec encode (small)...")
-        results.add(benchmarkOperation("ActionCodec Encode (Small ~40B)") {
-            actionCodec.encode(smallAction)
-        })
+        results.add(
+            benchmarkOperation("ActionCodec Encode (Small ~40B)") {
+                actionCodec.encode(smallAction)
+            },
+        )
         println(" done")
 
         print("  ActionCodec encode (medium)...")
-        results.add(benchmarkOperation("ActionCodec Encode (Medium ~200B)") {
-            actionCodec.encode(mediumAction)
-        })
+        results.add(
+            benchmarkOperation("ActionCodec Encode (Medium ~200B)") {
+                actionCodec.encode(mediumAction)
+            },
+        )
         println(" done")
 
         print("  ActionCodec encode (large)...")
-        results.add(benchmarkOperation("ActionCodec Encode (Large ~1KB)") {
-            actionCodec.encode(largeAction)
-        })
+        results.add(
+            benchmarkOperation("ActionCodec Encode (Large ~1KB)") {
+                actionCodec.encode(largeAction)
+            },
+        )
         println(" done")
 
         // Pre-encode for decode benchmarks
@@ -133,85 +133,98 @@ class SerializationBenchmark(
         val largeJson = actionCodec.encode(largeAction)
 
         print("  ActionCodec decode (small)...")
-        results.add(benchmarkOperation("ActionCodec Decode (Small ~40B)") {
-            actionCodec.decode(smallJson)
-        })
+        results.add(
+            benchmarkOperation("ActionCodec Decode (Small ~40B)") {
+                actionCodec.decode(smallJson)
+            },
+        )
         println(" done")
 
         print("  ActionCodec decode (medium)...")
-        results.add(benchmarkOperation("ActionCodec Decode (Medium ~200B)") {
-            actionCodec.decode(mediumJson)
-        })
+        results.add(
+            benchmarkOperation("ActionCodec Decode (Medium ~200B)") {
+                actionCodec.decode(mediumJson)
+            },
+        )
         println(" done")
 
         print("  ActionCodec decode (large)...")
-        results.add(benchmarkOperation("ActionCodec Decode (Large ~1KB)") {
-            actionCodec.decode(largeJson)
-        })
+        results.add(
+            benchmarkOperation("ActionCodec Decode (Large ~1KB)") {
+                actionCodec.decode(largeJson)
+            },
+        )
         println(" done")
 
         // MessageCodec benchmarks
         print("  MessageCodec encode...")
-        results.add(benchmarkOperation("MessageCodec EncodeAction") {
-            messageCodec.encodeActionMessage(mediumJson)
-        })
+        results.add(
+            benchmarkOperation("MessageCodec EncodeAction") {
+                messageCodec.encodeActionMessage(mediumJson)
+            },
+        )
         println(" done")
 
         val wireMessage = messageCodec.encodeServerResponse(listOf(smallJson, mediumJson))
         print("  MessageCodec decode...")
-        results.add(benchmarkOperation("MessageCodec DecodeServer (2 actions)") {
-            messageCodec.decodeServerMessage(wireMessage)
-        })
+        results.add(
+            benchmarkOperation("MessageCodec DecodeServer (2 actions)") {
+                messageCodec.decodeServerMessage(wireMessage)
+            },
+        )
         println(" done")
 
         // Full round-trip
         print("  Full round-trip (medium)...")
-        results.add(benchmarkOperation("Full Round-trip (Medium)") {
-            // Client side: action → wire
-            val encoded = actionCodec.encode(mediumAction)
-            val message = messageCodec.encodeActionMessage(encoded)
+        results.add(
+            benchmarkOperation("Full Round-trip (Medium)") {
+                // Client side: action → wire
+                val encoded = actionCodec.encode(mediumAction)
+                val message = messageCodec.encodeActionMessage(encoded)
 
-            // Server side: wire → action
-            val actionJson = messageCodec.decodeActionFromClient(message)
-            actionCodec.decode(actionJson)
+                // Server side: wire → action
+                val actionJson = messageCodec.decodeActionFromClient(message)
+                actionCodec.decode(actionJson)
 
-            // Server side: action → wire (response)
-            val responseEncoded = actionCodec.encode(mediumAction)
-            val response = messageCodec.encodeServerResponse(listOf(responseEncoded))
+                // Server side: action → wire (response)
+                val responseEncoded = actionCodec.encode(mediumAction)
+                val response = messageCodec.encodeServerResponse(listOf(responseEncoded))
 
-            // Client side: wire → action (response)
-            val serverResponse = messageCodec.decodeServerMessage(response)
-            for (json in serverResponse.actions) {
-                actionCodec.decode(json)
-            }
-        })
+                // Client side: wire → action (response)
+                val serverResponse = messageCodec.decodeServerMessage(response)
+                for (json in serverResponse.actions) {
+                    actionCodec.decode(json)
+                }
+            },
+        )
         println(" done")
 
         // Batch encoding (server broadcasting to N clients)
         print("  Batch encode (10 actions)...")
         val batchActions = List(10) { mediumJson }
-        results.add(benchmarkOperation("Batch Encode (10 actions)") {
-            messageCodec.encodeServerResponse(batchActions)
-        })
+        results.add(
+            benchmarkOperation("Batch Encode (10 actions)") {
+                messageCodec.encodeServerResponse(batchActions)
+            },
+        )
         println(" done")
 
         val batchWire = messageCodec.encodeServerResponse(batchActions)
         print("  Batch decode (10 actions)...")
-        results.add(benchmarkOperation("Batch Decode (10 actions)") {
-            val resp = messageCodec.decodeServerMessage(batchWire)
-            for (json in resp.actions) {
-                actionCodec.decode(json)
-            }
-        })
+        results.add(
+            benchmarkOperation("Batch Decode (10 actions)") {
+                val resp = messageCodec.decodeServerMessage(batchWire)
+                for (json in resp.actions) {
+                    actionCodec.decode(json)
+                }
+            },
+        )
         println(" done")
 
         return results
     }
 
-    private fun benchmarkOperation(
-        name: String,
-        operation: () -> Unit,
-    ): BenchmarkResult {
+    private fun benchmarkOperation(name: String, operation: () -> Unit): BenchmarkResult {
         val iterations = config.actionsPerBenchmark
         val latencies = mutableListOf<Duration>()
 

--- a/kotlin/flowdux/build.gradle.kts
+++ b/kotlin/flowdux/build.gradle.kts
@@ -12,7 +12,7 @@ mavenPublishing {
 }
 
 // JitPack only publishes JVM artifacts to avoid variant resolution issues for JVM/Android consumers
-val isJitPack = System.getenv("JITPACK") == "true"
+val isJitPack = providers.environmentVariable("JITPACK").map { it == "true" }.getOrElse(false)
 
 kotlin {
     jvm()

--- a/kotlin/flowdux/src/commonMain/kotlin/io/flowdux/Action.kt
+++ b/kotlin/flowdux/src/commonMain/kotlin/io/flowdux/Action.kt
@@ -15,6 +15,7 @@ interface Action
 enum class FlowActionDelivery {
     /** Inner actions go directly to the reducer, bypassing user middlewares. */
     Emit,
+
     /** Inner actions are re-dispatched through the full middleware pipeline. */
     Dispatch,
 }

--- a/kotlin/flowdux/src/commonMain/kotlin/io/flowdux/ErrorProcessor.kt
+++ b/kotlin/flowdux/src/commonMain/kotlin/io/flowdux/ErrorProcessor.kt
@@ -3,12 +3,10 @@ package io.flowdux
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 
-interface ErrorProcessor<A: Action> {
-    fun process(throwable: Throwable) : Flow<A>
+interface ErrorProcessor<A : Action> {
+    fun process(throwable: Throwable): Flow<A>
 }
 
-class DefaultErrorProcessor<A: Action> : ErrorProcessor<A> {
-    override fun process(throwable: Throwable): Flow<A> {
-        return emptyFlow()
-    }
+class DefaultErrorProcessor<A : Action> : ErrorProcessor<A> {
+    override fun process(throwable: Throwable): Flow<A> = emptyFlow()
 }

--- a/kotlin/flowdux/src/commonMain/kotlin/io/flowdux/ExecutionStrategy.kt
+++ b/kotlin/flowdux/src/commonMain/kotlin/io/flowdux/ExecutionStrategy.kt
@@ -17,12 +17,15 @@ import kotlin.time.TimeSource
 enum class StrategyCategory {
     /** Timing strategies control when to execute (debounce, throttle) */
     TIMING,
+
     /** Concurrency strategies control how to handle concurrent executions (takeLatest, takeLeading) */
     CONCURRENCY,
+
     /** Resilience strategies control how to handle failures (retry, circuitBreaker) */
     RESILIENCE,
+
     /** Chained strategies composed of multiple strategies */
-    CHAINED
+    CHAINED,
 }
 
 /**
@@ -39,7 +42,7 @@ sealed interface ExecutionStrategy {
      * The wrapper manages the execution lifecycle according to the strategy.
      */
     fun <S, A, T : A> wrap(
-        processor: suspend FlowCollector<A>.(state: S, action: T) -> Unit
+        processor: suspend FlowCollector<A>.(state: S, action: T) -> Unit,
     ): suspend FlowCollector<A>.(state: S, action: T) -> Unit
 }
 
@@ -56,7 +59,7 @@ class TakeLatest : ExecutionStrategy {
     private var currentJob: Job? = null
 
     override fun <S, A, T : A> wrap(
-        processor: suspend FlowCollector<A>.(state: S, action: T) -> Unit
+        processor: suspend FlowCollector<A>.(state: S, action: T) -> Unit,
     ): suspend FlowCollector<A>.(state: S, action: T) -> Unit = { state, action ->
         val job = currentCoroutineContext()[Job]!!
 
@@ -92,16 +95,17 @@ class TakeLeading : ExecutionStrategy {
     private var isActive = false
 
     override fun <S, A, T : A> wrap(
-        processor: suspend FlowCollector<A>.(state: S, action: T) -> Unit
+        processor: suspend FlowCollector<A>.(state: S, action: T) -> Unit,
     ): suspend FlowCollector<A>.(state: S, action: T) -> Unit = { state, action ->
-        val shouldExecute = mutex.withLock {
-            if (isActive) {
-                false
-            } else {
-                isActive = true
-                true
+        val shouldExecute =
+            mutex.withLock {
+                if (isActive) {
+                    false
+                } else {
+                    isActive = true
+                    true
+                }
             }
-        }
 
         if (shouldExecute) {
             try {
@@ -128,7 +132,7 @@ class Sequential : ExecutionStrategy {
     private val mutex = Mutex()
 
     override fun <S, A, T : A> wrap(
-        processor: suspend FlowCollector<A>.(state: S, action: T) -> Unit
+        processor: suspend FlowCollector<A>.(state: S, action: T) -> Unit,
     ): suspend FlowCollector<A>.(state: S, action: T) -> Unit = { state, action ->
         mutex.withLock {
             processor(state, action)
@@ -149,7 +153,7 @@ class Debounce(private val duration: Duration) : ExecutionStrategy {
     private var pendingJob: Job? = null
 
     override fun <S, A, T : A> wrap(
-        processor: suspend FlowCollector<A>.(state: S, action: T) -> Unit
+        processor: suspend FlowCollector<A>.(state: S, action: T) -> Unit,
     ): suspend FlowCollector<A>.(state: S, action: T) -> Unit = { state, action ->
         val currentJob = currentCoroutineContext()[Job]!!
 
@@ -160,9 +164,10 @@ class Debounce(private val duration: Duration) : ExecutionStrategy {
 
         delay(duration)
 
-        val shouldExecute = mutex.withLock {
-            pendingJob === currentJob
-        }
+        val shouldExecute =
+            mutex.withLock {
+                pendingJob === currentJob
+            }
 
         if (shouldExecute) {
             processor(state, action)
@@ -184,19 +189,20 @@ class Throttle(private val duration: Duration) : ExecutionStrategy {
     private var lastExecutionMark: TimeSource.Monotonic.ValueTimeMark? = null
 
     override fun <S, A, T : A> wrap(
-        processor: suspend FlowCollector<A>.(state: S, action: T) -> Unit
+        processor: suspend FlowCollector<A>.(state: S, action: T) -> Unit,
     ): suspend FlowCollector<A>.(state: S, action: T) -> Unit = { state, action ->
         val now = timeSource.markNow()
 
-        val shouldExecute = mutex.withLock {
-            val last = lastExecutionMark
-            if (last == null || now - last >= duration) {
-                lastExecutionMark = now
-                true
-            } else {
-                false
+        val shouldExecute =
+            mutex.withLock {
+                val last = lastExecutionMark
+                if (last == null || now - last >= duration) {
+                    lastExecutionMark = now
+                    true
+                } else {
+                    false
+                }
             }
-        }
 
         if (shouldExecute) {
             processor(state, action)
@@ -211,10 +217,7 @@ class Throttle(private val duration: Duration) : ExecutionStrategy {
  * @param retryIf Optional predicate to determine if a specific exception should trigger a retry.
  *                Defaults to retrying on all non-cancellation exceptions.
  */
-class Retry(
-    private val maxAttempts: Int,
-    private val retryIf: (Throwable) -> Boolean = { true }
-) : ExecutionStrategy {
+class Retry(private val maxAttempts: Int, private val retryIf: (Throwable) -> Boolean = { true }) : ExecutionStrategy {
     override val category = StrategyCategory.RESILIENCE
 
     init {
@@ -222,7 +225,7 @@ class Retry(
     }
 
     override fun <S, A, T : A> wrap(
-        processor: suspend FlowCollector<A>.(state: S, action: T) -> Unit
+        processor: suspend FlowCollector<A>.(state: S, action: T) -> Unit,
     ): suspend FlowCollector<A>.(state: S, action: T) -> Unit = { state, action ->
         for (attempt in 0 until maxAttempts) {
             try {
@@ -260,7 +263,7 @@ class RetryWithBackoff(
     private val maxDelay: Duration = Duration.INFINITE,
     private val factor: Double = 2.0,
     private val jitter: Double = 0.0,
-    private val retryIf: (Throwable) -> Boolean = { true }
+    private val retryIf: (Throwable) -> Boolean = { true },
 ) : ExecutionStrategy {
     override val category = StrategyCategory.RESILIENCE
 
@@ -271,7 +274,7 @@ class RetryWithBackoff(
     }
 
     override fun <S, A, T : A> wrap(
-        processor: suspend FlowCollector<A>.(state: S, action: T) -> Unit
+        processor: suspend FlowCollector<A>.(state: S, action: T) -> Unit,
     ): suspend FlowCollector<A>.(state: S, action: T) -> Unit = { state, action ->
         for (attempt in 0 until maxAttempts) {
             try {
@@ -289,12 +292,13 @@ class RetryWithBackoff(
                 val cappedDelay = minOf(baseDelay, maxDelay)
 
                 // Apply jitter
-                val jitterAmount = if (jitter > 0.0) {
-                    // jitter is a factor (0.0–1.0); this yields an extra delay in [0, cappedDelay * jitter]
-                    cappedDelay * jitter * kotlin.random.Random.nextDouble()
-                } else {
-                    Duration.ZERO
-                }
+                val jitterAmount =
+                    if (jitter > 0.0) {
+                        // jitter is a factor (0.0–1.0); this yields an extra delay in [0, cappedDelay * jitter]
+                        cappedDelay * jitter * kotlin.random.Random.nextDouble()
+                    } else {
+                        Duration.ZERO
+                    }
 
                 val finalDelay = (cappedDelay + jitterAmount).coerceAtLeast(Duration.ZERO)
                 delay(finalDelay)
@@ -319,7 +323,7 @@ class Concurrent : ExecutionStrategy {
     override val category = StrategyCategory.CONCURRENCY
 
     override fun <S, A, T : A> wrap(
-        processor: suspend FlowCollector<A>.(state: S, action: T) -> Unit
+        processor: suspend FlowCollector<A>.(state: S, action: T) -> Unit,
     ): suspend FlowCollector<A>.(state: S, action: T) -> Unit = processor
 }
 
@@ -388,10 +392,7 @@ fun throttle(timeMs: Long): ExecutionStrategy = Throttle(timeMs.milliseconds)
  * @param maxAttempts Maximum number of attempts (including the initial attempt)
  * @param retryIf Optional predicate to determine if a specific exception should trigger a retry
  */
-fun retry(
-    maxAttempts: Int,
-    retryIf: (Throwable) -> Boolean = { true }
-): ExecutionStrategy = Retry(maxAttempts, retryIf)
+fun retry(maxAttempts: Int, retryIf: (Throwable) -> Boolean = { true }): ExecutionStrategy = Retry(maxAttempts, retryIf)
 
 /**
  * Creates a [RetryWithBackoff] strategy that retries failed executions with exponential backoff.
@@ -409,7 +410,7 @@ fun retryWithBackoff(
     maxDelay: Duration = Duration.INFINITE,
     factor: Double = 2.0,
     jitter: Double = 0.0,
-    retryIf: (Throwable) -> Boolean = { true }
+    retryIf: (Throwable) -> Boolean = { true },
 ): ExecutionStrategy = RetryWithBackoff(maxAttempts, initialDelay, maxDelay, factor, jitter, retryIf)
 
 // Strategy chaining
@@ -424,10 +425,8 @@ fun retryWithBackoff(
  * @param second The inner strategy (runs second)
  * @throws IllegalArgumentException if both strategies belong to the same category
  */
-class ChainedStrategy(
-    private val first: ExecutionStrategy,
-    private val second: ExecutionStrategy
-) : ExecutionStrategy {
+class ChainedStrategy(private val first: ExecutionStrategy, private val second: ExecutionStrategy) :
+    ExecutionStrategy {
     override val category = StrategyCategory.CHAINED
 
     private val categories: Set<StrategyCategory>
@@ -447,9 +446,8 @@ class ChainedStrategy(
     }
 
     override fun <S, A, T : A> wrap(
-        processor: suspend FlowCollector<A>.(state: S, action: T) -> Unit
-    ): suspend FlowCollector<A>.(state: S, action: T) -> Unit =
-        first.wrap(second.wrap(processor))
+        processor: suspend FlowCollector<A>.(state: S, action: T) -> Unit,
+    ): suspend FlowCollector<A>.(state: S, action: T) -> Unit = first.wrap(second.wrap(processor))
 }
 
 /**
@@ -466,5 +464,4 @@ class ChainedStrategy(
  * @return A new [ChainedStrategy] combining both strategies
  * @throws IllegalArgumentException if both strategies belong to the same category
  */
-infix fun ExecutionStrategy.then(next: ExecutionStrategy): ExecutionStrategy =
-    ChainedStrategy(this, next)
+infix fun ExecutionStrategy.then(next: ExecutionStrategy): ExecutionStrategy = ChainedStrategy(this, next)

--- a/kotlin/flowdux/src/commonMain/kotlin/io/flowdux/FlowHolderMiddleware.kt
+++ b/kotlin/flowdux/src/commonMain/kotlin/io/flowdux/FlowHolderMiddleware.kt
@@ -28,7 +28,6 @@ internal class FlowHolderMiddleware<S : State, A : Action>(
     private val logger: StoreLogger<S, A>,
     private val dispatch: (A) -> Unit,
 ) : Middleware<S, A> {
-
     override val processors: ActionProcessorMap<S, A> = emptyMap()
     private val isLoggingEnabled = logger::class != NoOpStoreLogger::class
 
@@ -47,45 +46,49 @@ internal class FlowHolderMiddleware<S : State, A : Action>(
         val wrapped = getOrCreateWrappedProcessor(action)
 
         return when (action.delivery) {
-            FlowActionDelivery.Emit -> flow {
-                wrapped.invoke(this, getState(), action)
-            }.transform { innerAction ->
-                if (innerAction is FlowHolderAction) {
-                    // Recursive processing for nested FlowHolderActions
-                    emitAll(process(getState, innerAction as A))
-                } else {
-                    emit(innerAction)
+            FlowActionDelivery.Emit ->
+                flow {
+                    wrapped.invoke(this, getState(), action)
+                }.transform { innerAction ->
+                    if (innerAction is FlowHolderAction) {
+                        // Recursive processing for nested FlowHolderActions
+                        emitAll(process(getState, innerAction as A))
+                    } else {
+                        emit(innerAction)
+                    }
                 }
-            }
 
-            FlowActionDelivery.Dispatch -> flow<A> {
-                wrapped.invoke(this, getState(), action)
-            }.onEach { innerAction ->
-                // Re-dispatch through full pipeline; nested FlowHolderActions
-                // will be processed when they reach this middleware again
-                dispatch(innerAction)
-            }.transform {
-                // Don't emit anything; all inner actions are re-dispatched
-            }
+            FlowActionDelivery.Dispatch ->
+                flow<A> {
+                    wrapped.invoke(this, getState(), action)
+                }.onEach { innerAction ->
+                    // Re-dispatch through full pipeline; nested FlowHolderActions
+                    // will be processed when they reach this middleware again
+                    dispatch(innerAction)
+                }.transform {
+                    // Don't emit anything; all inner actions are re-dispatched
+                }
         }
     }
 
     @Suppress("UNCHECKED_CAST")
-    private fun getOrCreateWrappedProcessor(action: FlowHolderAction): WrappedProcessor<S, A> {
-        return wrappedProcessors.getOrPut(action::class) {
+    private fun getOrCreateWrappedProcessor(action: FlowHolderAction): WrappedProcessor<S, A> =
+        wrappedProcessors.getOrPut(action::class) {
             val baseProcessor: suspend FlowCollector<A>.(S, A) -> Unit = { _, a ->
                 emitAll(
-                    (a as FlowHolderAction).toFlowAction()
+                    (a as FlowHolderAction)
+                        .toFlowAction()
                         .run {
-                            if (isLoggingEnabled) onEach { logger.onFlowHolderActionEmitted(it as A) }
-                            else this
-                        }
-                        .map { it as A }
+                            if (isLoggingEnabled) {
+                                onEach { logger.onFlowHolderActionEmitted(it as A) }
+                            } else {
+                                this
+                            }
+                        }.map { it as A },
                 )
             }
             action.strategy.wrap(baseProcessor)
         }
-    }
 }
 
 private typealias WrappedProcessor<S, A> = suspend FlowCollector<A>.(S, A) -> Unit

--- a/kotlin/flowdux/src/commonMain/kotlin/io/flowdux/Middleware.kt
+++ b/kotlin/flowdux/src/commonMain/kotlin/io/flowdux/Middleware.kt
@@ -12,10 +12,7 @@ interface Middleware<S : State, A : Action> {
     val name: String get() = this::class.simpleName ?: "Unknown"
     val processors: ActionProcessorMap<S, A>
 
-    fun process(
-        getState: () -> S,
-        action: A,
-    ): Flow<A> = flow {
+    fun process(getState: () -> S, action: A): Flow<A> = flow {
         val processor = processors[action::class]
         if (processor != null) {
             processor.invoke(this, getState(), action)
@@ -27,10 +24,11 @@ interface Middleware<S : State, A : Action> {
     /**
      * Exception thrown when attempting to register a duplicate action processor.
      */
-    class DuplicateProcessorException(actionClass: KClass<*>) : IllegalArgumentException(
-        "Processor for action type '${actionClass.simpleName}' is already registered. " +
-            "Each action type can only have one processor per middleware."
-    )
+    class DuplicateProcessorException(actionClass: KClass<*>) :
+        IllegalArgumentException(
+            "Processor for action type '${actionClass.simpleName}' is already registered. " +
+                "Each action type can only have one processor per middleware.",
+        )
 
     class ActionProcessorBuilder<S, A> {
         @PublishedApi
@@ -43,17 +41,13 @@ interface Middleware<S : State, A : Action> {
             }
         }
 
-        inline fun <reified T : A> on(
-            noinline processor: suspend FlowCollector<A>.(state: S, action: T) -> Unit
-        ) {
+        inline fun <reified T : A> on(noinline processor: suspend FlowCollector<A>.(state: S, action: T) -> Unit) {
             checkDuplicate(T::class)
             @Suppress("UNCHECKED_CAST")
             processors[T::class] = processor as ActionProcessor<S, A>
         }
 
-        inline fun <reified T : A> on(
-            noinline processor: suspend FlowCollector<A>.() -> Unit
-        ) {
+        inline fun <reified T : A> on(noinline processor: suspend FlowCollector<A>.() -> Unit) {
             checkDuplicate(T::class)
             processors[T::class] = { _, _ -> processor() }
         }
@@ -66,7 +60,7 @@ interface Middleware<S : State, A : Action> {
          */
         inline fun <reified T : A> on(
             strategy: ExecutionStrategy,
-            noinline processor: suspend FlowCollector<A>.(state: S, action: T) -> Unit
+            noinline processor: suspend FlowCollector<A>.(state: S, action: T) -> Unit,
         ) {
             checkDuplicate(T::class)
             val wrappedProcessor = strategy.wrap(processor)
@@ -82,7 +76,7 @@ interface Middleware<S : State, A : Action> {
          */
         inline fun <reified T : A> on(
             strategy: ExecutionStrategy,
-            noinline processor: suspend FlowCollector<A>.() -> Unit
+            noinline processor: suspend FlowCollector<A>.() -> Unit,
         ) {
             checkDuplicate(T::class)
             val baseProcessor: suspend FlowCollector<A>.(S, T) -> Unit = { _, _ -> processor() }
@@ -119,7 +113,7 @@ interface Middleware<S : State, A : Action> {
      */
     class StrategyGroupBuilder<S, A>(
         @PublishedApi internal val strategy: ExecutionStrategy,
-        @PublishedApi internal val processors: MutableMap<KClass<*>, ActionProcessor<S, A>>
+        @PublishedApi internal val processors: MutableMap<KClass<*>, ActionProcessor<S, A>>,
     ) {
         @PublishedApi
         internal fun checkDuplicate(actionClass: KClass<*>) {
@@ -131,9 +125,7 @@ interface Middleware<S : State, A : Action> {
         /**
          * Registers an action processor that shares this group's execution strategy.
          */
-        inline fun <reified T : A> on(
-            noinline processor: suspend FlowCollector<A>.(state: S, action: T) -> Unit
-        ) {
+        inline fun <reified T : A> on(noinline processor: suspend FlowCollector<A>.(state: S, action: T) -> Unit) {
             checkDuplicate(T::class)
             val wrappedProcessor = strategy.wrap(processor)
             @Suppress("UNCHECKED_CAST")
@@ -143,9 +135,7 @@ interface Middleware<S : State, A : Action> {
         /**
          * Registers an action processor (no parameters) that shares this group's execution strategy.
          */
-        inline fun <reified T : A> on(
-            noinline processor: suspend FlowCollector<A>.() -> Unit
-        ) {
+        inline fun <reified T : A> on(noinline processor: suspend FlowCollector<A>.() -> Unit) {
             checkDuplicate(T::class)
             val baseProcessor: suspend FlowCollector<A>.(S, T) -> Unit = { _, _ -> processor() }
             val wrappedProcessor = strategy.wrap(baseProcessor)
@@ -154,9 +144,6 @@ interface Middleware<S : State, A : Action> {
         }
     }
 
-    fun buildProcessors(
-        block: ActionProcessorBuilder<S, A>.() -> Unit
-    ): ActionProcessorMap<S, A> {
-        return ActionProcessorBuilder<S, A>().apply(block).build()
-    }
+    fun buildProcessors(block: ActionProcessorBuilder<S, A>.() -> Unit): ActionProcessorMap<S, A> =
+        ActionProcessorBuilder<S, A>().apply(block).build()
 }

--- a/kotlin/flowdux/src/commonMain/kotlin/io/flowdux/Reducer.kt
+++ b/kotlin/flowdux/src/commonMain/kotlin/io/flowdux/Reducer.kt
@@ -3,10 +3,7 @@ package io.flowdux
 import kotlin.reflect.KClass
 
 fun interface Reducer<S : State, A : Action> {
-    fun reduce(
-        state: S,
-        action: A,
-    ): S
+    fun reduce(state: S, action: A): S
 }
 
 class ReducerBuilder<S : State, A : Action> {
@@ -19,12 +16,10 @@ class ReducerBuilder<S : State, A : Action> {
         }
     }
 
-    fun build(): Reducer<S, A> =
-        Reducer { state, action ->
-            handlers[action::class]?.invoke(state, action) ?: state
-        }
+    fun build(): Reducer<S, A> = Reducer { state, action ->
+        handlers[action::class]?.invoke(state, action) ?: state
+    }
 }
 
-inline fun <S : State, A : Action> buildReducer(
-    block: ReducerBuilder<S, A>.() -> Unit
-): Reducer<S, A> = ReducerBuilder<S, A>().apply(block).build()
+inline fun <S : State, A : Action> buildReducer(block: ReducerBuilder<S, A>.() -> Unit): Reducer<S, A> =
+    ReducerBuilder<S, A>().apply(block).build()

--- a/kotlin/flowdux/src/commonMain/kotlin/io/flowdux/Store.kt
+++ b/kotlin/flowdux/src/commonMain/kotlin/io/flowdux/Store.kt
@@ -22,12 +22,14 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
+import kotlin.concurrent.atomics.AtomicBoolean
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
 private const val DEFAULT_CONCURRENCY = 16
 
-@OptIn(ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalAtomicApi::class)
 class Store<S : State, A : Action> internal constructor(
     initialState: S,
     private val reducer: Reducer<S, A>,
@@ -38,10 +40,10 @@ class Store<S : State, A : Action> internal constructor(
     private val concurrency: Int,
 ) {
     private val actionFlow = Channel<A>()
-    private var _isClosed = false
+    private val _isClosed = AtomicBoolean(false)
     private val isLoggingEnabled = logger::class != NoOpStoreLogger::class
 
-    val isClosed: Boolean get() = _isClosed
+    val isClosed: Boolean get() = _isClosed.load()
 
     private val stateFlow = actionFlow
         .receiveAsFlow()
@@ -78,7 +80,7 @@ class Store<S : State, A : Action> internal constructor(
     val currentState: S get() = stateFlow.value
 
     fun dispatch(action: A) {
-        if (_isClosed) {
+        if (_isClosed.load()) {
             if (isLoggingEnabled) logger.onDispatchAfterClose(action)
             return
         }
@@ -94,8 +96,7 @@ class Store<S : State, A : Action> internal constructor(
     }
 
     fun close() {
-        if (_isClosed) return
-        _isClosed = true
+        if (!_isClosed.compareAndSet(expectedValue = false, newValue = true)) return
         actionFlow.close()
         scope.cancel()
     }
@@ -138,7 +139,7 @@ class Store<S : State, A : Action> internal constructor(
         timeout: Duration = 5.seconds,
         beforeClose: (suspend (dispatch: suspend (A) -> Unit) -> Unit)? = null,
     ) {
-        if (_isClosed) return
+        if (_isClosed.load()) return
         beforeClose?.invoke {
             if (isLoggingEnabled) logger.onActionDispatched(it)
             actionFlow.send(it)

--- a/kotlin/flowdux/src/commonMain/kotlin/io/flowdux/Store.kt
+++ b/kotlin/flowdux/src/commonMain/kotlin/io/flowdux/Store.kt
@@ -1,12 +1,12 @@
 package io.flowdux
 
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ClosedSendChannelException
 import kotlinx.coroutines.flow.Flow
@@ -45,11 +45,12 @@ class Store<S : State, A : Action> internal constructor(
 
     val isClosed: Boolean get() = _isClosed.load()
 
-    private val stateFlow = actionFlow
-        .receiveAsFlow()
-        .flatMapMerge(concurrency) { processAction(it) }
-        .map { reduceAction(state.value, it) }
-        .stateIn(scope, SharingStarted.Eagerly, initialState)
+    private val stateFlow =
+        actionFlow
+            .receiveAsFlow()
+            .flatMapMerge(concurrency) { processAction(it) }
+            .map { reduceAction(state.value, it) }
+            .stateIn(scope, SharingStarted.Eagerly, initialState)
 
     private fun processAction(a: A): Flow<A> = middlewares
         .fold(flowOf(a)) { flow, middleware ->
@@ -60,18 +61,22 @@ class Store<S : State, A : Action> internal constructor(
                     action = currentAction,
                 )
             }
-        }
-        .run {
-            if (isLoggingEnabled) onEach { logger.onMiddlewaresCompleted(it) }
-            else this
-        }
-        .catch { error ->
+        }.run {
+            if (isLoggingEnabled) {
+                onEach { logger.onMiddlewaresCompleted(it) }
+            } else {
+                this
+            }
+        }.catch { error ->
             if (isLoggingEnabled) logger.onErrorOccurred(error)
             emitAll(
                 errorProcessor.process(error).run {
-                    if (isLoggingEnabled) onEach { logger.onErrorHandled(it) }
-                    else this
-                }
+                    if (isLoggingEnabled) {
+                        onEach { logger.onErrorHandled(it) }
+                    } else {
+                        this
+                    }
+                },
             )
         }
 
@@ -173,16 +178,18 @@ fun <S : State, A : Action> createStore(
     concurrency: Int = DEFAULT_CONCURRENCY,
 ): Store<S, A> {
     lateinit var store: Store<S, A>
-    val allMiddlewares = middlewares +
-        FlowHolderMiddleware<S, A>(logger, dispatch = { store.dispatch(it) })
-    store = Store(
-        initialState = initialState,
-        reducer = reducer,
-        middlewares = allMiddlewares,
-        errorProcessor = errorProcessor,
-        logger = logger,
-        scope = scope,
-        concurrency = concurrency,
-    )
+    val allMiddlewares =
+        middlewares +
+            FlowHolderMiddleware<S, A>(logger, dispatch = { store.dispatch(it) })
+    store =
+        Store(
+            initialState = initialState,
+            reducer = reducer,
+            middlewares = allMiddlewares,
+            errorProcessor = errorProcessor,
+            logger = logger,
+            scope = scope,
+            concurrency = concurrency,
+        )
     return store
 }

--- a/kotlin/flowdux/src/commonMain/kotlin/io/flowdux/StoreLogger.kt
+++ b/kotlin/flowdux/src/commonMain/kotlin/io/flowdux/StoreLogger.kt
@@ -2,11 +2,17 @@ package io.flowdux
 
 interface StoreLogger<S : State, A : Action> {
     fun onActionDispatched(action: A)
+
     fun onMiddlewareProcessing(middlewareName: String, action: A)
+
     fun onMiddlewaresCompleted(action: A)
+
     fun onFlowHolderActionEmitted(action: A)
+
     fun onErrorOccurred(throwable: Throwable)
+
     fun onErrorHandled(action: A)
+
     fun onStateReduced(action: A, previousState: S, newState: S)
 
     /**
@@ -18,18 +24,23 @@ interface StoreLogger<S : State, A : Action> {
 
 open class NoOpStoreLogger<S : State, A : Action> : StoreLogger<S, A> {
     override fun onActionDispatched(action: A) {}
+
     override fun onMiddlewareProcessing(middlewareName: String, action: A) {}
+
     override fun onMiddlewaresCompleted(action: A) {}
+
     override fun onFlowHolderActionEmitted(action: A) {}
+
     override fun onErrorOccurred(throwable: Throwable) {}
+
     override fun onErrorHandled(action: A) {}
+
     override fun onStateReduced(action: A, previousState: S, newState: S) {}
+
     override fun onDispatchAfterClose(action: A) {}
 }
 
-class DebugStoreLogger<S : State, A : Action>(
-    private val tag: String = "Store"
-) : StoreLogger<S, A> {
+class DebugStoreLogger<S : State, A : Action>(private val tag: String = "Store") : StoreLogger<S, A> {
     override fun onActionDispatched(action: A) {
         println("[$tag] Dispatched: $action")
     }

--- a/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/CloseGracefullyTest.kt
+++ b/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/CloseGracefullyTest.kt
@@ -12,16 +12,16 @@ import kotlin.time.Duration.Companion.seconds
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class CloseGracefullyTest {
-
     @Test
     fun `closeGracefully processes beforeClose actions before closing`() = runTest {
         val storeScope = CoroutineScope(coroutineContext + Job())
-        val store = createStore(
-            initialState = CounterState(),
-            reducer = counterReducer,
-            errorProcessor = testErrorProcessor,
-            scope = storeScope,
-        )
+        val store =
+            createStore(
+                initialState = CounterState(),
+                reducer = counterReducer,
+                errorProcessor = testErrorProcessor,
+                scope = storeScope,
+            )
         advanceUntilIdle()
 
         store.closeGracefully { dispatch ->
@@ -37,12 +37,13 @@ class CloseGracefullyTest {
     @Test
     fun `closeGracefully without beforeClose drains pending actions`() = runTest {
         val storeScope = CoroutineScope(coroutineContext + Job())
-        val store = createStore(
-            initialState = CounterState(),
-            reducer = counterReducer,
-            errorProcessor = testErrorProcessor,
-            scope = storeScope,
-        )
+        val store =
+            createStore(
+                initialState = CounterState(),
+                reducer = counterReducer,
+                errorProcessor = testErrorProcessor,
+                scope = storeScope,
+            )
         advanceUntilIdle()
 
         store.dispatch(CounterAction.Add(5))
@@ -56,12 +57,13 @@ class CloseGracefullyTest {
     @Test
     fun `closeGracefully on already-closed store is no-op`() = runTest {
         val storeScope = CoroutineScope(coroutineContext + Job())
-        val store = createStore(
-            initialState = CounterState(),
-            reducer = counterReducer,
-            errorProcessor = testErrorProcessor,
-            scope = storeScope,
-        )
+        val store =
+            createStore(
+                initialState = CounterState(),
+                reducer = counterReducer,
+                errorProcessor = testErrorProcessor,
+                scope = storeScope,
+            )
         advanceUntilIdle()
 
         store.close()
@@ -80,12 +82,13 @@ class CloseGracefullyTest {
     @Test
     fun `closeGracefully with timeout closes even if drain takes too long`() = runTest {
         val storeScope = CoroutineScope(coroutineContext + Job())
-        val store = createStore(
-            initialState = CounterState(),
-            reducer = counterReducer,
-            errorProcessor = testErrorProcessor,
-            scope = storeScope,
-        )
+        val store =
+            createStore(
+                initialState = CounterState(),
+                reducer = counterReducer,
+                errorProcessor = testErrorProcessor,
+                scope = storeScope,
+            )
         advanceUntilIdle()
 
         // Use a very short timeout — the drain sentinel will complete fast
@@ -99,27 +102,34 @@ class CloseGracefullyTest {
     @Test
     fun `closeGracefully sentinel passes through middleware pipeline`() = runTest {
         val processedActions = mutableListOf<Action>()
-        val trackingMiddleware = object : Middleware<CounterState, CounterAction> {
-            override val name: String = "tracking"
-            override val processors = emptyMap<kotlin.reflect.KClass<*>, suspend kotlinx.coroutines.flow.FlowCollector<CounterAction>.(CounterState, CounterAction) -> Unit>()
+        val trackingMiddleware =
+            object : Middleware<CounterState, CounterAction> {
+                override val name: String = "tracking"
+                override val processors =
+                    emptyMap<
+                        kotlin.reflect.KClass<*>,
+                        suspend kotlinx.coroutines.flow.FlowCollector<CounterAction>.(
+                            CounterState,
+                            CounterAction,
+                        ) -> Unit,
+                        >()
 
-            override fun process(
-                getState: () -> CounterState,
-                action: CounterAction,
-            ) = kotlinx.coroutines.flow.flow {
-                processedActions.add(action)
-                emit(action)
+                override fun process(getState: () -> CounterState, action: CounterAction) =
+                    kotlinx.coroutines.flow.flow {
+                        processedActions.add(action)
+                        emit(action)
+                    }
             }
-        }
 
         val storeScope = CoroutineScope(coroutineContext + Job())
-        val store = createStore(
-            initialState = CounterState(),
-            middlewares = listOf(trackingMiddleware),
-            reducer = counterReducer,
-            errorProcessor = testErrorProcessor,
-            scope = storeScope,
-        )
+        val store =
+            createStore(
+                initialState = CounterState(),
+                middlewares = listOf(trackingMiddleware),
+                reducer = counterReducer,
+                errorProcessor = testErrorProcessor,
+                scope = storeScope,
+            )
         advanceUntilIdle()
 
         store.closeGracefully { dispatch ->

--- a/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/ConcurrencyTest.kt
+++ b/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/ConcurrencyTest.kt
@@ -9,38 +9,34 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.runBlocking
-import kotlin.test.assertEquals
 import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class ConcurrencyTest {
-
     @Test
-    fun `concurrent increments should not lose updates due to race condition`() =
-        runBlocking {
-            // This test verifies that concurrent actions don't cause lost updates
-            // due to reading stale state before acquiring mutex lock.
-            //
-            // Race condition scenario (if broken):
-            // 1. Action A reads state.value = 0 (before mutex)
-            // 2. Action B reads state.value = 0 (before mutex, A not yet completed)
-            // 3. Action A acquires mutex, reduces 0 -> 1, releases mutex
-            // 4. Action B acquires mutex, reduces 0 -> 1 (using stale state!), releases mutex
-            // Result: count = 1, but expected count = 2
-            //
-            // NOTE: Using runBlocking with Dispatchers.Default to ensure real multi-threading
-            // NOTE: Reducer includes delay to force context switch during reduce phase
+    fun `concurrent increments should not lose updates due to race condition`() = runBlocking {
+        // This test verifies that concurrent actions don't cause lost updates
+        // due to reading stale state before acquiring mutex lock.
+        //
+        // Race condition scenario (if broken):
+        // 1. Action A reads state.value = 0 (before mutex)
+        // 2. Action B reads state.value = 0 (before mutex, A not yet completed)
+        // 3. Action A acquires mutex, reduces 0 -> 1, releases mutex
+        // 4. Action B acquires mutex, reduces 0 -> 1 (using stale state!), releases mutex
+        // Result: count = 1, but expected count = 2
+        //
+        // NOTE: Using runBlocking with Dispatchers.Default to ensure real multi-threading
+        // NOTE: Reducer includes delay to force context switch during reduce phase
 
-            val concurrentActionCount = 100
-            val storeScope = CoroutineScope(Dispatchers.Default + Job())
+        val concurrentActionCount = 100
+        val storeScope = CoroutineScope(Dispatchers.Default + Job())
 
-            // Middleware that adds delay to ensure concurrent execution at reduce phase
-            val delayMiddleware = object : Middleware<CounterState, CounterAction> {
+        // Middleware that adds delay to ensure concurrent execution at reduce phase
+        val delayMiddleware =
+            object : Middleware<CounterState, CounterAction> {
                 override val processors: ActionProcessorMap<CounterState, CounterAction> = emptyMap()
 
-                override fun process(
-                    getState: () -> CounterState,
-                    action: CounterAction,
-                ): Flow<CounterAction> = flow {
+                override fun process(getState: () -> CounterState, action: CounterAction): Flow<CounterAction> = flow {
                     if (action is CounterAction.Increment) {
                         delay(10) // Small delay to increase chance of concurrent reduce
                     }
@@ -48,16 +44,19 @@ class ConcurrencyTest {
                 }
             }
 
-            // Reducer that includes delay to simulate slow reduce operation
-            // This delay happens AFTER state.value is read but BEFORE mutex is acquired,
-            // creating a window for race condition
-            val slowReducer = Reducer<CounterState, CounterAction> { state, action ->
+        // Reducer that includes delay to simulate slow reduce operation
+        // This delay happens AFTER state.value is read but BEFORE mutex is acquired,
+        // creating a window for race condition
+        val slowReducer =
+            Reducer<CounterState, CounterAction> { state, action ->
                 when (action) {
                     is CounterAction.Increment -> {
                         // Delay to force context switch - this is where race condition occurs
                         // because state.value was already read before this point
                         // Small busy wait to slow down without yielding the coroutine
-                        val start = kotlin.time.TimeSource.Monotonic.markNow()
+                        val start =
+                            kotlin.time.TimeSource.Monotonic
+                                .markNow()
                         @Suppress("ControlFlowWithEmptyBody")
                         while (start.elapsedNow().inWholeMilliseconds < 1) { }
                         state.copy(count = state.count + 1)
@@ -66,7 +65,8 @@ class ConcurrencyTest {
                 }
             }
 
-            val store = createStore(
+        val store =
+            createStore(
                 initialState = CounterState(count = 0),
                 reducer = slowReducer,
                 middlewares = listOf(delayMiddleware),
@@ -74,54 +74,51 @@ class ConcurrencyTest {
                 scope = storeScope,
             )
 
-            try {
-                store.state.test {
-                    assertEquals(0, awaitItem().count)
+        try {
+            store.state.test {
+                assertEquals(0, awaitItem().count)
 
-                    // Dispatch many increments concurrently
-                    repeat(concurrentActionCount) {
-                        store.dispatch(CounterAction.Increment)
-                    }
-
-                    // Collect all state updates
-                    var lastCount = 0
-                    repeat(concurrentActionCount) {
-                        lastCount = awaitItem().count
-                    }
-
-                    // If synchronization is correct, final count should equal the number of actions
-                    assertEquals(
-                        concurrentActionCount,
-                        lastCount,
-                        "Expected $concurrentActionCount but got $lastCount. " +
-                                "This indicates a race condition where some increments were lost."
-                    )
-
-                    cancelAndIgnoreRemainingEvents()
+                // Dispatch many increments concurrently
+                repeat(concurrentActionCount) {
+                    store.dispatch(CounterAction.Increment)
                 }
-            } finally {
-                storeScope.cancel()
+
+                // Collect all state updates
+                var lastCount = 0
+                repeat(concurrentActionCount) {
+                    lastCount = awaitItem().count
+                }
+
+                // If synchronization is correct, final count should equal the number of actions
+                assertEquals(
+                    concurrentActionCount,
+                    lastCount,
+                    "Expected $concurrentActionCount but got $lastCount. " +
+                        "This indicates a race condition where some increments were lost.",
+                )
+
+                cancelAndIgnoreRemainingEvents()
             }
+        } finally {
+            storeScope.cancel()
         }
+    }
 
     @Test
-    fun `concurrent add operations should accumulate correctly`() =
-        runBlocking {
-            // Similar to increment test but with Add operations
-            // Each Add(1) should increment by 1, so 50 Add(1) actions should result in 50
-            //
-            // NOTE: Using runBlocking with Dispatchers.Default to ensure real multi-threading
+    fun `concurrent add operations should accumulate correctly`() = runBlocking {
+        // Similar to increment test but with Add operations
+        // Each Add(1) should increment by 1, so 50 Add(1) actions should result in 50
+        //
+        // NOTE: Using runBlocking with Dispatchers.Default to ensure real multi-threading
 
-            val concurrentActionCount = 50
-            val storeScope = CoroutineScope(Dispatchers.Default + Job())
+        val concurrentActionCount = 50
+        val storeScope = CoroutineScope(Dispatchers.Default + Job())
 
-            val delayMiddleware = object : Middleware<CounterState, CounterAction> {
+        val delayMiddleware =
+            object : Middleware<CounterState, CounterAction> {
                 override val processors: ActionProcessorMap<CounterState, CounterAction> = emptyMap()
 
-                override fun process(
-                    getState: () -> CounterState,
-                    action: CounterAction,
-                ): Flow<CounterAction> = flow {
+                override fun process(getState: () -> CounterState, action: CounterAction): Flow<CounterAction> = flow {
                     if (action is CounterAction.Add) {
                         delay(5)
                     }
@@ -129,7 +126,8 @@ class ConcurrencyTest {
                 }
             }
 
-            val store = createStore(
+        val store =
+            createStore(
                 initialState = CounterState(count = 0),
                 reducer = counterReducer,
                 middlewares = listOf(delayMiddleware),
@@ -137,49 +135,46 @@ class ConcurrencyTest {
                 scope = storeScope,
             )
 
-            try {
-                store.state.test {
-                    assertEquals(0, awaitItem().count)
+        try {
+            store.state.test {
+                assertEquals(0, awaitItem().count)
 
-                    repeat(concurrentActionCount) {
-                        store.dispatch(CounterAction.Add(1))
-                    }
-
-                    var lastCount = 0
-                    repeat(concurrentActionCount) {
-                        lastCount = awaitItem().count
-                    }
-
-                    assertEquals(
-                        concurrentActionCount,
-                        lastCount,
-                        "Expected $concurrentActionCount but got $lastCount. Race condition detected."
-                    )
-
-                    cancelAndIgnoreRemainingEvents()
+                repeat(concurrentActionCount) {
+                    store.dispatch(CounterAction.Add(1))
                 }
-            } finally {
-                storeScope.cancel()
+
+                var lastCount = 0
+                repeat(concurrentActionCount) {
+                    lastCount = awaitItem().count
+                }
+
+                assertEquals(
+                    concurrentActionCount,
+                    lastCount,
+                    "Expected $concurrentActionCount but got $lastCount. Race condition detected.",
+                )
+
+                cancelAndIgnoreRemainingEvents()
             }
+        } finally {
+            storeScope.cancel()
         }
+    }
 
     @Test
-    fun `mixed fast and slow actions should maintain state consistency`() =
-        runBlocking {
-            // Test scenario: slow IO action followed by fast actions
-            // All actions should be properly synchronized
-            //
-            // NOTE: Using runBlocking with Dispatchers.Default to ensure real multi-threading
+    fun `mixed fast and slow actions should maintain state consistency`() = runBlocking {
+        // Test scenario: slow IO action followed by fast actions
+        // All actions should be properly synchronized
+        //
+        // NOTE: Using runBlocking with Dispatchers.Default to ensure real multi-threading
 
-            val storeScope = CoroutineScope(Dispatchers.Default + Job())
+        val storeScope = CoroutineScope(Dispatchers.Default + Job())
 
-            val slowMiddleware = object : Middleware<CounterState, CounterAction> {
+        val slowMiddleware =
+            object : Middleware<CounterState, CounterAction> {
                 override val processors: ActionProcessorMap<CounterState, CounterAction> = emptyMap()
 
-                override fun process(
-                    getState: () -> CounterState,
-                    action: CounterAction,
-                ): Flow<CounterAction> = flow {
+                override fun process(getState: () -> CounterState, action: CounterAction): Flow<CounterAction> = flow {
                     when (action) {
                         is CounterAction.FetchData -> {
                             delay(100) // Slow IO
@@ -190,7 +185,8 @@ class ConcurrencyTest {
                 }
             }
 
-            val store = createStore(
+        val store =
+            createStore(
                 initialState = CounterState(count = 0),
                 reducer = counterReducer,
                 middlewares = listOf(slowMiddleware),
@@ -198,75 +194,75 @@ class ConcurrencyTest {
                 scope = storeScope,
             )
 
-            try {
-                store.state.test {
-                    assertEquals(0, awaitItem().count)
+        try {
+            store.state.test {
+                assertEquals(0, awaitItem().count)
 
-                    // Dispatch slow action
-                    store.dispatch(CounterAction.FetchData("slow"))
+                // Dispatch slow action
+                store.dispatch(CounterAction.FetchData("slow"))
 
-                    // Dispatch fast actions while slow is processing
-                    store.dispatch(CounterAction.Increment) // +1
-                    store.dispatch(CounterAction.Increment) // +1
-                    store.dispatch(CounterAction.Increment) // +1
+                // Dispatch fast actions while slow is processing
+                store.dispatch(CounterAction.Increment) // +1
+                store.dispatch(CounterAction.Increment) // +1
+                store.dispatch(CounterAction.Increment) // +1
 
-                    // Fast actions complete first
-                    assertEquals(1, awaitItem().count)
-                    assertEquals(2, awaitItem().count)
-                    assertEquals(3, awaitItem().count)
+                // Fast actions complete first
+                assertEquals(1, awaitItem().count)
+                assertEquals(2, awaitItem().count)
+                assertEquals(3, awaitItem().count)
 
-                    // Slow action completes and should add 10 to current state (3)
-                    assertEquals(13, awaitItem().count)
+                // Slow action completes and should add 10 to current state (3)
+                assertEquals(13, awaitItem().count)
 
-                    cancelAndIgnoreRemainingEvents()
-                }
-            } finally {
-                storeScope.cancel()
+                cancelAndIgnoreRemainingEvents()
             }
+        } finally {
+            storeScope.cancel()
         }
+    }
 
     @Test
-    fun `high concurrency stress test for state synchronization`() =
-        runBlocking {
-            // Stress test with high concurrency to detect any synchronization issues
-            //
-            // NOTE: Using runBlocking with Dispatchers.Default to ensure real multi-threading
+    fun `high concurrency stress test for state synchronization`() = runBlocking {
+        // Stress test with high concurrency to detect any synchronization issues
+        //
+        // NOTE: Using runBlocking with Dispatchers.Default to ensure real multi-threading
 
-            val actionCount = 200
-            val storeScope = CoroutineScope(Dispatchers.Default + Job())
+        val actionCount = 200
+        val storeScope = CoroutineScope(Dispatchers.Default + Job())
 
-            val store = createStore(
+        val store =
+            createStore(
                 initialState = CounterState(count = 0),
                 reducer = counterReducer,
                 errorProcessor = testErrorProcessor,
                 scope = storeScope,
             )
 
-            try {
-                store.state.test {
-                    assertEquals(0, awaitItem().count)
+        try {
+            store.state.test {
+                assertEquals(0, awaitItem().count)
 
-                    // Dispatch many actions as fast as possible
-                    repeat(actionCount) {
-                        store.dispatch(CounterAction.Increment)
-                    }
-
-                    // Wait for all to complete and verify final state
-                    var lastCount = 0
-                    repeat(actionCount) {
-                        lastCount = awaitItem().count
-                    }
-
-                    assertEquals(
-                        actionCount,
-                        lastCount,
-                        "State synchronization failed under high concurrency"
-                    )
-
-                    cancelAndIgnoreRemainingEvents()
+                // Dispatch many actions as fast as possible
+                repeat(actionCount) {
+                    store.dispatch(CounterAction.Increment)
                 }
-            } finally {
-                storeScope.cancel()
+
+                // Wait for all to complete and verify final state
+                var lastCount = 0
+                repeat(actionCount) {
+                    lastCount = awaitItem().count
+                }
+
+                assertEquals(
+                    actionCount,
+                    lastCount,
+                    "State synchronization failed under high concurrency",
+                )
+
+                cancelAndIgnoreRemainingEvents()
             }
+        } finally {
+            storeScope.cancel()
         }
+    }
 }

--- a/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/ErrorHandlingTest.kt
+++ b/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/ErrorHandlingTest.kt
@@ -11,23 +11,19 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-import kotlin.test.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ErrorHandlingTest {
-
     @Test
-    fun `middleware handles IO error and emits error action`() =
-        runTest {
-            val ioMiddleware = object : Middleware<CounterState, CounterAction> {
+    fun `middleware handles IO error and emits error action`() = runTest {
+        val ioMiddleware =
+            object : Middleware<CounterState, CounterAction> {
                 override val processors: ActionProcessorMap<CounterState, CounterAction> = emptyMap()
 
-                override fun process(
-                    getState: () -> CounterState,
-                    action: CounterAction,
-                ): Flow<CounterAction> = flow {
+                override fun process(getState: () -> CounterState, action: CounterAction): Flow<CounterAction> = flow {
                     if (action is CounterAction.FetchData) {
                         delay(100)
                         if (action.id == "error") {
@@ -41,8 +37,9 @@ class ErrorHandlingTest {
                 }
             }
 
-            var errorReceived = false
-            val errorTrackingReducer = Reducer<CounterState, CounterAction> { state, action ->
+        var errorReceived = false
+        val errorTrackingReducer =
+            Reducer<CounterState, CounterAction> { state, action ->
                 when (action) {
                     is CounterAction.FetchDataError -> {
                         errorReceived = true
@@ -53,7 +50,8 @@ class ErrorHandlingTest {
                 }
             }
 
-            val store = createStore(
+        val store =
+            createStore(
                 initialState = CounterState(),
                 reducer = errorTrackingReducer,
                 middlewares = listOf(ioMiddleware),
@@ -61,37 +59,35 @@ class ErrorHandlingTest {
                 scope = backgroundScope,
             )
 
-            store.state.test {
-                assertEquals(0, awaitItem().count)
+        store.state.test {
+            assertEquals(0, awaitItem().count)
 
-                store.dispatch(CounterAction.FetchData("error"))
-                assertEquals(-1, awaitItem().count)
+            store.dispatch(CounterAction.FetchData("error"))
+            assertEquals(-1, awaitItem().count)
 
-                assertTrue(errorReceived)
+            assertTrue(errorReceived)
 
-                cancelAndIgnoreRemainingEvents()
-            }
+            cancelAndIgnoreRemainingEvents()
         }
+    }
 
     @Test
-    fun `middleware with IO exception is caught by error processor`() =
-        runTest {
-            var caughtException: Throwable? = null
+    fun `middleware with IO exception is caught by error processor`() = runTest {
+        var caughtException: Throwable? = null
 
-            val errorProcessor = object : ErrorProcessor<CounterAction> {
+        val errorProcessor =
+            object : ErrorProcessor<CounterAction> {
                 override fun process(throwable: Throwable): Flow<CounterAction> {
                     caughtException = throwable
                     return flowOf(CounterAction.SetValue(-1))
                 }
             }
 
-            val ioMiddleware = object : Middleware<CounterState, CounterAction> {
+        val ioMiddleware =
+            object : Middleware<CounterState, CounterAction> {
                 override val processors: ActionProcessorMap<CounterState, CounterAction> = emptyMap()
 
-                override fun process(
-                    getState: () -> CounterState,
-                    action: CounterAction,
-                ): Flow<CounterAction> = flow {
+                override fun process(getState: () -> CounterState, action: CounterAction): Flow<CounterAction> = flow {
                     if (action is CounterAction.FetchData && action.id == "crash") {
                         throw RuntimeException("IO Exception!")
                     }
@@ -99,7 +95,8 @@ class ErrorHandlingTest {
                 }
             }
 
-            val store = createStore(
+        val store =
+            createStore(
                 initialState = CounterState(),
                 reducer = counterReducer,
                 middlewares = listOf(ioMiddleware),
@@ -107,38 +104,36 @@ class ErrorHandlingTest {
                 scope = backgroundScope,
             )
 
-            store.state.test {
-                assertEquals(0, awaitItem().count)
+        store.state.test {
+            assertEquals(0, awaitItem().count)
 
-                store.dispatch(CounterAction.FetchData("crash"))
-                assertEquals(-1, awaitItem().count)
+            store.dispatch(CounterAction.FetchData("crash"))
+            assertEquals(-1, awaitItem().count)
 
-                assertTrue(caughtException is RuntimeException)
-                assertEquals("IO Exception!", caughtException?.message)
+            assertTrue(caughtException is RuntimeException)
+            assertEquals("IO Exception!", caughtException?.message)
 
-                cancelAndIgnoreRemainingEvents()
-            }
+            cancelAndIgnoreRemainingEvents()
         }
+    }
 
     @Test
-    fun `error in one IO operation does not affect others`() =
-        runTest {
-            var errorCount = 0
+    fun `error in one IO operation does not affect others`() = runTest {
+        var errorCount = 0
 
-            val errorProcessor = object : ErrorProcessor<CounterAction> {
+        val errorProcessor =
+            object : ErrorProcessor<CounterAction> {
                 override fun process(throwable: Throwable): Flow<CounterAction> {
                     errorCount++
                     return emptyFlow()
                 }
             }
 
-            val ioMiddleware = object : Middleware<CounterState, CounterAction> {
+        val ioMiddleware =
+            object : Middleware<CounterState, CounterAction> {
                 override val processors: ActionProcessorMap<CounterState, CounterAction> = emptyMap()
 
-                override fun process(
-                    getState: () -> CounterState,
-                    action: CounterAction,
-                ): Flow<CounterAction> = flow {
+                override fun process(getState: () -> CounterState, action: CounterAction): Flow<CounterAction> = flow {
                     if (action is CounterAction.FetchData) {
                         delay(50)
                         if (action.id == "fail") {
@@ -151,7 +146,8 @@ class ErrorHandlingTest {
                 }
             }
 
-            val store = createStore(
+        val store =
+            createStore(
                 initialState = CounterState(),
                 reducer = counterReducer,
                 middlewares = listOf(ioMiddleware),
@@ -159,100 +155,102 @@ class ErrorHandlingTest {
                 scope = backgroundScope,
             )
 
-            store.state.test {
-                assertEquals(0, awaitItem().count)
+        store.state.test {
+            assertEquals(0, awaitItem().count)
 
-                store.dispatch(CounterAction.FetchData("success-1"))
-                store.dispatch(CounterAction.FetchData("fail"))
-                store.dispatch(CounterAction.FetchData("success-2"))
+            store.dispatch(CounterAction.FetchData("success-1"))
+            store.dispatch(CounterAction.FetchData("fail"))
+            store.dispatch(CounterAction.FetchData("success-2"))
 
-                // Two successful operations should complete
-                assertEquals(10, awaitItem().count)
-                assertEquals(20, awaitItem().count)
+            // Two successful operations should complete
+            assertEquals(10, awaitItem().count)
+            assertEquals(20, awaitItem().count)
 
-                assertEquals(1, errorCount)
+            assertEquals(1, errorCount)
 
-                cancelAndIgnoreRemainingEvents()
-            }
+            cancelAndIgnoreRemainingEvents()
         }
+    }
 
     @Test
-    fun `external flow error is caught by error processor`() =
-        runTest {
-            var errorProcessed = false
-            val errorProcessor = object : ErrorProcessor<CounterAction> {
+    fun `external flow error is caught by error processor`() = runTest {
+        var errorProcessed = false
+        val errorProcessor =
+            object : ErrorProcessor<CounterAction> {
                 override fun process(throwable: Throwable): Flow<CounterAction> {
                     errorProcessed = true
                     return flowOf(CounterAction.SetValue(-999))
                 }
             }
 
-            val externalChannel = Channel<Int>(Channel.UNLIMITED)
-            val errorFlow = externalChannel.receiveAsFlow().map { value ->
+        val externalChannel = Channel<Int>(Channel.UNLIMITED)
+        val errorFlow =
+            externalChannel.receiveAsFlow().map { value ->
                 if (value < 0) throw RuntimeException("Negative value error!")
                 value
             }
 
-            val store = createStore(
+        val store =
+            createStore(
                 initialState = CounterState(),
                 reducer = counterReducer,
                 errorProcessor = errorProcessor,
                 scope = backgroundScope,
             )
 
-            store.state.test {
-                assertEquals(0, awaitItem().count)
+        store.state.test {
+            assertEquals(0, awaitItem().count)
 
-                store.dispatch(CounterAction.StreamConnected(errorFlow))
+            store.dispatch(CounterAction.StreamConnected(errorFlow))
 
-                externalChannel.send(10)
-                assertEquals(10, awaitItem().count)
+            externalChannel.send(10)
+            assertEquals(10, awaitItem().count)
 
-                externalChannel.send(-1)
-                assertEquals(-999, awaitItem().count)
+            externalChannel.send(-1)
+            assertEquals(-999, awaitItem().count)
 
-                assertTrue(errorProcessed)
+            assertTrue(errorProcessed)
 
-                cancelAndIgnoreRemainingEvents()
-            }
-
-            externalChannel.close()
+            cancelAndIgnoreRemainingEvents()
         }
 
+        externalChannel.close()
+    }
+
     @Test
-    fun `store continues working after FlowHolderAction error`() =
-        runTest {
-            val errorProcessor = object : ErrorProcessor<CounterAction> {
-                override fun process(throwable: Throwable): Flow<CounterAction> {
-                    return flowOf(CounterAction.SetValue(-1))
-                }
+    fun `store continues working after FlowHolderAction error`() = runTest {
+        val errorProcessor =
+            object : ErrorProcessor<CounterAction> {
+                override fun process(throwable: Throwable): Flow<CounterAction> = flowOf(CounterAction.SetValue(-1))
             }
 
-            val errorFlow = flow<Int> {
+        val errorFlow =
+            flow<Int> {
                 throw RuntimeException("Immediate error!")
             }
 
-            val store = createStore(
+        val store =
+            createStore(
                 initialState = CounterState(),
                 reducer = counterReducer,
                 errorProcessor = errorProcessor,
                 scope = backgroundScope,
             )
 
-            store.state.test {
-                assertEquals(0, awaitItem().count)
+        store.state.test {
+            assertEquals(0, awaitItem().count)
 
-                store.dispatch(CounterAction.StreamConnected(errorFlow))
-                assertEquals(-1, awaitItem().count)
+            store.dispatch(CounterAction.StreamConnected(errorFlow))
+            assertEquals(-1, awaitItem().count)
 
-                // Store is still working
-                store.dispatch(CounterAction.Increment)
-                assertEquals(0, awaitItem().count)
+            // Store is still working
+            store.dispatch(CounterAction.Increment)
+            assertEquals(0, awaitItem().count)
 
-                store.dispatch(CounterAction.Add(100))
-                assertEquals(100, awaitItem().count)
+            store.dispatch(CounterAction.Add(100))
+            assertEquals(100, awaitItem().count)
 
-                cancelAndIgnoreRemainingEvents()
-            }
+            cancelAndIgnoreRemainingEvents()
         }
+    }
 }

--- a/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/FlowHolderActionTest.kt
+++ b/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/FlowHolderActionTest.kt
@@ -6,319 +6,322 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-import kotlin.test.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class FlowHolderActionTest {
-
     // ============= Basic FlowHolderAction Tests =============
 
     @Test
-    fun `FlowHolderAction flattens inner flows and updates state`() =
-        runTest {
-            val valueChannel = Channel<Int>(Channel.UNLIMITED)
+    fun `FlowHolderAction flattens inner flows and updates state`() = runTest {
+        val valueChannel = Channel<Int>(Channel.UNLIMITED)
 
-            val store = createStore(
+        val store =
+            createStore(
                 initialState = CounterState(),
                 reducer = counterReducer,
                 errorProcessor = testErrorProcessor,
                 scope = backgroundScope,
             )
 
-            store.state.test {
-                assertEquals(0, awaitItem().count)
+        store.state.test {
+            assertEquals(0, awaitItem().count)
 
-                store.dispatch(CounterAction.StreamConnected(valueChannel.receiveAsFlow()))
+            store.dispatch(CounterAction.StreamConnected(valueChannel.receiveAsFlow()))
 
-                valueChannel.send(5)
-                assertEquals(5, awaitItem().count)
+            valueChannel.send(5)
+            assertEquals(5, awaitItem().count)
 
-                valueChannel.send(3)
-                assertEquals(8, awaitItem().count)
+            valueChannel.send(3)
+            assertEquals(8, awaitItem().count)
 
-                valueChannel.close()
-                cancelAndIgnoreRemainingEvents()
-            }
+            valueChannel.close()
+            cancelAndIgnoreRemainingEvents()
         }
+    }
 
     @Test
-    fun `FlowHolderAction with multiple flows merges all streams`() =
-        runTest {
-            val channel1 = Channel<Int>(Channel.UNLIMITED)
-            val channel2 = Channel<Int>(Channel.UNLIMITED)
+    fun `FlowHolderAction with multiple flows merges all streams`() = runTest {
+        val channel1 = Channel<Int>(Channel.UNLIMITED)
+        val channel2 = Channel<Int>(Channel.UNLIMITED)
 
-            val store = createStore(
+        val store =
+            createStore(
                 initialState = CounterState(),
                 reducer = counterReducer,
                 errorProcessor = testErrorProcessor,
                 scope = backgroundScope,
             )
 
-            store.state.test {
-                assertEquals(0, awaitItem().count)
+        store.state.test {
+            assertEquals(0, awaitItem().count)
 
-                store.dispatch(
-                    CounterAction.MultiStreamConnected(
-                        channel1.receiveAsFlow(),
-                        channel2.receiveAsFlow()
-                    )
-                )
+            store.dispatch(
+                CounterAction.MultiStreamConnected(
+                    channel1.receiveAsFlow(),
+                    channel2.receiveAsFlow(),
+                ),
+            )
 
-                channel1.send(10)
-                assertEquals(10, awaitItem().count)
+            channel1.send(10)
+            assertEquals(10, awaitItem().count)
 
-                channel2.send(5)
-                assertEquals(15, awaitItem().count)
+            channel2.send(5)
+            assertEquals(15, awaitItem().count)
 
-                channel1.send(3)
-                assertEquals(18, awaitItem().count)
+            channel1.send(3)
+            assertEquals(18, awaitItem().count)
 
-                channel1.close()
-                channel2.close()
-                cancelAndIgnoreRemainingEvents()
-            }
+            channel1.close()
+            channel2.close()
+            cancelAndIgnoreRemainingEvents()
         }
+    }
 
     @Test
-    fun `FlowHolderAction completes when channel is closed`() =
-        runTest {
-            val valueChannel = Channel<Int>(Channel.UNLIMITED)
+    fun `FlowHolderAction completes when channel is closed`() = runTest {
+        val valueChannel = Channel<Int>(Channel.UNLIMITED)
 
-            val store = createStore(
+        val store =
+            createStore(
                 initialState = CounterState(),
                 reducer = counterReducer,
                 errorProcessor = testErrorProcessor,
                 scope = backgroundScope,
             )
 
-            store.state.test {
-                assertEquals(0, awaitItem().count)
+        store.state.test {
+            assertEquals(0, awaitItem().count)
 
-                store.dispatch(CounterAction.StreamConnected(valueChannel.receiveAsFlow()))
+            store.dispatch(CounterAction.StreamConnected(valueChannel.receiveAsFlow()))
 
-                valueChannel.send(5)
-                assertEquals(5, awaitItem().count)
+            valueChannel.send(5)
+            assertEquals(5, awaitItem().count)
 
-                valueChannel.send(10)
-                assertEquals(15, awaitItem().count)
+            valueChannel.send(10)
+            assertEquals(15, awaitItem().count)
 
-                valueChannel.close()
+            valueChannel.close()
 
-                cancelAndIgnoreRemainingEvents()
-            }
+            cancelAndIgnoreRemainingEvents()
         }
+    }
 
     @Test
-    fun `cancelable FlowHolderAction cancels previous stream when new one is dispatched`() =
-        runTest {
-            val store = createStore(
+    fun `cancelable FlowHolderAction cancels previous stream when new one is dispatched`() = runTest {
+        val store =
+            createStore(
                 initialState = CounterState(),
                 reducer = counterReducer,
                 errorProcessor = testErrorProcessor,
                 scope = backgroundScope,
             )
 
-            store.state.test {
-                assertEquals(0, awaitItem().count)
+        store.state.test {
+            assertEquals(0, awaitItem().count)
 
-                // Start first infinite stream
-                store.dispatch(CounterAction.InfiniteStreamAction("stream1", emitInterval = 50L))
+            // Start first infinite stream
+            store.dispatch(CounterAction.InfiniteStreamAction("stream1", emitInterval = 50L))
 
-                // Wait for a few emissions
-                assertEquals(1, awaitItem().count)
-                assertEquals(2, awaitItem().count)
+            // Wait for a few emissions
+            assertEquals(1, awaitItem().count)
+            assertEquals(2, awaitItem().count)
 
-                val countBeforeNewStream = store.currentState.count
+            val countBeforeNewStream = store.currentState.count
 
-                // Start second stream - should cancel the first
-                store.dispatch(CounterAction.InfiniteStreamAction("stream2", emitInterval = 50L))
+            // Start second stream - should cancel the first
+            store.dispatch(CounterAction.InfiniteStreamAction("stream2", emitInterval = 50L))
 
-                // Wait for emissions from the new stream
-                awaitItem()
-                awaitItem()
-                awaitItem()
+            // Wait for emissions from the new stream
+            awaitItem()
+            awaitItem()
+            awaitItem()
 
-                // The count should only reflect emissions from one stream at a time
-                // If both streams were running, count would increase much faster
-                val countAfter = store.currentState.count
+            // The count should only reflect emissions from one stream at a time
+            // If both streams were running, count would increase much faster
+            val countAfter = store.currentState.count
 
-                // Should have roughly countBeforeNewStream + 3 emissions (not double)
-                assertTrue(
-                    countAfter <= countBeforeNewStream + 5,
-                    "Expected count to be around ${countBeforeNewStream + 3}, but was $countAfter. " +
-                        "Both streams might be running concurrently."
-                )
+            // Should have roughly countBeforeNewStream + 3 emissions (not double)
+            assertTrue(
+                countAfter <= countBeforeNewStream + 5,
+                "Expected count to be around ${countBeforeNewStream + 3}, but was $countAfter. " +
+                    "Both streams might be running concurrently.",
+            )
 
-                cancelAndIgnoreRemainingEvents()
-            }
+            cancelAndIgnoreRemainingEvents()
         }
+    }
 
     @Test
-    fun `non-cancelable FlowHolderAction allows multiple streams to run concurrently`() =
-        runTest {
-            val store = createStore(
+    fun `non-cancelable FlowHolderAction allows multiple streams to run concurrently`() = runTest {
+        val store =
+            createStore(
                 initialState = CounterState(),
                 reducer = counterReducer,
                 errorProcessor = testErrorProcessor,
                 scope = backgroundScope,
             )
 
-            store.state.test {
-                assertEquals(0, awaitItem().count)
+        store.state.test {
+            assertEquals(0, awaitItem().count)
 
-                // Start two non-cancelable streams
-                store.dispatch(CounterAction.NonCancelableStreamAction("stream1", listOf(1, 1, 1), delayBetween = 30L))
-                store.dispatch(CounterAction.NonCancelableStreamAction("stream2", listOf(10, 10, 10), delayBetween = 30L))
+            // Start two non-cancelable streams
+            store.dispatch(CounterAction.NonCancelableStreamAction("stream1", listOf(1, 1, 1), delayBetween = 30L))
+            store.dispatch(
+                CounterAction.NonCancelableStreamAction("stream2", listOf(10, 10, 10), delayBetween = 30L),
+            )
 
-                // Both streams should complete and contribute to the count
-                // stream1: 1 + 1 + 1 = 3
-                // stream2: 10 + 10 + 10 = 30
-                // Total: 33
+            // Both streams should complete and contribute to the count
+            // stream1: 1 + 1 + 1 = 3
+            // stream2: 10 + 10 + 10 = 30
+            // Total: 33
 
-                // Collect all emissions
-                var lastCount = 0
-                repeat(6) {
-                    lastCount = awaitItem().count
+            // Collect all emissions
+            var lastCount = 0
+            repeat(6) {
+                lastCount = awaitItem().count
+            }
+
+            assertEquals(
+                33,
+                lastCount,
+                "Expected both streams to contribute (33), but got $lastCount",
+            )
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `cancelable FlowHolderAction is cancelled when store is closed`() = runTest {
+        val store =
+            createStore(
+                initialState = CounterState(),
+                reducer = counterReducer,
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
+
+        store.state.test {
+            assertEquals(0, awaitItem().count)
+
+            // Start infinite stream
+            store.dispatch(CounterAction.InfiniteStreamAction("stream1", emitInterval = 50L))
+
+            // Wait for a few emissions
+            assertEquals(1, awaitItem().count)
+            assertEquals(2, awaitItem().count)
+
+            // Close the store
+            store.close()
+
+            // Verify no new emissions occur after closing
+            expectNoEvents()
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `other actions are processed while infinite stream is running`() = runTest {
+        val store =
+            createStore(
+                initialState = CounterState(),
+                reducer = counterReducer,
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
+
+        store.state.test {
+            assertEquals(0, awaitItem().count)
+
+            // Start infinite stream
+            store.dispatch(CounterAction.InfiniteStreamAction("stream1", emitInterval = 100L))
+
+            // Wait for first emission
+            assertEquals(1, awaitItem().count)
+
+            // Dispatch a regular action while stream is running
+            store.dispatch(CounterAction.Add(100))
+
+            // The Add action should be processed
+            // We might get stream emission first or Add first, but Add should be processed
+            var foundAdd = false
+            repeat(5) {
+                val count = awaitItem().count
+                if (count >= 101) {
+                    foundAdd = true
                 }
-
-                assertEquals(33, lastCount,
-                    "Expected both streams to contribute (33), but got $lastCount"
-                )
-
-                cancelAndIgnoreRemainingEvents()
             }
+
+            assertTrue(
+                foundAdd,
+                "Regular action should be processed while infinite stream is running",
+            )
+
+            cancelAndIgnoreRemainingEvents()
         }
+    }
 
     @Test
-    fun `cancelable FlowHolderAction is cancelled when store is closed`() =
-        runTest {
-            val store = createStore(
+    fun `different cancelable FlowHolderAction types run concurrently without canceling each other`() = runTest {
+        val store =
+            createStore(
                 initialState = CounterState(),
                 reducer = counterReducer,
                 errorProcessor = testErrorProcessor,
                 scope = backgroundScope,
             )
 
-            store.state.test {
-                assertEquals(0, awaitItem().count)
+        store.state.test {
+            assertEquals(0, awaitItem().count)
 
-                // Start infinite stream
-                store.dispatch(CounterAction.InfiniteStreamAction("stream1", emitInterval = 50L))
+            // Start first cancelable stream (adds 1 per emission)
+            store.dispatch(CounterAction.InfiniteStreamAction("stream1", emitInterval = 50L))
 
-                // Wait for a few emissions
-                assertEquals(1, awaitItem().count)
-                assertEquals(2, awaitItem().count)
+            // Wait for first emission from InfiniteStreamAction
+            val firstCount = awaitItem().count
+            assertEquals(1, firstCount)
 
-                // Close the store
-                store.close()
+            // Start second cancelable stream of a DIFFERENT type (adds 10 per emission)
+            store.dispatch(CounterAction.SecondaryStreamAction("stream2", emitInterval = 50L))
 
-                // Verify no new emissions occur after closing
-                expectNoEvents()
+            // Both streams should continue running concurrently
+            // We should see increments of both 1 and 10
+            var sawIncrementByOne = false
+            var sawIncrementByTen = false
 
-                cancelAndIgnoreRemainingEvents()
+            var previousCount = firstCount
+            repeat(10) {
+                val currentCount = awaitItem().count
+                val increment = currentCount - previousCount
+
+                if (increment == 1) sawIncrementByOne = true
+                if (increment == 10) sawIncrementByTen = true
+
+                previousCount = currentCount
             }
-        }
 
-    @Test
-    fun `other actions are processed while infinite stream is running`() =
-        runTest {
-            val store = createStore(
-                initialState = CounterState(),
-                reducer = counterReducer,
-                errorProcessor = testErrorProcessor,
-                scope = backgroundScope,
+            assertTrue(
+                sawIncrementByOne && sawIncrementByTen,
+                "Expected both streams to run concurrently. " +
+                    "sawIncrementByOne=$sawIncrementByOne, sawIncrementByTen=$sawIncrementByTen",
             )
 
-            store.state.test {
-                assertEquals(0, awaitItem().count)
-
-                // Start infinite stream
-                store.dispatch(CounterAction.InfiniteStreamAction("stream1", emitInterval = 100L))
-
-                // Wait for first emission
-                assertEquals(1, awaitItem().count)
-
-                // Dispatch a regular action while stream is running
-                store.dispatch(CounterAction.Add(100))
-
-                // The Add action should be processed
-                // We might get stream emission first or Add first, but Add should be processed
-                var foundAdd = false
-                repeat(5) {
-                    val count = awaitItem().count
-                    if (count >= 101) {
-                        foundAdd = true
-                    }
-                }
-
-                assertTrue(
-                    foundAdd,
-                    "Regular action should be processed while infinite stream is running"
-                )
-
-                cancelAndIgnoreRemainingEvents()
-            }
+            cancelAndIgnoreRemainingEvents()
         }
-
-    @Test
-    fun `different cancelable FlowHolderAction types run concurrently without canceling each other`() =
-        runTest {
-            val store = createStore(
-                initialState = CounterState(),
-                reducer = counterReducer,
-                errorProcessor = testErrorProcessor,
-                scope = backgroundScope,
-            )
-
-            store.state.test {
-                assertEquals(0, awaitItem().count)
-
-                // Start first cancelable stream (adds 1 per emission)
-                store.dispatch(CounterAction.InfiniteStreamAction("stream1", emitInterval = 50L))
-
-                // Wait for first emission from InfiniteStreamAction
-                val firstCount = awaitItem().count
-                assertEquals(1, firstCount)
-
-                // Start second cancelable stream of a DIFFERENT type (adds 10 per emission)
-                store.dispatch(CounterAction.SecondaryStreamAction("stream2", emitInterval = 50L))
-
-                // Both streams should continue running concurrently
-                // We should see increments of both 1 and 10
-                var sawIncrementByOne = false
-                var sawIncrementByTen = false
-
-                var previousCount = firstCount
-                repeat(10) {
-                    val currentCount = awaitItem().count
-                    val increment = currentCount - previousCount
-
-                    if (increment == 1) sawIncrementByOne = true
-                    if (increment == 10) sawIncrementByTen = true
-
-                    previousCount = currentCount
-                }
-
-                assertTrue(
-                    sawIncrementByOne && sawIncrementByTen,
-                    "Expected both streams to run concurrently. " +
-                        "sawIncrementByOne=$sawIncrementByOne, sawIncrementByTen=$sawIncrementByTen"
-                )
-
-                cancelAndIgnoreRemainingEvents()
-            }
-        }
+    }
 
     // ============= Delivery Tests =============
 
     @Test
-    fun `default Emit delivery bypasses user middlewares`() =
-        runTest {
-            val middlewareProcessedActions = mutableListOf<Action>()
+    fun `default Emit delivery bypasses user middlewares`() = runTest {
+        val middlewareProcessedActions = mutableListOf<Action>()
 
-            val trackingMiddleware = object : Middleware<CounterState, CounterAction> {
+        val trackingMiddleware =
+            object : Middleware<CounterState, CounterAction> {
                 override val name = "TrackingMiddleware"
                 override val processors: ActionProcessorMap<CounterState, CounterAction> = emptyMap()
 
@@ -331,9 +334,10 @@ class FlowHolderActionTest {
                 }
             }
 
-            val valueChannel = Channel<Int>(Channel.UNLIMITED)
+        val valueChannel = Channel<Int>(Channel.UNLIMITED)
 
-            val store = createStore(
+        val store =
+            createStore(
                 initialState = CounterState(),
                 middlewares = listOf(trackingMiddleware),
                 reducer = counterReducer,
@@ -341,38 +345,38 @@ class FlowHolderActionTest {
                 scope = backgroundScope,
             )
 
-            store.state.test {
-                assertEquals(0, awaitItem().count)
+        store.state.test {
+            assertEquals(0, awaitItem().count)
 
-                // StreamConnected uses default delivery (Emit)
-                store.dispatch(CounterAction.StreamConnected(valueChannel.receiveAsFlow()))
+            // StreamConnected uses default delivery (Emit)
+            store.dispatch(CounterAction.StreamConnected(valueChannel.receiveAsFlow()))
 
-                valueChannel.send(5)
-                assertEquals(5, awaitItem().count)
+            valueChannel.send(5)
+            assertEquals(5, awaitItem().count)
 
-                valueChannel.send(3)
-                assertEquals(8, awaitItem().count)
+            valueChannel.send(3)
+            assertEquals(8, awaitItem().count)
 
-                valueChannel.close()
+            valueChannel.close()
 
-                // StreamConnected itself passes through the middleware,
-                // but inner Add actions should NOT appear in the tracking middleware
-                val innerActionsInMiddleware = middlewareProcessedActions.filterIsInstance<CounterAction.Add>()
-                assertTrue(
-                    innerActionsInMiddleware.isEmpty(),
-                    "Default Emit delivery should bypass user middlewares, but found inner actions: $innerActionsInMiddleware"
-                )
+            // StreamConnected itself passes through the middleware,
+            // but inner Add actions should NOT appear in the tracking middleware
+            val innerActionsInMiddleware = middlewareProcessedActions.filterIsInstance<CounterAction.Add>()
+            assertTrue(
+                innerActionsInMiddleware.isEmpty(),
+                "Default Emit delivery should bypass user middlewares, but found inner actions: $innerActionsInMiddleware",
+            )
 
-                cancelAndIgnoreRemainingEvents()
-            }
+            cancelAndIgnoreRemainingEvents()
         }
+    }
 
     @Test
-    fun `explicit Dispatch delivery sends inner actions through full middleware pipeline`() =
-        runTest {
-            val middlewareProcessedActions = mutableListOf<Action>()
+    fun `explicit Dispatch delivery sends inner actions through full middleware pipeline`() = runTest {
+        val middlewareProcessedActions = mutableListOf<Action>()
 
-            val trackingMiddleware = object : Middleware<CounterState, CounterAction> {
+        val trackingMiddleware =
+            object : Middleware<CounterState, CounterAction> {
                 override val name = "TrackingMiddleware"
                 override val processors: ActionProcessorMap<CounterState, CounterAction> = emptyMap()
 
@@ -385,9 +389,10 @@ class FlowHolderActionTest {
                 }
             }
 
-            val valueChannel = Channel<Int>(Channel.UNLIMITED)
+        val valueChannel = Channel<Int>(Channel.UNLIMITED)
 
-            val store = createStore(
+        val store =
+            createStore(
                 initialState = CounterState(),
                 middlewares = listOf(trackingMiddleware),
                 reducer = counterReducer,
@@ -395,214 +400,220 @@ class FlowHolderActionTest {
                 scope = backgroundScope,
             )
 
-            store.state.test {
-                assertEquals(0, awaitItem().count)
+        store.state.test {
+            assertEquals(0, awaitItem().count)
 
-                // DispatchDeliveryStreamAction uses explicit Dispatch delivery
-                store.dispatch(CounterAction.DispatchDeliveryStreamAction(valueChannel.receiveAsFlow()))
+            // DispatchDeliveryStreamAction uses explicit Dispatch delivery
+            store.dispatch(CounterAction.DispatchDeliveryStreamAction(valueChannel.receiveAsFlow()))
 
-                valueChannel.send(5)
-                assertEquals(5, awaitItem().count)
+            valueChannel.send(5)
+            assertEquals(5, awaitItem().count)
 
-                valueChannel.send(3)
-                assertEquals(8, awaitItem().count)
+            valueChannel.send(3)
+            assertEquals(8, awaitItem().count)
 
-                valueChannel.close()
+            valueChannel.close()
 
-                // Inner Add actions should pass through the tracking middleware
-                val innerActionsInMiddleware = middlewareProcessedActions.filterIsInstance<CounterAction.Add>()
-                assertTrue(
-                    innerActionsInMiddleware.isNotEmpty(),
-                    "Dispatch delivery should send inner actions through middlewares"
-                )
-                assertEquals(
-                    listOf(CounterAction.Add(5), CounterAction.Add(3)),
-                    innerActionsInMiddleware,
-                    "Expected Add(5) and Add(3) to pass through middleware"
-                )
+            // Inner Add actions should pass through the tracking middleware
+            val innerActionsInMiddleware = middlewareProcessedActions.filterIsInstance<CounterAction.Add>()
+            assertTrue(
+                innerActionsInMiddleware.isNotEmpty(),
+                "Dispatch delivery should send inner actions through middlewares",
+            )
+            assertEquals(
+                listOf(CounterAction.Add(5), CounterAction.Add(3)),
+                innerActionsInMiddleware,
+                "Expected Add(5) and Add(3) to pass through middleware",
+            )
 
-                cancelAndIgnoreRemainingEvents()
-            }
+            cancelAndIgnoreRemainingEvents()
         }
+    }
 
     // ============= Strategy-based Tests =============
 
     @Test
-    fun `FlowHolderAction with TakeLeading strategy ignores subsequent dispatches`() =
-        runTest {
-            val store = createStore(
+    fun `FlowHolderAction with TakeLeading strategy ignores subsequent dispatches`() = runTest {
+        val store =
+            createStore(
                 initialState = CounterState(),
                 reducer = counterReducer,
                 errorProcessor = testErrorProcessor,
                 scope = backgroundScope,
             )
 
-            store.state.test {
-                assertEquals(0, awaitItem().count)
+        store.state.test {
+            assertEquals(0, awaitItem().count)
 
-                // Start first TakeLeading stream (values: 1, 1, 1)
-                store.dispatch(CounterAction.TakeLeadingStreamAction("stream1", listOf(1, 1, 1), delayBetween = 50L))
+            // Start first TakeLeading stream (values: 1, 1, 1)
+            store.dispatch(CounterAction.TakeLeadingStreamAction("stream1", listOf(1, 1, 1), delayBetween = 50L))
 
-                // Immediately dispatch second stream (values: 10, 10, 10) - should be ignored
-                store.dispatch(CounterAction.TakeLeadingStreamAction("stream2", listOf(10, 10, 10), delayBetween = 50L))
+            // Immediately dispatch second stream (values: 10, 10, 10) - should be ignored
+            store.dispatch(CounterAction.TakeLeadingStreamAction("stream2", listOf(10, 10, 10), delayBetween = 50L))
 
-                // Only first stream should run
-                // stream1: 1 + 1 + 1 = 3
-                assertEquals(1, awaitItem().count)
-                assertEquals(2, awaitItem().count)
-                assertEquals(3, awaitItem().count)
+            // Only first stream should run
+            // stream1: 1 + 1 + 1 = 3
+            assertEquals(1, awaitItem().count)
+            assertEquals(2, awaitItem().count)
+            assertEquals(3, awaitItem().count)
 
-                // Verify second stream was ignored - no more emissions
-                expectNoEvents()
+            // Verify second stream was ignored - no more emissions
+            expectNoEvents()
 
-                assertEquals(3, store.currentState.count)
+            assertEquals(3, store.currentState.count)
 
-                cancelAndIgnoreRemainingEvents()
-            }
+            cancelAndIgnoreRemainingEvents()
         }
+    }
 
     @Test
-    fun `FlowHolderAction with Debounce strategy delays execution`() =
-        runTest {
-            val store = createStore(
+    fun `FlowHolderAction with Debounce strategy delays execution`() = runTest {
+        val store =
+            createStore(
                 initialState = CounterState(),
                 reducer = counterReducer,
                 errorProcessor = testErrorProcessor,
                 scope = backgroundScope,
             )
 
-            store.state.test {
-                assertEquals(0, awaitItem().count)
+        store.state.test {
+            assertEquals(0, awaitItem().count)
 
-                // Dispatch multiple debounced actions rapidly
-                store.dispatch(CounterAction.DebouncedStreamAction("a1", value = 1, debounceMs = 100L))
-                delay(30)
-                store.dispatch(CounterAction.DebouncedStreamAction("a2", value = 2, debounceMs = 100L))
-                delay(30)
-                store.dispatch(CounterAction.DebouncedStreamAction("a3", value = 3, debounceMs = 100L))
+            // Dispatch multiple debounced actions rapidly
+            store.dispatch(CounterAction.DebouncedStreamAction("a1", value = 1, debounceMs = 100L))
+            delay(30)
+            store.dispatch(CounterAction.DebouncedStreamAction("a2", value = 2, debounceMs = 100L))
+            delay(30)
+            store.dispatch(CounterAction.DebouncedStreamAction("a3", value = 3, debounceMs = 100L))
 
-                // Only the last one should execute after debounce
-                // Wait for debounce to complete
-                delay(150)
+            // Only the last one should execute after debounce
+            // Wait for debounce to complete
+            delay(150)
 
-                val finalCount = awaitItem().count
-                assertEquals(3, finalCount,
-                    "Expected only last debounced action (3) to execute, but got $finalCount"
-                )
+            val finalCount = awaitItem().count
+            assertEquals(
+                3,
+                finalCount,
+                "Expected only last debounced action (3) to execute, but got $finalCount",
+            )
 
-                cancelAndIgnoreRemainingEvents()
-            }
+            cancelAndIgnoreRemainingEvents()
         }
+    }
 
     @Test
-    fun `FlowHolderAction with Throttle strategy limits execution rate`() =
-        runTest {
-            val store = createStore(
+    fun `FlowHolderAction with Throttle strategy limits execution rate`() = runTest {
+        val store =
+            createStore(
                 initialState = CounterState(),
                 reducer = counterReducer,
                 errorProcessor = testErrorProcessor,
                 scope = backgroundScope,
             )
 
-            store.state.test {
-                assertEquals(0, awaitItem().count)
+        store.state.test {
+            assertEquals(0, awaitItem().count)
 
-                // Dispatch first throttled action - should execute immediately
-                store.dispatch(CounterAction.ThrottledStreamAction("a1", value = 1, throttleMs = 200L))
-                assertEquals(1, awaitItem().count)
+            // Dispatch first throttled action - should execute immediately
+            store.dispatch(CounterAction.ThrottledStreamAction("a1", value = 1, throttleMs = 200L))
+            assertEquals(1, awaitItem().count)
 
-                // Dispatch more actions within throttle window - should be ignored
-                store.dispatch(CounterAction.ThrottledStreamAction("a2", value = 10, throttleMs = 200L))
-                store.dispatch(CounterAction.ThrottledStreamAction("a3", value = 100, throttleMs = 200L))
+            // Dispatch more actions within throttle window - should be ignored
+            store.dispatch(CounterAction.ThrottledStreamAction("a2", value = 10, throttleMs = 200L))
+            store.dispatch(CounterAction.ThrottledStreamAction("a3", value = 100, throttleMs = 200L))
 
-                // Verify no new emissions from throttled actions
-                expectNoEvents()
+            // Verify no new emissions from throttled actions
+            expectNoEvents()
 
-                assertEquals(1, store.currentState.count,
-                    "Expected actions within throttle window to be ignored"
-                )
+            assertEquals(
+                1,
+                store.currentState.count,
+                "Expected actions within throttle window to be ignored",
+            )
 
-                cancelAndIgnoreRemainingEvents()
-            }
+            cancelAndIgnoreRemainingEvents()
         }
+    }
 
     // ============= Nested FlowHolderAction Tests =============
 
     @Test
-    fun `nested FlowHolderAction processes recursively`() =
-        runTest {
-            val store = createStore(
+    fun `nested FlowHolderAction processes recursively`() = runTest {
+        val store =
+            createStore(
                 initialState = CounterState(),
                 reducer = counterReducer,
                 errorProcessor = testErrorProcessor,
                 scope = backgroundScope,
             )
 
-            store.state.test {
-                assertEquals(0, awaitItem().count)
+        store.state.test {
+            assertEquals(0, awaitItem().count)
 
-                // Create an inner FlowHolderAction that adds 1, 2, 3
-                val innerAction = CounterAction.NonCancelableStreamAction(
+            // Create an inner FlowHolderAction that adds 1, 2, 3
+            val innerAction =
+                CounterAction.NonCancelableStreamAction(
                     id = "inner",
                     values = listOf(1, 2, 3),
-                    delayBetween = 10L
+                    delayBetween = 10L,
                 )
 
-                // Dispatch nested FlowHolderAction
-                // It will emit Add(100) first, then emit the innerAction
-                store.dispatch(CounterAction.NestedFlowHolderAction(innerAction))
+            // Dispatch nested FlowHolderAction
+            // It will emit Add(100) first, then emit the innerAction
+            store.dispatch(CounterAction.NestedFlowHolderAction(innerAction))
 
-                // First: Add(100) from outer action
-                assertEquals(100, awaitItem().count)
+            // First: Add(100) from outer action
+            assertEquals(100, awaitItem().count)
 
-                // Then: 1, 2, 3 from inner action
-                assertEquals(101, awaitItem().count)
-                assertEquals(103, awaitItem().count)
-                assertEquals(106, awaitItem().count)
+            // Then: 1, 2, 3 from inner action
+            assertEquals(101, awaitItem().count)
+            assertEquals(103, awaitItem().count)
+            assertEquals(106, awaitItem().count)
 
-                cancelAndIgnoreRemainingEvents()
-            }
+            cancelAndIgnoreRemainingEvents()
         }
+    }
 
     @Test
-    fun `deeply nested FlowHolderActions process correctly`() =
-        runTest {
-            val store = createStore(
+    fun `deeply nested FlowHolderActions process correctly`() = runTest {
+        val store =
+            createStore(
                 initialState = CounterState(),
                 reducer = counterReducer,
                 errorProcessor = testErrorProcessor,
                 scope = backgroundScope,
             )
 
-            store.state.test {
-                assertEquals(0, awaitItem().count)
+        store.state.test {
+            assertEquals(0, awaitItem().count)
 
-                // Level 3: innermost action emits 1
-                val level3 = CounterAction.NonCancelableStreamAction(
+            // Level 3: innermost action emits 1
+            val level3 =
+                CounterAction.NonCancelableStreamAction(
                     id = "level3",
                     values = listOf(1),
-                    delayBetween = 10L
+                    delayBetween = 10L,
                 )
 
-                // Level 2: wraps level3, also emits Add(100)
-                val level2 = CounterAction.NestedFlowHolderAction(level3)
+            // Level 2: wraps level3, also emits Add(100)
+            val level2 = CounterAction.NestedFlowHolderAction(level3)
 
-                // Level 1: wraps level2, also emits Add(100)
-                val level1 = CounterAction.NestedFlowHolderAction(level2)
+            // Level 1: wraps level2, also emits Add(100)
+            val level1 = CounterAction.NestedFlowHolderAction(level2)
 
-                // Dispatch the outermost nested action
-                store.dispatch(level1)
+            // Dispatch the outermost nested action
+            store.dispatch(level1)
 
-                // level1 emits Add(100), then level2
-                // level2 emits Add(100), then level3
-                // level3 emits Add(1)
-                // Total: 100 + 100 + 1 = 201
+            // level1 emits Add(100), then level2
+            // level2 emits Add(100), then level3
+            // level3 emits Add(1)
+            // Total: 100 + 100 + 1 = 201
 
-                assertEquals(100, awaitItem().count)  // From level1
-                assertEquals(200, awaitItem().count)  // From level2
-                assertEquals(201, awaitItem().count)  // From level3
+            assertEquals(100, awaitItem().count) // From level1
+            assertEquals(200, awaitItem().count) // From level2
+            assertEquals(201, awaitItem().count) // From level3
 
-                cancelAndIgnoreRemainingEvents()
-            }
+            cancelAndIgnoreRemainingEvents()
         }
+    }
 }

--- a/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/FlowPipelineTest.kt
+++ b/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/FlowPipelineTest.kt
@@ -17,7 +17,6 @@ import kotlin.test.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class FlowPipelineTest {
-
     @Test
     fun `stateIn with Dispatchers Default`(): Unit = runBlocking {
         println("\n=== stateIn with Dispatchers.Default ===\n")
@@ -26,23 +25,20 @@ class FlowPipelineTest {
 
         flow {
             listOf(1, 2, 3).forEach {
-                println("[${coroutineContext}] emit: $it")
+                println("[$coroutineContext] emit: $it")
                 emit(it)
             }
-        }
-            .map {
-                println("[${coroutineContext}] map1 start: $it")
-                delay(50)
-                println("[${coroutineContext}] map1 end: $it → ${it * 2}")
-                it * 2
-            }
-            .map {
-                println("[${coroutineContext}] map2 start: $it")
-                delay(50)
-                println("[${coroutineContext}] map2 end: $it → ${it + 1}")
-                it + 1
-            }
-            .stateIn(scope, SharingStarted.Eagerly, 0)
+        }.map {
+            println("[$coroutineContext] map1 start: $it")
+            delay(50)
+            println("[$coroutineContext] map1 end: $it → ${it * 2}")
+            it * 2
+        }.map {
+            println("[$coroutineContext] map2 start: $it")
+            delay(50)
+            println("[$coroutineContext] map2 end: $it → ${it + 1}")
+            it + 1
+        }.stateIn(scope, SharingStarted.Eagerly, 0)
             .let { stateFlow ->
                 delay(500)
                 println("\nFinal state: ${stateFlow.value}")
@@ -59,33 +55,29 @@ class FlowPipelineTest {
 
         flow {
             listOf(1, 2, 3).forEach {
-                println("[${coroutineContext}] emit: $it")
+                println("[$coroutineContext] emit: $it")
                 emit(it)
             }
-        }
-            .flatMapMerge { value ->
-                flow {
-                    println("[${coroutineContext}] flatMapMerge processing: $value")
-                    delay(50) // simulate async work
-                    emit(value)
-                }
+        }.flatMapMerge { value ->
+            flow {
+                println("[$coroutineContext] flatMapMerge processing: $value")
+                delay(50) // simulate async work
+                emit(value)
             }
-            .map {
-                println("[${coroutineContext}] map1 start: $it")
-                delay(30)
-                println("[${coroutineContext}] map1 end: $it → ${it * 10}")
-                it * 10
-            }
-            .map {
-                println("[${coroutineContext}] map2 start: $it")
-                delay(30)
-                println("[${coroutineContext}] map2 end: $it → ${it * 10}")
-                it * 10
-            }
-            .flowOn(Dispatchers.Default)
+        }.map {
+            println("[$coroutineContext] map1 start: $it")
+            delay(30)
+            println("[$coroutineContext] map1 end: $it → ${it * 10}")
+            it * 10
+        }.map {
+            println("[$coroutineContext] map2 start: $it")
+            delay(30)
+            println("[$coroutineContext] map2 end: $it → ${it * 10}")
+            it * 10
+        }.flowOn(Dispatchers.Default)
             .collect {
                 delay(500)
-                println("\nFinal state: ${it}")
+                println("\nFinal state: $it")
             }
 
         scope.coroutineContext[Job]?.cancel()
@@ -97,33 +89,29 @@ class FlowPipelineTest {
 
         flow {
             listOf(1, 2, 3).forEach {
-                println("[${coroutineContext}] emit: $it")
+                println("[$coroutineContext] emit: $it")
                 emit(it)
             }
-        }
-            .flatMapMerge { value ->
-                flow {
-                    println("[${coroutineContext}] flatMapMerge processing: $value")
-                    delay(50)
-                    emit(value)
-                }
+        }.flatMapMerge { value ->
+            flow {
+                println("[$coroutineContext] flatMapMerge processing: $value")
+                delay(50)
+                emit(value)
             }
+        }.map {
+            println("[$coroutineContext] map1 start: $it")
+            delay(30)
+            println("[$coroutineContext] map1 end: $it → ${it * 10}")
+            it * 10
+        }.flowOn(Dispatchers.Default) // 여기서 컨텍스트 변경!
             .map {
-                println("[${coroutineContext}] map1 start: $it")
+                println("[$coroutineContext] map2 start: $it")
                 delay(30)
-                println("[${coroutineContext}] map1 end: $it → ${it * 10}")
+                println("[$coroutineContext] map2 end: $it → ${it * 10}")
                 it * 10
-            }
-            .flowOn(Dispatchers.Default)  // 여기서 컨텍스트 변경!
-            .map {
-                println("[${coroutineContext}] map2 start: $it")
-                delay(30)
-                println("[${coroutineContext}] map2 end: $it → ${it * 10}")
-                it * 10
-            }
-            .flowOn(Dispatchers.Default)  // 여기서 컨텍스트 변경!
+            }.flowOn(Dispatchers.Default) // 여기서 컨텍스트 변경!
             .collect {
-                println("[${coroutineContext}] collect: $it")
+                println("[$coroutineContext] collect: $it")
             }
     }
 }

--- a/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/IOTest.kt
+++ b/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/IOTest.kt
@@ -6,22 +6,18 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.runTest
-import kotlin.test.assertEquals
 import kotlin.test.Test
+import kotlin.test.assertEquals
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class IOTest {
-
     @Test
-    fun `middleware with IO delay processes action after delay`() =
-        runTest {
-            val ioMiddleware = object : Middleware<CounterState, CounterAction> {
+    fun `middleware with IO delay processes action after delay`() = runTest {
+        val ioMiddleware =
+            object : Middleware<CounterState, CounterAction> {
                 override val processors: ActionProcessorMap<CounterState, CounterAction> = emptyMap()
 
-                override fun process(
-                    getState: () -> CounterState,
-                    action: CounterAction,
-                ): Flow<CounterAction> = flow {
+                override fun process(getState: () -> CounterState, action: CounterAction): Flow<CounterAction> = flow {
                     if (action is CounterAction.FetchData) {
                         delay(1000) // Simulate network delay
                         emit(CounterAction.FetchDataSuccess(action.id, 42))
@@ -31,7 +27,8 @@ class IOTest {
                 }
             }
 
-            val store = createStore(
+        val store =
+            createStore(
                 initialState = CounterState(),
                 reducer = counterReducer,
                 middlewares = listOf(ioMiddleware),
@@ -39,29 +36,26 @@ class IOTest {
                 scope = backgroundScope,
             )
 
-            store.state.test {
-                assertEquals(0, awaitItem().count)
+        store.state.test {
+            assertEquals(0, awaitItem().count)
 
-                store.dispatch(CounterAction.FetchData("test-1"))
-                // After delay, FetchDataSuccess should be emitted
-                assertEquals(42, awaitItem().count)
+            store.dispatch(CounterAction.FetchData("test-1"))
+            // After delay, FetchDataSuccess should be emitted
+            assertEquals(42, awaitItem().count)
 
-                cancelAndIgnoreRemainingEvents()
-            }
+            cancelAndIgnoreRemainingEvents()
         }
+    }
 
     @Test
-    fun `middleware processes multiple IO requests concurrently`() =
-        runTest {
-            val processedIds = mutableListOf<String>()
+    fun `middleware processes multiple IO requests concurrently`() = runTest {
+        val processedIds = mutableListOf<String>()
 
-            val ioMiddleware = object : Middleware<CounterState, CounterAction> {
+        val ioMiddleware =
+            object : Middleware<CounterState, CounterAction> {
                 override val processors: ActionProcessorMap<CounterState, CounterAction> = emptyMap()
 
-                override fun process(
-                    getState: () -> CounterState,
-                    action: CounterAction,
-                ): Flow<CounterAction> = flow {
+                override fun process(getState: () -> CounterState, action: CounterAction): Flow<CounterAction> = flow {
                     if (action is CounterAction.FetchData) {
                         delay(100) // Simulate network delay
                         processedIds.add(action.id)
@@ -72,7 +66,8 @@ class IOTest {
                 }
             }
 
-            val store = createStore(
+        val store =
+            createStore(
                 initialState = CounterState(),
                 reducer = counterReducer,
                 middlewares = listOf(ioMiddleware),
@@ -80,37 +75,34 @@ class IOTest {
                 scope = backgroundScope,
             )
 
-            store.state.test {
-                assertEquals(0, awaitItem().count)
+        store.state.test {
+            assertEquals(0, awaitItem().count)
 
-                // Dispatch multiple actions concurrently
-                store.dispatch(CounterAction.FetchData("request-1"))
-                store.dispatch(CounterAction.FetchData("request-2"))
-                store.dispatch(CounterAction.FetchData("request-3"))
+            // Dispatch multiple actions concurrently
+            store.dispatch(CounterAction.FetchData("request-1"))
+            store.dispatch(CounterAction.FetchData("request-2"))
+            store.dispatch(CounterAction.FetchData("request-3"))
 
-                // All three should complete (order may vary due to concurrency)
-                assertEquals(10, awaitItem().count)
-                assertEquals(20, awaitItem().count)
-                assertEquals(30, awaitItem().count)
+            // All three should complete (order may vary due to concurrency)
+            assertEquals(10, awaitItem().count)
+            assertEquals(20, awaitItem().count)
+            assertEquals(30, awaitItem().count)
 
-                assertEquals(3, processedIds.size)
+            assertEquals(3, processedIds.size)
 
-                cancelAndIgnoreRemainingEvents()
-            }
+            cancelAndIgnoreRemainingEvents()
         }
+    }
 
     @Test
-    fun `fast action completes before slow IO action`() =
-        runTest {
-            val executionOrder = mutableListOf<String>()
+    fun `fast action completes before slow IO action`() = runTest {
+        val executionOrder = mutableListOf<String>()
 
-            val ioMiddleware = object : Middleware<CounterState, CounterAction> {
+        val ioMiddleware =
+            object : Middleware<CounterState, CounterAction> {
                 override val processors: ActionProcessorMap<CounterState, CounterAction> = emptyMap()
 
-                override fun process(
-                    getState: () -> CounterState,
-                    action: CounterAction,
-                ): Flow<CounterAction> = flow {
+                override fun process(getState: () -> CounterState, action: CounterAction): Flow<CounterAction> = flow {
                     when (action) {
                         is CounterAction.FetchData -> {
                             delay(500) // Slow IO operation
@@ -126,7 +118,8 @@ class IOTest {
                 }
             }
 
-            val store = createStore(
+        val store =
+            createStore(
                 initialState = CounterState(),
                 reducer = counterReducer,
                 middlewares = listOf(ioMiddleware),
@@ -134,33 +127,30 @@ class IOTest {
                 scope = backgroundScope,
             )
 
-            store.state.test {
-                assertEquals(0, awaitItem().count)
+        store.state.test {
+            assertEquals(0, awaitItem().count)
 
-                store.dispatch(CounterAction.FetchData("slow"))
-                store.dispatch(CounterAction.Increment)
+            store.dispatch(CounterAction.FetchData("slow"))
+            store.dispatch(CounterAction.Increment)
 
-                // Fast action should complete first
-                assertEquals(1, awaitItem().count)
-                // Then slow IO action completes
-                assertEquals(101, awaitItem().count)
+            // Fast action should complete first
+            assertEquals(1, awaitItem().count)
+            // Then slow IO action completes
+            assertEquals(101, awaitItem().count)
 
-                assertEquals(listOf("fast-increment", "slow-io"), executionOrder)
+            assertEquals(listOf("fast-increment", "slow-io"), executionOrder)
 
-                cancelAndIgnoreRemainingEvents()
-            }
+            cancelAndIgnoreRemainingEvents()
         }
+    }
 
     @Test
-    fun `middleware emits multiple actions from single IO operation`() =
-        runTest {
-            val ioMiddleware = object : Middleware<CounterState, CounterAction> {
+    fun `middleware emits multiple actions from single IO operation`() = runTest {
+        val ioMiddleware =
+            object : Middleware<CounterState, CounterAction> {
                 override val processors: ActionProcessorMap<CounterState, CounterAction> = emptyMap()
 
-                override fun process(
-                    getState: () -> CounterState,
-                    action: CounterAction,
-                ): Flow<CounterAction> = flow {
+                override fun process(getState: () -> CounterState, action: CounterAction): Flow<CounterAction> = flow {
                     if (action is CounterAction.FetchData) {
                         delay(50)
                         // Emit multiple results from paginated API
@@ -175,7 +165,8 @@ class IOTest {
                 }
             }
 
-            val store = createStore(
+        val store =
+            createStore(
                 initialState = CounterState(),
                 reducer = counterReducer,
                 middlewares = listOf(ioMiddleware),
@@ -183,31 +174,28 @@ class IOTest {
                 scope = backgroundScope,
             )
 
-            store.state.test {
-                assertEquals(0, awaitItem().count)
+        store.state.test {
+            assertEquals(0, awaitItem().count)
 
-                store.dispatch(CounterAction.FetchData("paginated"))
+            store.dispatch(CounterAction.FetchData("paginated"))
 
-                assertEquals(10, awaitItem().count)
-                assertEquals(30, awaitItem().count)
-                assertEquals(60, awaitItem().count)
+            assertEquals(10, awaitItem().count)
+            assertEquals(30, awaitItem().count)
+            assertEquals(60, awaitItem().count)
 
-                cancelAndIgnoreRemainingEvents()
-            }
+            cancelAndIgnoreRemainingEvents()
         }
+    }
 
     @Test
-    fun `sequential IO operations maintain order with flatMapConcat in middleware chain`() =
-        runTest {
-            val operationOrder = mutableListOf<String>()
+    fun `sequential IO operations maintain order with flatMapConcat in middleware chain`() = runTest {
+        val operationOrder = mutableListOf<String>()
 
-            val firstMiddleware = object : Middleware<CounterState, CounterAction> {
+        val firstMiddleware =
+            object : Middleware<CounterState, CounterAction> {
                 override val processors: ActionProcessorMap<CounterState, CounterAction> = emptyMap()
 
-                override fun process(
-                    getState: () -> CounterState,
-                    action: CounterAction,
-                ): Flow<CounterAction> = flow {
+                override fun process(getState: () -> CounterState, action: CounterAction): Flow<CounterAction> = flow {
                     if (action is CounterAction.FetchData) {
                         delay(100)
                         operationOrder.add("first-${action.id}")
@@ -216,13 +204,11 @@ class IOTest {
                 }
             }
 
-            val secondMiddleware = object : Middleware<CounterState, CounterAction> {
+        val secondMiddleware =
+            object : Middleware<CounterState, CounterAction> {
                 override val processors: ActionProcessorMap<CounterState, CounterAction> = emptyMap()
 
-                override fun process(
-                    getState: () -> CounterState,
-                    action: CounterAction,
-                ): Flow<CounterAction> = flow {
+                override fun process(getState: () -> CounterState, action: CounterAction): Flow<CounterAction> = flow {
                     if (action is CounterAction.FetchData) {
                         delay(50)
                         operationOrder.add("second-${action.id}")
@@ -233,7 +219,8 @@ class IOTest {
                 }
             }
 
-            val store = createStore(
+        val store =
+            createStore(
                 initialState = CounterState(),
                 reducer = counterReducer,
                 middlewares = listOf(firstMiddleware, secondMiddleware),
@@ -241,31 +228,28 @@ class IOTest {
                 scope = backgroundScope,
             )
 
-            store.state.test {
-                assertEquals(0, awaitItem().count)
+        store.state.test {
+            assertEquals(0, awaitItem().count)
 
-                store.dispatch(CounterAction.FetchData("A"))
-                assertEquals(5, awaitItem().count)
+            store.dispatch(CounterAction.FetchData("A"))
+            assertEquals(5, awaitItem().count)
 
-                // For single action, middleware chain is sequential
-                assertEquals(listOf("first-A", "second-A"), operationOrder)
+            // For single action, middleware chain is sequential
+            assertEquals(listOf("first-A", "second-A"), operationOrder)
 
-                cancelAndIgnoreRemainingEvents()
-            }
+            cancelAndIgnoreRemainingEvents()
         }
+    }
 
     @Test
-    fun `IO operation can read latest state via getState`() =
-        runTest {
-            val stateAtIOTime = mutableListOf<Int>()
+    fun `IO operation can read latest state via getState`() = runTest {
+        val stateAtIOTime = mutableListOf<Int>()
 
-            val ioMiddleware = object : Middleware<CounterState, CounterAction> {
+        val ioMiddleware =
+            object : Middleware<CounterState, CounterAction> {
                 override val processors: ActionProcessorMap<CounterState, CounterAction> = emptyMap()
 
-                override fun process(
-                    getState: () -> CounterState,
-                    action: CounterAction,
-                ): Flow<CounterAction> = flow {
+                override fun process(getState: () -> CounterState, action: CounterAction): Flow<CounterAction> = flow {
                     if (action is CounterAction.FetchData) {
                         delay(200) // Long IO operation
                         stateAtIOTime.add(getState().count)
@@ -276,7 +260,8 @@ class IOTest {
                 }
             }
 
-            val store = createStore(
+        val store =
+            createStore(
                 initialState = CounterState(count = 10),
                 reducer = counterReducer,
                 middlewares = listOf(ioMiddleware),
@@ -284,32 +269,29 @@ class IOTest {
                 scope = backgroundScope,
             )
 
-            store.state.test {
-                assertEquals(10, awaitItem().count)
+        store.state.test {
+            assertEquals(10, awaitItem().count)
 
-                store.dispatch(CounterAction.FetchData("read-state"))
-                store.dispatch(CounterAction.Increment) // This will complete first
+            store.dispatch(CounterAction.FetchData("read-state"))
+            store.dispatch(CounterAction.Increment) // This will complete first
 
-                assertEquals(11, awaitItem().count)
-                // IO reads state after Increment completed
-                assertEquals(33, awaitItem().count) // 11 + (11 * 2)
+            assertEquals(11, awaitItem().count)
+            // IO reads state after Increment completed
+            assertEquals(33, awaitItem().count) // 11 + (11 * 2)
 
-                assertEquals(listOf(11), stateAtIOTime)
+            assertEquals(listOf(11), stateAtIOTime)
 
-                cancelAndIgnoreRemainingEvents()
-            }
+            cancelAndIgnoreRemainingEvents()
         }
+    }
 
     @Test
-    fun `long running IO does not block other actions`() =
-        runTest {
-            val ioMiddleware = object : Middleware<CounterState, CounterAction> {
+    fun `long running IO does not block other actions`() = runTest {
+        val ioMiddleware =
+            object : Middleware<CounterState, CounterAction> {
                 override val processors: ActionProcessorMap<CounterState, CounterAction> = emptyMap()
 
-                override fun process(
-                    getState: () -> CounterState,
-                    action: CounterAction,
-                ): Flow<CounterAction> = flow {
+                override fun process(getState: () -> CounterState, action: CounterAction): Flow<CounterAction> = flow {
                     when (action) {
                         is CounterAction.FetchData -> {
                             delay(1000) // Very long operation
@@ -320,7 +302,8 @@ class IOTest {
                 }
             }
 
-            val store = createStore(
+        val store =
+            createStore(
                 initialState = CounterState(),
                 reducer = counterReducer,
                 middlewares = listOf(ioMiddleware),
@@ -328,23 +311,23 @@ class IOTest {
                 scope = backgroundScope,
             )
 
-            store.state.test {
-                assertEquals(0, awaitItem().count)
+        store.state.test {
+            assertEquals(0, awaitItem().count)
 
-                store.dispatch(CounterAction.FetchData("long"))
-                store.dispatch(CounterAction.Increment)
-                store.dispatch(CounterAction.Increment)
-                store.dispatch(CounterAction.Increment)
+            store.dispatch(CounterAction.FetchData("long"))
+            store.dispatch(CounterAction.Increment)
+            store.dispatch(CounterAction.Increment)
+            store.dispatch(CounterAction.Increment)
 
-                // Fast actions complete first
-                assertEquals(1, awaitItem().count)
-                assertEquals(2, awaitItem().count)
-                assertEquals(3, awaitItem().count)
+            // Fast actions complete first
+            assertEquals(1, awaitItem().count)
+            assertEquals(2, awaitItem().count)
+            assertEquals(3, awaitItem().count)
 
-                // Long IO completes last
-                assertEquals(1003, awaitItem().count)
+            // Long IO completes last
+            assertEquals(1003, awaitItem().count)
 
-                cancelAndIgnoreRemainingEvents()
-            }
+            cancelAndIgnoreRemainingEvents()
         }
+    }
 }

--- a/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/MiddlewareEmitFlowHolderActionTest.kt
+++ b/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/MiddlewareEmitFlowHolderActionTest.kt
@@ -2,11 +2,10 @@ package io.flowdux
 
 import app.cash.turbine.test
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
-import kotlin.test.assertTrue
 import kotlin.test.Test
+import kotlin.test.assertTrue
 
 /**
  * Tests for emitting multiple FlowHolderActions from within a middleware processor.
@@ -17,37 +16,38 @@ import kotlin.test.Test
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class MiddlewareEmitFlowHolderActionTest {
-
     /**
      * Middleware that emits multiple FlowHolderActions when StartMultipleObservers is dispatched.
      * This simulates the real-world scenario where an app starts observing multiple data streams.
      */
     private class MultiObserverMiddleware : Middleware<CounterState, CounterAction> {
-        override val processors: ActionProcessorMap<CounterState, CounterAction> = buildProcessors {
-            on<CounterAction.StartMultipleObservers> { _, _ ->
-                // Emit first infinite FlowHolderAction
-                emit(CounterAction.InfiniteStreamAction("observer1", emitInterval = 50L))
+        override val processors: ActionProcessorMap<CounterState, CounterAction> =
+            buildProcessors {
+                on<CounterAction.StartMultipleObservers> { _, _ ->
+                    // Emit first infinite FlowHolderAction
+                    emit(CounterAction.InfiniteStreamAction("observer1", emitInterval = 50L))
 
-                // Emit second infinite FlowHolderAction
-                // With flatMapMerge, this executes concurrently (not blocked by first emit)
-                emit(CounterAction.SecondaryStreamAction("observer2", emitInterval = 50L))
+                    // Emit second infinite FlowHolderAction
+                    // With flatMapMerge, this executes concurrently (not blocked by first emit)
+                    emit(CounterAction.SecondaryStreamAction("observer2", emitInterval = 50L))
 
-                // Emit a marker action to indicate setup is complete
-                // With flatMapMerge, this also executes without blocking
-                emit(CounterAction.SetupComplete(0L))
+                    // Emit a marker action to indicate setup is complete
+                    // With flatMapMerge, this also executes without blocking
+                    emit(CounterAction.SetupComplete(0L))
+                }
             }
-        }
     }
 
     @Test
     fun `emitting multiple FlowHolderActions from middleware should not block`() = runTest {
-        val store = createStore(
-            initialState = CounterState(),
-            middlewares = listOf(MultiObserverMiddleware()),
-            reducer = counterReducer,
-            errorProcessor = testErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = CounterState(),
+                middlewares = listOf(MultiObserverMiddleware()),
+                reducer = counterReducer,
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             assertEquals(0, awaitItem().count)
@@ -84,7 +84,7 @@ class MiddlewareEmitFlowHolderActionTest {
                 sawIncrementByOne && sawIncrementByTen,
                 "Expected both FlowHolderActions to run concurrently. " +
                     "sawIncrementByOne=$sawIncrementByOne, sawIncrementByTen=$sawIncrementByTen. " +
-                    "If only sawIncrementByOne=true, the second emit was blocked."
+                    "If only sawIncrementByOne=true, the second emit was blocked.",
             )
 
             cancelAndIgnoreRemainingEvents()
@@ -95,24 +95,26 @@ class MiddlewareEmitFlowHolderActionTest {
     fun `code after emitting FlowHolderAction should execute`() = runTest {
         var setupCompleteReceived = false
 
-        val testReducer = Reducer<CounterState, CounterAction> { state, action ->
-            when (action) {
-                is CounterAction.SetupComplete -> {
-                    setupCompleteReceived = true
-                    state
+        val testReducer =
+            Reducer<CounterState, CounterAction> { state, action ->
+                when (action) {
+                    is CounterAction.SetupComplete -> {
+                        setupCompleteReceived = true
+                        state
+                    }
+                    is CounterAction.Add -> state.copy(count = state.count + action.value)
+                    else -> state
                 }
-                is CounterAction.Add -> state.copy(count = state.count + action.value)
-                else -> state
             }
-        }
 
-        val store = createStore(
-            initialState = CounterState(),
-            middlewares = listOf(MultiObserverMiddleware()),
-            reducer = testReducer,
-            errorProcessor = testErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = CounterState(),
+                middlewares = listOf(MultiObserverMiddleware()),
+                reducer = testReducer,
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             assertEquals(0, awaitItem().count)
@@ -130,7 +132,7 @@ class MiddlewareEmitFlowHolderActionTest {
             assertTrue(
                 setupCompleteReceived,
                 "SetupComplete action should have been emitted after the FlowHolderActions, " +
-                    "but the code after emit() was blocked."
+                    "but the code after emit() was blocked.",
             )
 
             cancelAndIgnoreRemainingEvents()

--- a/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/MiddlewareTest.kt
+++ b/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/MiddlewareTest.kt
@@ -5,31 +5,28 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
-import kotlin.test.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class MiddlewareTest {
-
     @Test
-    fun `middleware intercepts actions`() =
-        runTest {
-            val interceptedActions = mutableListOf<CounterAction>()
+    fun `middleware intercepts actions`() = runTest {
+        val interceptedActions = mutableListOf<CounterAction>()
 
-            val loggingMiddleware = object : Middleware<CounterState, CounterAction> {
+        val loggingMiddleware =
+            object : Middleware<CounterState, CounterAction> {
                 override val processors: ActionProcessorMap<CounterState, CounterAction> = emptyMap()
-                override fun process(
-                    getState: () -> CounterState,
-                    action: CounterAction,
-                ): Flow<CounterAction> =
-                    flow {
-                        interceptedActions.add(action)
-                        emit(action)
-                    }
+
+                override fun process(getState: () -> CounterState, action: CounterAction): Flow<CounterAction> = flow {
+                    interceptedActions.add(action)
+                    emit(action)
+                }
             }
 
-            val store = createStore(
+        val store =
+            createStore(
                 initialState = CounterState(),
                 reducer = counterReducer,
                 middlewares = listOf(loggingMiddleware),
@@ -37,42 +34,39 @@ class MiddlewareTest {
                 scope = backgroundScope,
             )
 
-            store.state.test {
-                assertEquals(0, awaitItem().count)
+        store.state.test {
+            assertEquals(0, awaitItem().count)
 
-                store.dispatch(CounterAction.Increment)
-                awaitItem()
+            store.dispatch(CounterAction.Increment)
+            awaitItem()
 
-                store.dispatch(CounterAction.Decrement)
-                awaitItem()
+            store.dispatch(CounterAction.Decrement)
+            awaitItem()
 
-                assertEquals(2, interceptedActions.size)
-                assertEquals(CounterAction.Increment, interceptedActions[0])
-                assertEquals(CounterAction.Decrement, interceptedActions[1])
+            assertEquals(2, interceptedActions.size)
+            assertEquals(CounterAction.Increment, interceptedActions[0])
+            assertEquals(CounterAction.Decrement, interceptedActions[1])
 
-                cancelAndIgnoreRemainingEvents()
-            }
+            cancelAndIgnoreRemainingEvents()
         }
+    }
 
     @Test
-    fun `middleware can emit additional actions`() =
-        runTest {
-            val doublingMiddleware = object : Middleware<CounterState, CounterAction> {
+    fun `middleware can emit additional actions`() = runTest {
+        val doublingMiddleware =
+            object : Middleware<CounterState, CounterAction> {
                 override val processors: ActionProcessorMap<CounterState, CounterAction> = emptyMap()
 
-                override fun process(
-                    getState: () -> CounterState,
-                    action: CounterAction,
-                ): Flow<CounterAction> =
-                    flow {
-                        emit(action)
-                        if (action is CounterAction.Increment) {
-                            emit(CounterAction.Increment)
-                        }
+                override fun process(getState: () -> CounterState, action: CounterAction): Flow<CounterAction> = flow {
+                    emit(action)
+                    if (action is CounterAction.Increment) {
+                        emit(CounterAction.Increment)
                     }
+                }
             }
 
-            val store = createStore(
+        val store =
+            createStore(
                 initialState = CounterState(),
                 reducer = counterReducer,
                 middlewares = listOf(doublingMiddleware),
@@ -80,49 +74,43 @@ class MiddlewareTest {
                 scope = backgroundScope,
             )
 
-            store.state.test {
-                assertEquals(0, awaitItem().count)
+        store.state.test {
+            assertEquals(0, awaitItem().count)
 
-                store.dispatch(CounterAction.Increment)
-                assertEquals(1, awaitItem().count)
-                assertEquals(2, awaitItem().count)
+            store.dispatch(CounterAction.Increment)
+            assertEquals(1, awaitItem().count)
+            assertEquals(2, awaitItem().count)
 
-                cancelAndIgnoreRemainingEvents()
-            }
+            cancelAndIgnoreRemainingEvents()
         }
+    }
 
     @Test
-    fun `middleware chain executes in order`() =
-        runTest {
-            val executionOrder = mutableListOf<String>()
+    fun `middleware chain executes in order`() = runTest {
+        val executionOrder = mutableListOf<String>()
 
-            val firstMiddleware = object : Middleware<CounterState, CounterAction> {
+        val firstMiddleware =
+            object : Middleware<CounterState, CounterAction> {
                 override val processors: ActionProcessorMap<CounterState, CounterAction> = emptyMap()
 
-                override fun process(
-                    getState: () -> CounterState,
-                    action: CounterAction,
-                ): Flow<CounterAction> =
-                    flow {
-                        executionOrder.add("first")
-                        emit(action)
-                    }
+                override fun process(getState: () -> CounterState, action: CounterAction): Flow<CounterAction> = flow {
+                    executionOrder.add("first")
+                    emit(action)
+                }
             }
 
-            val secondMiddleware = object : Middleware<CounterState, CounterAction> {
+        val secondMiddleware =
+            object : Middleware<CounterState, CounterAction> {
                 override val processors: ActionProcessorMap<CounterState, CounterAction> = emptyMap()
 
-                override fun process(
-                    getState: () -> CounterState,
-                    action: CounterAction,
-                ): Flow<CounterAction> =
-                    flow {
-                        executionOrder.add("second")
-                        emit(action)
-                    }
+                override fun process(getState: () -> CounterState, action: CounterAction): Flow<CounterAction> = flow {
+                    executionOrder.add("second")
+                    emit(action)
+                }
             }
 
-            val store = createStore(
+        val store =
+            createStore(
                 initialState = CounterState(),
                 reducer = counterReducer,
                 middlewares = listOf(firstMiddleware, secondMiddleware),
@@ -130,36 +118,33 @@ class MiddlewareTest {
                 scope = backgroundScope,
             )
 
-            store.state.test {
-                assertEquals(0, awaitItem().count)
+        store.state.test {
+            assertEquals(0, awaitItem().count)
 
-                store.dispatch(CounterAction.Increment)
-                awaitItem()
+            store.dispatch(CounterAction.Increment)
+            awaitItem()
 
-                assertEquals(listOf("first", "second"), executionOrder)
+            assertEquals(listOf("first", "second"), executionOrder)
 
-                cancelAndIgnoreRemainingEvents()
-            }
+            cancelAndIgnoreRemainingEvents()
         }
+    }
 
     @Test
-    fun `middleware can block actions`() =
-        runTest {
-            val blockingMiddleware = object : Middleware<CounterState, CounterAction> {
+    fun `middleware can block actions`() = runTest {
+        val blockingMiddleware =
+            object : Middleware<CounterState, CounterAction> {
                 override val processors: ActionProcessorMap<CounterState, CounterAction> = emptyMap()
 
-                override fun process(
-                    getState: () -> CounterState,
-                    action: CounterAction,
-                ): Flow<CounterAction> =
-                    flow {
-                        if (action !is CounterAction.Decrement) {
-                            emit(action)
-                        }
+                override fun process(getState: () -> CounterState, action: CounterAction): Flow<CounterAction> = flow {
+                    if (action !is CounterAction.Decrement) {
+                        emit(action)
                     }
+                }
             }
 
-            val store = createStore(
+        val store =
+            createStore(
                 initialState = CounterState(count = 5),
                 reducer = counterReducer,
                 middlewares = listOf(blockingMiddleware),
@@ -167,41 +152,38 @@ class MiddlewareTest {
                 scope = backgroundScope,
             )
 
-            store.state.test {
-                assertEquals(5, awaitItem().count)
+        store.state.test {
+            assertEquals(5, awaitItem().count)
 
-                store.dispatch(CounterAction.Increment)
-                assertEquals(6, awaitItem().count)
+            store.dispatch(CounterAction.Increment)
+            assertEquals(6, awaitItem().count)
 
-                store.dispatch(CounterAction.Decrement)
-                // Decrement is blocked, no state change expected
-                expectNoEvents()
+            store.dispatch(CounterAction.Decrement)
+            // Decrement is blocked, no state change expected
+            expectNoEvents()
 
-                assertEquals(6, store.currentState.count)
+            assertEquals(6, store.currentState.count)
 
-                cancelAndIgnoreRemainingEvents()
-            }
+            cancelAndIgnoreRemainingEvents()
         }
+    }
 
     @Test
-    fun `middleware can access current state`() =
-        runTest {
-            val stateSnapshots = mutableListOf<Int>()
+    fun `middleware can access current state`() = runTest {
+        val stateSnapshots = mutableListOf<Int>()
 
-            val stateTrackingMiddleware = object : Middleware<CounterState, CounterAction> {
+        val stateTrackingMiddleware =
+            object : Middleware<CounterState, CounterAction> {
                 override val processors: ActionProcessorMap<CounterState, CounterAction> = emptyMap()
 
-                override fun process(
-                    getState: () -> CounterState,
-                    action: CounterAction,
-                ): Flow<CounterAction> =
-                    flow {
-                        stateSnapshots.add(getState().count)
-                        emit(action)
-                    }
+                override fun process(getState: () -> CounterState, action: CounterAction): Flow<CounterAction> = flow {
+                    stateSnapshots.add(getState().count)
+                    emit(action)
+                }
             }
 
-            val store = createStore(
+        val store =
+            createStore(
                 initialState = CounterState(count = 10),
                 reducer = counterReducer,
                 middlewares = listOf(stateTrackingMiddleware),
@@ -209,33 +191,35 @@ class MiddlewareTest {
                 scope = backgroundScope,
             )
 
-            store.state.test {
-                assertEquals(10, awaitItem().count)
+        store.state.test {
+            assertEquals(10, awaitItem().count)
 
-                store.dispatch(CounterAction.Increment)
-                awaitItem()
+            store.dispatch(CounterAction.Increment)
+            awaitItem()
 
-                store.dispatch(CounterAction.Add(5))
-                awaitItem()
+            store.dispatch(CounterAction.Add(5))
+            awaitItem()
 
-                assertEquals(listOf(10, 11), stateSnapshots)
+            assertEquals(listOf(10, 11), stateSnapshots)
 
-                cancelAndIgnoreRemainingEvents()
-            }
+            cancelAndIgnoreRemainingEvents()
         }
+    }
 
     @Test
-    fun `middleware passes through unregistered actions to reducer`() =
-        runTest {
-            val middleware = object : Middleware<CounterState, CounterAction> {
-                override val processors = buildProcessors {
-                    on<CounterAction.FetchData> { state, action ->
-                        emit(CounterAction.Add(100))
+    fun `middleware passes through unregistered actions to reducer`() = runTest {
+        val middleware =
+            object : Middleware<CounterState, CounterAction> {
+                override val processors =
+                    buildProcessors {
+                        on<CounterAction.FetchData> { state, action ->
+                            emit(CounterAction.Add(100))
+                        }
                     }
-                }
             }
 
-            val store = createStore(
+        val store =
+            createStore(
                 initialState = CounterState(),
                 reducer = counterReducer,
                 middlewares = listOf(middleware),
@@ -243,44 +227,48 @@ class MiddlewareTest {
                 scope = backgroundScope,
             )
 
-            store.state.test {
-                assertEquals(0, awaitItem().count)
+        store.state.test {
+            assertEquals(0, awaitItem().count)
 
-                // Unregistered action should pass through to reducer
-                store.dispatch(CounterAction.Increment)
-                assertEquals(1, awaitItem().count)
+            // Unregistered action should pass through to reducer
+            store.dispatch(CounterAction.Increment)
+            assertEquals(1, awaitItem().count)
 
-                store.dispatch(CounterAction.Add(5))
-                assertEquals(6, awaitItem().count)
+            store.dispatch(CounterAction.Add(5))
+            assertEquals(6, awaitItem().count)
 
-                // Registered action should be handled by middleware
-                store.dispatch(CounterAction.FetchData("test"))
-                assertEquals(106, awaitItem().count)
+            // Registered action should be handled by middleware
+            store.dispatch(CounterAction.FetchData("test"))
+            assertEquals(106, awaitItem().count)
 
-                cancelAndIgnoreRemainingEvents()
-            }
+            cancelAndIgnoreRemainingEvents()
         }
+    }
 
     @Test
-    fun `multiple middlewares pass through unregistered actions`() =
-        runTest {
-            val firstMiddleware = object : Middleware<CounterState, CounterAction> {
-                override val processors = buildProcessors {
-                    on<CounterAction.FetchData> { _, action ->
-                        emit(CounterAction.Add(10))
+    fun `multiple middlewares pass through unregistered actions`() = runTest {
+        val firstMiddleware =
+            object : Middleware<CounterState, CounterAction> {
+                override val processors =
+                    buildProcessors {
+                        on<CounterAction.FetchData> { _, action ->
+                            emit(CounterAction.Add(10))
+                        }
                     }
-                }
             }
 
-            val secondMiddleware = object : Middleware<CounterState, CounterAction> {
-                override val processors = buildProcessors {
-                    on<CounterAction.Reset> { _, _ ->
-                        emit(CounterAction.SetValue(0))
+        val secondMiddleware =
+            object : Middleware<CounterState, CounterAction> {
+                override val processors =
+                    buildProcessors {
+                        on<CounterAction.Reset> { _, _ ->
+                            emit(CounterAction.SetValue(0))
+                        }
                     }
-                }
             }
 
-            val store = createStore(
+        val store =
+            createStore(
                 initialState = CounterState(),
                 reducer = counterReducer,
                 middlewares = listOf(firstMiddleware, secondMiddleware),
@@ -288,36 +276,37 @@ class MiddlewareTest {
                 scope = backgroundScope,
             )
 
-            store.state.test {
-                assertEquals(0, awaitItem().count)
+        store.state.test {
+            assertEquals(0, awaitItem().count)
 
-                // Unregistered in both middlewares - should pass through
-                store.dispatch(CounterAction.Increment)
-                assertEquals(1, awaitItem().count)
+            // Unregistered in both middlewares - should pass through
+            store.dispatch(CounterAction.Increment)
+            assertEquals(1, awaitItem().count)
 
-                store.dispatch(CounterAction.Increment)
-                assertEquals(2, awaitItem().count)
+            store.dispatch(CounterAction.Increment)
+            assertEquals(2, awaitItem().count)
 
-                // Registered in first middleware
-                store.dispatch(CounterAction.FetchData("test"))
-                assertEquals(12, awaitItem().count)
+            // Registered in first middleware
+            store.dispatch(CounterAction.FetchData("test"))
+            assertEquals(12, awaitItem().count)
 
-                // Registered in second middleware
-                store.dispatch(CounterAction.Reset)
-                assertEquals(0, awaitItem().count)
+            // Registered in second middleware
+            store.dispatch(CounterAction.Reset)
+            assertEquals(0, awaitItem().count)
 
-                cancelAndIgnoreRemainingEvents()
-            }
+            cancelAndIgnoreRemainingEvents()
         }
+    }
 
     @Test
     fun `duplicate processor registration throws exception`() {
         assertFailsWith<Middleware.DuplicateProcessorException> {
             object : Middleware<CounterState, CounterAction> {
-                override val processors = buildProcessors {
-                    on<CounterAction.Increment> { _, _ -> emit(CounterAction.Increment) }
-                    on<CounterAction.Increment> { _, _ -> emit(CounterAction.Increment) } // Duplicate!
-                }
+                override val processors =
+                    buildProcessors {
+                        on<CounterAction.Increment> { _, _ -> emit(CounterAction.Increment) }
+                        on<CounterAction.Increment> { _, _ -> emit(CounterAction.Increment) } // Duplicate!
+                    }
             }
         }
     }
@@ -326,12 +315,13 @@ class MiddlewareTest {
     fun `duplicate processor in group throws exception`() {
         assertFailsWith<Middleware.DuplicateProcessorException> {
             object : Middleware<CounterState, CounterAction> {
-                override val processors = buildProcessors {
-                    on<CounterAction.Increment> { _, _ -> emit(CounterAction.Increment) }
-                    group(takeLatest()) {
-                        on<CounterAction.Increment> { _, _ -> emit(CounterAction.Increment) } // Duplicate!
+                override val processors =
+                    buildProcessors {
+                        on<CounterAction.Increment> { _, _ -> emit(CounterAction.Increment) }
+                        group(takeLatest()) {
+                            on<CounterAction.Increment> { _, _ -> emit(CounterAction.Increment) } // Duplicate!
+                        }
                     }
-                }
             }
         }
     }
@@ -340,14 +330,15 @@ class MiddlewareTest {
     fun `duplicate processor across groups throws exception`() {
         assertFailsWith<Middleware.DuplicateProcessorException> {
             object : Middleware<CounterState, CounterAction> {
-                override val processors = buildProcessors {
-                    group(takeLatest()) {
-                        on<CounterAction.Increment> { _, _ -> emit(CounterAction.Increment) }
+                override val processors =
+                    buildProcessors {
+                        group(takeLatest()) {
+                            on<CounterAction.Increment> { _, _ -> emit(CounterAction.Increment) }
+                        }
+                        group(takeLatest()) {
+                            on<CounterAction.Increment> { _, _ -> emit(CounterAction.Increment) } // Duplicate!
+                        }
                     }
-                    group(takeLatest()) {
-                        on<CounterAction.Increment> { _, _ -> emit(CounterAction.Increment) } // Duplicate!
-                    }
-                }
             }
         }
     }

--- a/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/ReducerUtilsTest.kt
+++ b/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/ReducerUtilsTest.kt
@@ -1,13 +1,10 @@
 package io.flowdux
 
-import kotlin.test.assertEquals
 import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class ReducerUtilsTest {
-    data class TestState(
-        val value1: Int = 0,
-        val value2: String = "",
-    ) : State
+    data class TestState(val value1: Int = 0, val value2: String = "") : State
 
     sealed interface TestAction : Action {
         data class SetValue1(val value: Int) : TestAction
@@ -19,17 +16,18 @@ class ReducerUtilsTest {
 
     @Test
     fun `buildReducer handles actions`() {
-        val reducer = buildReducer<TestState, TestAction> {
-            on<TestAction.SetValue1> { state, action ->
-                state.copy(value1 = action.value)
+        val reducer =
+            buildReducer<TestState, TestAction> {
+                on<TestAction.SetValue1> { state, action ->
+                    state.copy(value1 = action.value)
+                }
+                on<TestAction.SetValue2> { state, action ->
+                    state.copy(value2 = action.value)
+                }
+                on<TestAction.Reset> { _, _ ->
+                    TestState()
+                }
             }
-            on<TestAction.SetValue2> { state, action ->
-                state.copy(value2 = action.value)
-            }
-            on<TestAction.Reset> { _, _ ->
-                TestState()
-            }
-        }
 
         var state = TestState()
         state = reducer.reduce(state, TestAction.SetValue1(42))
@@ -47,11 +45,12 @@ class ReducerUtilsTest {
 
     @Test
     fun `buildReducer returns unchanged state for unhandled actions`() {
-        val reducer = buildReducer<TestState, TestAction> {
-            on<TestAction.SetValue1> { state, action ->
-                state.copy(value1 = action.value)
+        val reducer =
+            buildReducer<TestState, TestAction> {
+                on<TestAction.SetValue1> { state, action ->
+                    state.copy(value1 = action.value)
+                }
             }
-        }
 
         val initialState = TestState(value1 = 10, value2 = "test")
 
@@ -61,14 +60,15 @@ class ReducerUtilsTest {
 
     @Test
     fun `buildReducer last handler wins for same action type`() {
-        val reducer = buildReducer<TestState, TestAction> {
-            on<TestAction.SetValue1> { state, action ->
-                state.copy(value1 = action.value)
+        val reducer =
+            buildReducer<TestState, TestAction> {
+                on<TestAction.SetValue1> { state, action ->
+                    state.copy(value1 = action.value)
+                }
+                on<TestAction.SetValue1> { state, action ->
+                    state.copy(value1 = action.value * 2)
+                }
             }
-            on<TestAction.SetValue1> { state, action ->
-                state.copy(value1 = action.value * 2)
-            }
-        }
 
         val state = reducer.reduce(TestState(), TestAction.SetValue1(10))
         assertEquals(20, state.value1) // 10 * 2

--- a/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/ScopeAndLifecycleTest.kt
+++ b/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/ScopeAndLifecycleTest.kt
@@ -15,61 +15,60 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-import kotlin.test.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ScopeAndLifecycleTest {
-
     // ==================== Scope Cancellation Tests ====================
 
     @Test
-    fun `scope cancellation does not affect external channel producer`() =
-        runTest {
-            val externalChannel = Channel<Int>(Channel.UNLIMITED)
-            val storeScope = CoroutineScope(coroutineContext + Job())
+    fun `scope cancellation does not affect external channel producer`() = runTest {
+        val externalChannel = Channel<Int>(Channel.UNLIMITED)
+        val storeScope = CoroutineScope(coroutineContext + Job())
 
-            val store = createStore(
+        val store =
+            createStore(
                 initialState = CounterState(),
                 reducer = counterReducer,
                 errorProcessor = testErrorProcessor,
                 scope = storeScope,
             )
 
-            store.state.test {
-                assertEquals(0, awaitItem().count)
+        store.state.test {
+            assertEquals(0, awaitItem().count)
 
-                store.dispatch(CounterAction.StreamConnected(externalChannel.receiveAsFlow()))
+            store.dispatch(CounterAction.StreamConnected(externalChannel.receiveAsFlow()))
 
-                externalChannel.send(5)
-                assertEquals(5, awaitItem().count)
+            externalChannel.send(5)
+            assertEquals(5, awaitItem().count)
 
-                externalChannel.send(3)
-                assertEquals(8, awaitItem().count)
+            externalChannel.send(3)
+            assertEquals(8, awaitItem().count)
 
-                cancelAndIgnoreRemainingEvents()
-            }
-
-            storeScope.cancel()
-
-            assertFalse(externalChannel.isClosedForSend)
-            assertFalse(externalChannel.isClosedForReceive)
-
-            externalChannel.send(100)
-
-            externalChannel.close()
+            cancelAndIgnoreRemainingEvents()
         }
 
-    @Test
-    fun `scope cancel stops collecting from FlowHolderAction`() =
-        runTest {
-            val externalChannel = Channel<Int>(Channel.UNLIMITED)
-            val receivedValues = mutableListOf<Int>()
-            val storeScope = CoroutineScope(coroutineContext + Job())
+        storeScope.cancel()
 
-            val trackingReducer = Reducer<CounterState, CounterAction> { state, action ->
+        assertFalse(externalChannel.isClosedForSend)
+        assertFalse(externalChannel.isClosedForReceive)
+
+        externalChannel.send(100)
+
+        externalChannel.close()
+    }
+
+    @Test
+    fun `scope cancel stops collecting from FlowHolderAction`() = runTest {
+        val externalChannel = Channel<Int>(Channel.UNLIMITED)
+        val receivedValues = mutableListOf<Int>()
+        val storeScope = CoroutineScope(coroutineContext + Job())
+
+        val trackingReducer =
+            Reducer<CounterState, CounterAction> { state, action ->
                 when (action) {
                     is CounterAction.Add -> {
                         receivedValues.add(action.value)
@@ -79,79 +78,80 @@ class ScopeAndLifecycleTest {
                 }
             }
 
-            val store = createStore(
+        val store =
+            createStore(
                 initialState = CounterState(),
                 reducer = trackingReducer,
                 errorProcessor = testErrorProcessor,
                 scope = storeScope,
             )
 
-            store.state.test {
-                assertEquals(0, awaitItem().count)
+        store.state.test {
+            assertEquals(0, awaitItem().count)
 
-                store.dispatch(CounterAction.StreamConnected(externalChannel.receiveAsFlow()))
+            store.dispatch(CounterAction.StreamConnected(externalChannel.receiveAsFlow()))
 
-                externalChannel.send(10)
-                assertEquals(10, awaitItem().count)
+            externalChannel.send(10)
+            assertEquals(10, awaitItem().count)
 
-                externalChannel.send(20)
-                assertEquals(30, awaitItem().count)
+            externalChannel.send(20)
+            assertEquals(30, awaitItem().count)
 
-                assertEquals(listOf(10, 20), receivedValues)
+            assertEquals(listOf(10, 20), receivedValues)
 
-                cancelAndIgnoreRemainingEvents()
-            }
-
-            val valuesBefore = receivedValues.toList()
-
-            storeScope.cancel()
-
-            externalChannel.send(100)
-            externalChannel.send(200)
-            advanceUntilIdle()
-
-            assertEquals(valuesBefore, receivedValues)
-
-            externalChannel.close()
+            cancelAndIgnoreRemainingEvents()
         }
+
+        val valuesBefore = receivedValues.toList()
+
+        storeScope.cancel()
+
+        externalChannel.send(100)
+        externalChannel.send(200)
+        advanceUntilIdle()
+
+        assertEquals(valuesBefore, receivedValues)
+
+        externalChannel.close()
+    }
 
     // ==================== Store Close Tests ====================
 
     @Test
-    fun `close cancels scope and stops processing actions`() =
-        runTest {
-            val storeScope = CoroutineScope(coroutineContext + Job())
-            val store = createStore(
+    fun `close cancels scope and stops processing actions`() = runTest {
+        val storeScope = CoroutineScope(coroutineContext + Job())
+        val store =
+            createStore(
                 initialState = CounterState(),
                 reducer = counterReducer,
                 errorProcessor = testErrorProcessor,
                 scope = storeScope,
             )
 
-            store.state.test {
-                assertEquals(0, awaitItem().count)
+        store.state.test {
+            assertEquals(0, awaitItem().count)
 
-                store.dispatch(CounterAction.Increment)
-                assertEquals(1, awaitItem().count)
+            store.dispatch(CounterAction.Increment)
+            assertEquals(1, awaitItem().count)
 
-                store.close()
+            store.close()
 
-                // After close, dispatch should not update state
-                store.dispatch(CounterAction.Increment)
-                expectNoEvents()
+            // After close, dispatch should not update state
+            store.dispatch(CounterAction.Increment)
+            expectNoEvents()
 
-                cancelAndIgnoreRemainingEvents()
-            }
+            cancelAndIgnoreRemainingEvents()
         }
+    }
 
     @Test
-    fun `close stops FlowHolderAction stream collection`() =
-        runTest {
-            val storeScope = CoroutineScope(coroutineContext + Job())
-            val valueChannel = Channel<Int>(Channel.UNLIMITED)
-            val receivedValues = mutableListOf<Int>()
+    fun `close stops FlowHolderAction stream collection`() = runTest {
+        val storeScope = CoroutineScope(coroutineContext + Job())
+        val valueChannel = Channel<Int>(Channel.UNLIMITED)
+        val receivedValues = mutableListOf<Int>()
 
-            val trackingReducer = Reducer<CounterState, CounterAction> { state, action ->
+        val trackingReducer =
+            Reducer<CounterState, CounterAction> { state, action ->
                 when (action) {
                     is CounterAction.Add -> {
                         receivedValues.add(action.value)
@@ -161,89 +161,102 @@ class ScopeAndLifecycleTest {
                 }
             }
 
-            val store = createStore(
+        val store =
+            createStore(
                 initialState = CounterState(),
                 reducer = trackingReducer,
                 errorProcessor = testErrorProcessor,
                 scope = storeScope,
             )
 
-            store.state.test {
-                assertEquals(0, awaitItem().count)
+        store.state.test {
+            assertEquals(0, awaitItem().count)
 
-                store.dispatch(CounterAction.StreamConnected(valueChannel.receiveAsFlow()))
+            store.dispatch(CounterAction.StreamConnected(valueChannel.receiveAsFlow()))
 
-                valueChannel.send(10)
-                assertEquals(10, awaitItem().count)
+            valueChannel.send(10)
+            assertEquals(10, awaitItem().count)
 
-                store.close()
+            store.close()
 
-                valueChannel.send(20)
-                valueChannel.send(30)
-                advanceUntilIdle()
+            valueChannel.send(20)
+            valueChannel.send(30)
+            advanceUntilIdle()
 
-                // Values after close should not be received
-                assertEquals(listOf(10), receivedValues)
+            // Values after close should not be received
+            assertEquals(listOf(10), receivedValues)
 
-                cancelAndIgnoreRemainingEvents()
-            }
-
-            valueChannel.close()
+            cancelAndIgnoreRemainingEvents()
         }
 
+        valueChannel.close()
+    }
+
     @Test
-    fun `close can be called multiple times safely`() =
-        runTest {
-            val storeScope = CoroutineScope(coroutineContext + Job())
-            val store = createStore(
+    fun `close can be called multiple times safely`() = runTest {
+        val storeScope = CoroutineScope(coroutineContext + Job())
+        val store =
+            createStore(
                 initialState = CounterState(),
                 reducer = counterReducer,
                 errorProcessor = testErrorProcessor,
                 scope = storeScope,
             )
 
-            store.close()
-            store.close() // Should not throw
-        }
+        store.close()
+        store.close() // Should not throw
+    }
 
     @Test
-    fun `isClosed returns false before close and true after close`() =
-        runTest {
-            val storeScope = CoroutineScope(coroutineContext + Job())
-            val store = createStore(
+    fun `isClosed returns false before close and true after close`() = runTest {
+        val storeScope = CoroutineScope(coroutineContext + Job())
+        val store =
+            createStore(
                 initialState = CounterState(),
                 reducer = counterReducer,
                 errorProcessor = testErrorProcessor,
                 scope = storeScope,
             )
 
-            assertFalse(store.isClosed)
+        assertFalse(store.isClosed)
 
-            store.close()
+        store.close()
 
-            assertTrue(store.isClosed)
-        }
+        assertTrue(store.isClosed)
+    }
 
     @Test
-    fun `dispatch after close calls onDispatchAfterClose logger`() =
-        runTest {
-            val storeScope = CoroutineScope(coroutineContext + Job())
-            val dispatchedAfterClose = mutableListOf<CounterAction>()
+    fun `dispatch after close calls onDispatchAfterClose logger`() = runTest {
+        val storeScope = CoroutineScope(coroutineContext + Job())
+        val dispatchedAfterClose = mutableListOf<CounterAction>()
 
-            val testLogger = object : StoreLogger<CounterState, CounterAction> {
+        val testLogger =
+            object : StoreLogger<CounterState, CounterAction> {
                 override fun onActionDispatched(action: CounterAction) {}
+
                 override fun onMiddlewareProcessing(middlewareName: String, action: CounterAction) {}
+
                 override fun onMiddlewaresCompleted(action: CounterAction) {}
+
                 override fun onFlowHolderActionEmitted(action: CounterAction) {}
+
                 override fun onErrorOccurred(throwable: Throwable) {}
+
                 override fun onErrorHandled(action: CounterAction) {}
-                override fun onStateReduced(action: CounterAction, previousState: CounterState, newState: CounterState) {}
+
+                override fun onStateReduced(
+                    action: CounterAction,
+                    previousState: CounterState,
+                    newState: CounterState,
+                ) {}
+
                 override fun onDispatchAfterClose(action: CounterAction) {
                     dispatchedAfterClose.add(action)
                 }
             }
 
-            val store = createStore(
+        val store =
+            createStore(
                 initialState = CounterState(),
                 reducer = counterReducer,
                 errorProcessor = testErrorProcessor,
@@ -251,200 +264,205 @@ class ScopeAndLifecycleTest {
                 scope = storeScope,
             )
 
-            store.close()
+        store.close()
 
-            // Dispatch after close
-            store.dispatch(CounterAction.Increment)
-            store.dispatch(CounterAction.Add(5))
+        // Dispatch after close
+        store.dispatch(CounterAction.Increment)
+        store.dispatch(CounterAction.Add(5))
 
-            // Wait for coroutines to complete
-            advanceUntilIdle()
+        // Wait for coroutines to complete
+        advanceUntilIdle()
 
-            assertEquals(2, dispatchedAfterClose.size)
-            assertEquals(CounterAction.Increment, dispatchedAfterClose[0])
-            assertEquals(CounterAction.Add(5), dispatchedAfterClose[1])
-        }
+        assertEquals(2, dispatchedAfterClose.size)
+        assertEquals(CounterAction.Increment, dispatchedAfterClose[0])
+        assertEquals(CounterAction.Add(5), dispatchedAfterClose[1])
+    }
 
     // ==================== Duplicate State Emission Tests ====================
 
     @Test
-    fun `store does not emit duplicate states`() =
-        runTest {
-            var emissionCount = 0
+    fun `store does not emit duplicate states`() = runTest {
+        var emissionCount = 0
 
-            val store = createStore(
+        val store =
+            createStore(
                 initialState = CounterState(count = 5),
                 reducer = counterReducer,
                 errorProcessor = testErrorProcessor,
                 scope = backgroundScope,
             )
 
-            store.state.test {
-                assertEquals(5, awaitItem().count)
-                emissionCount++
+        store.state.test {
+            assertEquals(5, awaitItem().count)
+            emissionCount++
 
-                // Dispatch action that sets the same value
-                store.dispatch(CounterAction.SetValue(5))
+            // Dispatch action that sets the same value
+            store.dispatch(CounterAction.SetValue(5))
 
-                // No new emission should occur because state is the same
-                expectNoEvents()
+            // No new emission should occur because state is the same
+            expectNoEvents()
 
-                // Dispatch action that actually changes the state
-                store.dispatch(CounterAction.SetValue(10))
-                assertEquals(10, awaitItem().count)
-                emissionCount++
+            // Dispatch action that actually changes the state
+            store.dispatch(CounterAction.SetValue(10))
+            assertEquals(10, awaitItem().count)
+            emissionCount++
 
-                // Dispatch same value again
-                store.dispatch(CounterAction.SetValue(10))
-                expectNoEvents()
+            // Dispatch same value again
+            store.dispatch(CounterAction.SetValue(10))
+            expectNoEvents()
 
-                // Change state and verify emission
-                store.dispatch(CounterAction.Increment)
-                assertEquals(11, awaitItem().count)
-                emissionCount++
+            // Change state and verify emission
+            store.dispatch(CounterAction.Increment)
+            assertEquals(11, awaitItem().count)
+            emissionCount++
 
-                assertEquals(3, emissionCount)
+            assertEquals(3, emissionCount)
 
-                cancelAndIgnoreRemainingEvents()
-            }
+            cancelAndIgnoreRemainingEvents()
         }
+    }
 
     @Test
-    fun `store does not emit when reducer returns same state reference`() =
-        runTest {
-            // FetchData action returns the same state (state unchanged)
-            val store = createStore(
+    fun `store does not emit when reducer returns same state reference`() = runTest {
+        // FetchData action returns the same state (state unchanged)
+        val store =
+            createStore(
                 initialState = CounterState(count = 0),
                 reducer = counterReducer,
                 errorProcessor = testErrorProcessor,
                 scope = backgroundScope,
             )
 
-            store.state.test {
-                assertEquals(0, awaitItem().count)
+        store.state.test {
+            assertEquals(0, awaitItem().count)
 
-                // FetchData returns state unchanged
-                store.dispatch(CounterAction.FetchData("test"))
-                expectNoEvents()
+            // FetchData returns state unchanged
+            store.dispatch(CounterAction.FetchData("test"))
+            expectNoEvents()
 
-                // StreamConnected also returns state unchanged
-                store.dispatch(CounterAction.StreamConnected(emptyFlow()))
-                expectNoEvents()
+            // StreamConnected also returns state unchanged
+            store.dispatch(CounterAction.StreamConnected(emptyFlow()))
+            expectNoEvents()
 
-                // Actual state change should emit
-                store.dispatch(CounterAction.Increment)
-                assertEquals(1, awaitItem().count)
+            // Actual state change should emit
+            store.dispatch(CounterAction.Increment)
+            assertEquals(1, awaitItem().count)
 
-                cancelAndIgnoreRemainingEvents()
-            }
+            cancelAndIgnoreRemainingEvents()
         }
+    }
 
     @Test
-    fun `consecutive identical state updates are deduplicated`() =
-        runTest {
-            val emissions = mutableListOf<Int>()
+    fun `consecutive identical state updates are deduplicated`() = runTest {
+        val emissions = mutableListOf<Int>()
 
-            val store = createStore(
+        val store =
+            createStore(
                 initialState = CounterState(count = 0),
                 reducer = counterReducer,
                 errorProcessor = testErrorProcessor,
                 scope = backgroundScope,
             )
 
-            store.state.test {
-                emissions.add(awaitItem().count)
+        store.state.test {
+            emissions.add(awaitItem().count)
 
-                // Multiple actions that result in same state
-                store.dispatch(CounterAction.SetValue(10))
-                emissions.add(awaitItem().count)
+            // Multiple actions that result in same state
+            store.dispatch(CounterAction.SetValue(10))
+            emissions.add(awaitItem().count)
 
-                store.dispatch(CounterAction.SetValue(10))
-                store.dispatch(CounterAction.SetValue(10))
-                store.dispatch(CounterAction.SetValue(10))
+            store.dispatch(CounterAction.SetValue(10))
+            store.dispatch(CounterAction.SetValue(10))
+            store.dispatch(CounterAction.SetValue(10))
 
-                // Give time for potential emissions
-                expectNoEvents()
+            // Give time for potential emissions
+            expectNoEvents()
 
-                store.dispatch(CounterAction.SetValue(20))
-                emissions.add(awaitItem().count)
+            store.dispatch(CounterAction.SetValue(20))
+            emissions.add(awaitItem().count)
 
-                // Only initial, first change, and final change should be recorded
-                assertEquals(listOf(0, 10, 20), emissions)
+            // Only initial, first change, and final change should be recorded
+            assertEquals(listOf(0, 10, 20), emissions)
 
-                cancelAndIgnoreRemainingEvents()
-            }
+            cancelAndIgnoreRemainingEvents()
         }
+    }
 
     // ==================== Concurrent Dispatch + Close Race Tests ====================
     // NOTE: Using runBlocking with Dispatchers.Default to ensure real multi-threading
 
     @Test
-    fun `concurrent close from multiple coroutines does not throw`() =
-        runBlocking {
-            val storeScope = CoroutineScope(Dispatchers.Default + Job())
-            val store = createStore(
+    fun `concurrent close from multiple coroutines does not throw`() = runBlocking {
+        val storeScope = CoroutineScope(Dispatchers.Default + Job())
+        val store =
+            createStore(
                 initialState = CounterState(),
                 reducer = counterReducer,
                 errorProcessor = testErrorProcessor,
                 scope = storeScope,
             )
-            delay(50) // Let store initialize
+        delay(50) // Let store initialize
 
-            // Launch multiple coroutines that all try to close simultaneously
-            val jobs = (1..10).map {
+        // Launch multiple coroutines that all try to close simultaneously
+        val jobs =
+            (1..10).map {
                 launch(Dispatchers.Default) { store.close() }
             }
-            jobs.joinAll()
+        jobs.joinAll()
 
-            assertTrue(store.isClosed)
-        }
+        assertTrue(store.isClosed)
+    }
 
     @Test
-    fun `dispatch during close does not throw`() =
-        runBlocking {
-            val storeScope = CoroutineScope(Dispatchers.Default + Job())
-            val store = createStore(
+    fun `dispatch during close does not throw`() = runBlocking {
+        val storeScope = CoroutineScope(Dispatchers.Default + Job())
+        val store =
+            createStore(
                 initialState = CounterState(),
                 reducer = counterReducer,
                 errorProcessor = testErrorProcessor,
                 scope = storeScope,
             )
-            delay(50) // Let store initialize
+        delay(50) // Let store initialize
 
-            // Dispatch and close concurrently — neither should throw
-            val dispatchJob = launch(Dispatchers.Default) {
+        // Dispatch and close concurrently — neither should throw
+        val dispatchJob =
+            launch(Dispatchers.Default) {
                 repeat(100) { store.dispatch(CounterAction.Increment) }
             }
-            val closeJob = launch(Dispatchers.Default) {
+        val closeJob =
+            launch(Dispatchers.Default) {
                 store.close()
             }
 
-            dispatchJob.join()
-            closeJob.join()
-            assertTrue(store.isClosed)
-        }
+        dispatchJob.join()
+        closeJob.join()
+        assertTrue(store.isClosed)
+    }
 
     @Test
-    fun `closeGracefully during concurrent dispatch does not throw`() =
-        runBlocking {
-            val storeScope = CoroutineScope(Dispatchers.Default + Job())
-            val store = createStore(
+    fun `closeGracefully during concurrent dispatch does not throw`() = runBlocking {
+        val storeScope = CoroutineScope(Dispatchers.Default + Job())
+        val store =
+            createStore(
                 initialState = CounterState(),
                 reducer = counterReducer,
                 errorProcessor = testErrorProcessor,
                 scope = storeScope,
             )
-            delay(50) // Let store initialize
+        delay(50) // Let store initialize
 
-            val dispatchJob = launch(Dispatchers.Default) {
+        val dispatchJob =
+            launch(Dispatchers.Default) {
                 repeat(50) { store.dispatch(CounterAction.Increment) }
             }
-            val closeJob = launch(Dispatchers.Default) {
+        val closeJob =
+            launch(Dispatchers.Default) {
                 store.closeGracefully()
             }
 
-            dispatchJob.join()
-            closeJob.join()
-            assertTrue(store.isClosed)
-        }
+        dispatchJob.join()
+        closeJob.join()
+        assertTrue(store.isClosed)
+    }
 }

--- a/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/ScopeAndLifecycleTest.kt
+++ b/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/ScopeAndLifecycleTest.kt
@@ -2,12 +2,17 @@ package io.flowdux
 
 import app.cash.turbine.test
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlin.test.assertEquals
@@ -368,5 +373,78 @@ class ScopeAndLifecycleTest {
 
                 cancelAndIgnoreRemainingEvents()
             }
+        }
+
+    // ==================== Concurrent Dispatch + Close Race Tests ====================
+    // NOTE: Using runBlocking with Dispatchers.Default to ensure real multi-threading
+
+    @Test
+    fun `concurrent close from multiple coroutines does not throw`() =
+        runBlocking {
+            val storeScope = CoroutineScope(Dispatchers.Default + Job())
+            val store = createStore(
+                initialState = CounterState(),
+                reducer = counterReducer,
+                errorProcessor = testErrorProcessor,
+                scope = storeScope,
+            )
+            delay(50) // Let store initialize
+
+            // Launch multiple coroutines that all try to close simultaneously
+            val jobs = (1..10).map {
+                launch(Dispatchers.Default) { store.close() }
+            }
+            jobs.joinAll()
+
+            assertTrue(store.isClosed)
+        }
+
+    @Test
+    fun `dispatch during close does not throw`() =
+        runBlocking {
+            val storeScope = CoroutineScope(Dispatchers.Default + Job())
+            val store = createStore(
+                initialState = CounterState(),
+                reducer = counterReducer,
+                errorProcessor = testErrorProcessor,
+                scope = storeScope,
+            )
+            delay(50) // Let store initialize
+
+            // Dispatch and close concurrently — neither should throw
+            val dispatchJob = launch(Dispatchers.Default) {
+                repeat(100) { store.dispatch(CounterAction.Increment) }
+            }
+            val closeJob = launch(Dispatchers.Default) {
+                store.close()
+            }
+
+            dispatchJob.join()
+            closeJob.join()
+            assertTrue(store.isClosed)
+        }
+
+    @Test
+    fun `closeGracefully during concurrent dispatch does not throw`() =
+        runBlocking {
+            val storeScope = CoroutineScope(Dispatchers.Default + Job())
+            val store = createStore(
+                initialState = CounterState(),
+                reducer = counterReducer,
+                errorProcessor = testErrorProcessor,
+                scope = storeScope,
+            )
+            delay(50) // Let store initialize
+
+            val dispatchJob = launch(Dispatchers.Default) {
+                repeat(50) { store.dispatch(CounterAction.Increment) }
+            }
+            val closeJob = launch(Dispatchers.Default) {
+                store.closeGracefully()
+            }
+
+            dispatchJob.join()
+            closeJob.join()
+            assertTrue(store.isClosed)
         }
 }

--- a/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/StateInTimingTest.kt
+++ b/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/StateInTimingTest.kt
@@ -26,26 +26,21 @@ import kotlin.test.assertEquals
  * @see <a href="https://github.com/chibimoons/flowdux/issues/80">Issue #80</a>
  */
 class StateInTimingTest {
-
     /**
      * Creates a middleware that adds random delay to Increment actions.
      * This forces concurrent execution through flatMapMerge to test race conditions.
      */
-    private fun createRandomDelayMiddleware(
-        maxDelayMs: Long = 20,
-    ): Middleware<CounterState, CounterAction> = object : Middleware<CounterState, CounterAction> {
-        override val processors: ActionProcessorMap<CounterState, CounterAction> = emptyMap()
+    private fun createRandomDelayMiddleware(maxDelayMs: Long = 20): Middleware<CounterState, CounterAction> =
+        object : Middleware<CounterState, CounterAction> {
+            override val processors: ActionProcessorMap<CounterState, CounterAction> = emptyMap()
 
-        override fun process(
-            getState: () -> CounterState,
-            action: CounterAction,
-        ): Flow<CounterAction> = flow {
-            if (action is CounterAction.Increment) {
-                delay(Random.nextLong(1, maxDelayMs))
+            override fun process(getState: () -> CounterState, action: CounterAction): Flow<CounterAction> = flow {
+                if (action is CounterAction.Increment) {
+                    delay(Random.nextLong(1, maxDelayMs))
+                }
+                emit(action)
             }
-            emit(action)
         }
-    }
 
     /**
      * Test 1: Lost Update Detection (Empirical Test)
@@ -59,13 +54,14 @@ class StateInTimingTest {
         val actionCount = 100
         val storeScope = CoroutineScope(Dispatchers.Default + Job())
 
-        val store = createStore(
-            initialState = CounterState(count = 0),
-            reducer = counterReducer,
-            middlewares = listOf(createRandomDelayMiddleware(maxDelayMs = 20)),
-            errorProcessor = testErrorProcessor,
-            scope = storeScope,
-        )
+        val store =
+            createStore(
+                initialState = CounterState(count = 0),
+                reducer = counterReducer,
+                middlewares = listOf(createRandomDelayMiddleware(maxDelayMs = 20)),
+                errorProcessor = testErrorProcessor,
+                scope = storeScope,
+            )
 
         try {
             repeat(actionCount) { store.dispatch(CounterAction.Increment) }
@@ -77,7 +73,7 @@ class StateInTimingTest {
                 actionCount,
                 store.state.value.count,
                 "Expected $actionCount but got ${store.state.value.count}. " +
-                    "This indicates lost updates due to stale state reads."
+                    "This indicates lost updates due to stale state reads.",
             )
         } finally {
             // store.close() internally cancels the scope, so no need for storeScope.cancel()
@@ -99,25 +95,27 @@ class StateInTimingTest {
         val readLog = mutableListOf<Pair<Int, Int>>() // (oldState.count, newState.count)
 
         // Logger that captures state before and after each reduction
-        val capturingLogger = object : NoOpStoreLogger<CounterState, CounterAction>() {
-            override fun onStateReduced(
-                action: CounterAction,
-                previousState: CounterState,
-                newState: CounterState,
-            ) {
-                // No synchronization needed - map operator in Store's Flow pipeline runs sequentially
-                readLog.add(previousState.count to newState.count)
+        val capturingLogger =
+            object : NoOpStoreLogger<CounterState, CounterAction>() {
+                override fun onStateReduced(
+                    action: CounterAction,
+                    previousState: CounterState,
+                    newState: CounterState,
+                ) {
+                    // No synchronization needed - map operator in Store's Flow pipeline runs sequentially
+                    readLog.add(previousState.count to newState.count)
+                }
             }
-        }
 
-        val store = createStore(
-            initialState = CounterState(count = 0),
-            reducer = counterReducer,
-            middlewares = listOf(createRandomDelayMiddleware(maxDelayMs = 10)),
-            errorProcessor = testErrorProcessor,
-            logger = capturingLogger,
-            scope = storeScope,
-        )
+        val store =
+            createStore(
+                initialState = CounterState(count = 0),
+                reducer = counterReducer,
+                middlewares = listOf(createRandomDelayMiddleware(maxDelayMs = 10)),
+                errorProcessor = testErrorProcessor,
+                logger = capturingLogger,
+                scope = storeScope,
+            )
 
         try {
             repeat(actionCount) { store.dispatch(CounterAction.Increment) }
@@ -126,7 +124,7 @@ class StateInTimingTest {
             assertEquals(
                 actionCount,
                 readLog.size,
-                "Expected $actionCount reductions but got ${readLog.size}"
+                "Expected $actionCount reductions but got ${readLog.size}",
             )
 
             // Verify sequential progression in logging order: (0,1), (1,2), (2,3), ...
@@ -135,12 +133,12 @@ class StateInTimingTest {
                 assertEquals(
                     index,
                     old,
-                    "Reduction #$index read stale state: expected $index, got $old"
+                    "Reduction #$index read stale state: expected $index, got $old",
                 )
                 assertEquals(
                     index + 1,
                     new,
-                    "Reduction #$index produced wrong state: expected ${index + 1}, got $new"
+                    "Reduction #$index produced wrong state: expected ${index + 1}, got $new",
                 )
             }
         } finally {
@@ -162,13 +160,14 @@ class StateInTimingTest {
         repeat(trials) { trial ->
             val storeScope = CoroutineScope(Dispatchers.Default + Job())
 
-            val store = createStore(
-                initialState = CounterState(count = 0),
-                reducer = counterReducer,
-                middlewares = listOf(createRandomDelayMiddleware(maxDelayMs = 15)),
-                errorProcessor = testErrorProcessor,
-                scope = storeScope,
-            )
+            val store =
+                createStore(
+                    initialState = CounterState(count = 0),
+                    reducer = counterReducer,
+                    middlewares = listOf(createRandomDelayMiddleware(maxDelayMs = 15)),
+                    errorProcessor = testErrorProcessor,
+                    scope = storeScope,
+                )
 
             try {
                 repeat(actionsPerTrial) { store.dispatch(CounterAction.Increment) }
@@ -177,7 +176,7 @@ class StateInTimingTest {
                 assertEquals(
                     actionsPerTrial,
                     store.state.value.count,
-                    "Trial #$trial: Lost update detected. Expected $actionsPerTrial, got ${store.state.value.count}"
+                    "Trial #$trial: Lost update detected. Expected $actionsPerTrial, got ${store.state.value.count}",
                 )
             } finally {
                 store.close()

--- a/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/StoreLoggerTest.kt
+++ b/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/StoreLoggerTest.kt
@@ -3,18 +3,15 @@ package io.flowdux
 import app.cash.turbine.test
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class StoreLoggerTest {
-
     private class TestLogger : StoreLogger<CounterState, CounterAction> {
         val dispatched = mutableListOf<CounterAction>()
         val middlewareProcessing = mutableListOf<Pair<String, CounterAction>>()
@@ -61,13 +58,14 @@ class StoreLoggerTest {
     @Test
     fun `onActionDispatched is called for each dispatch`() = runTest {
         val logger = TestLogger()
-        val store = createStore(
-            initialState = CounterState(),
-            reducer = counterReducer,
-            errorProcessor = testErrorProcessor,
-            logger = logger,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = CounterState(),
+                reducer = counterReducer,
+                errorProcessor = testErrorProcessor,
+                logger = logger,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             awaitItem()
@@ -89,13 +87,14 @@ class StoreLoggerTest {
     @Test
     fun `onStateReduced is called with correct previous and new state`() = runTest {
         val logger = TestLogger()
-        val store = createStore(
-            initialState = CounterState(count = 0),
-            reducer = counterReducer,
-            errorProcessor = testErrorProcessor,
-            logger = logger,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = CounterState(count = 0),
+                reducer = counterReducer,
+                errorProcessor = testErrorProcessor,
+                logger = logger,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             awaitItem()
@@ -125,21 +124,24 @@ class StoreLoggerTest {
     @Test
     fun `onMiddlewareProcessing is called for each middleware`() = runTest {
         val logger = TestLogger()
-        val passthrough = object : Middleware<CounterState, CounterAction> {
-            override val name = "PassthroughMiddleware"
-            override val processors: ActionProcessorMap<CounterState, CounterAction> = emptyMap()
-            override fun process(getState: () -> CounterState, action: CounterAction): Flow<CounterAction> =
-                flowOf(action)
-        }
+        val passthrough =
+            object : Middleware<CounterState, CounterAction> {
+                override val name = "PassthroughMiddleware"
+                override val processors: ActionProcessorMap<CounterState, CounterAction> = emptyMap()
 
-        val store = createStore(
-            initialState = CounterState(),
-            reducer = counterReducer,
-            middlewares = listOf(passthrough),
-            errorProcessor = testErrorProcessor,
-            logger = logger,
-            scope = backgroundScope,
-        )
+                override fun process(getState: () -> CounterState, action: CounterAction): Flow<CounterAction> =
+                    flowOf(action)
+            }
+
+        val store =
+            createStore(
+                initialState = CounterState(),
+                reducer = counterReducer,
+                middlewares = listOf(passthrough),
+                errorProcessor = testErrorProcessor,
+                logger = logger,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             awaitItem()
@@ -159,13 +161,14 @@ class StoreLoggerTest {
     @Test
     fun `onMiddlewaresCompleted is called after middleware chain`() = runTest {
         val logger = TestLogger()
-        val store = createStore(
-            initialState = CounterState(),
-            reducer = counterReducer,
-            errorProcessor = testErrorProcessor,
-            logger = logger,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = CounterState(),
+                reducer = counterReducer,
+                errorProcessor = testErrorProcessor,
+                logger = logger,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             awaitItem()
@@ -183,13 +186,14 @@ class StoreLoggerTest {
     @Test
     fun `onFlowHolderActionEmitted is called for FlowHolderAction inner actions`() = runTest {
         val logger = TestLogger()
-        val store = createStore(
-            initialState = CounterState(),
-            reducer = counterReducer,
-            errorProcessor = testErrorProcessor,
-            logger = logger,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = CounterState(),
+                reducer = counterReducer,
+                errorProcessor = testErrorProcessor,
+                logger = logger,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             awaitItem()
@@ -209,30 +213,32 @@ class StoreLoggerTest {
     fun `onErrorOccurred and onErrorHandled are called on middleware error`() = runTest {
         val logger = TestLogger()
 
-        val errorProcessor = object : ErrorProcessor<CounterAction> {
-            override fun process(throwable: Throwable): Flow<CounterAction> =
-                flowOf(CounterAction.SetValue(-1))
-        }
+        val errorProcessor =
+            object : ErrorProcessor<CounterAction> {
+                override fun process(throwable: Throwable): Flow<CounterAction> = flowOf(CounterAction.SetValue(-1))
+            }
 
-        val throwingMiddleware = object : Middleware<CounterState, CounterAction> {
-            override val processors: ActionProcessorMap<CounterState, CounterAction> = emptyMap()
-            override fun process(getState: () -> CounterState, action: CounterAction): Flow<CounterAction> =
-                flow {
+        val throwingMiddleware =
+            object : Middleware<CounterState, CounterAction> {
+                override val processors: ActionProcessorMap<CounterState, CounterAction> = emptyMap()
+
+                override fun process(getState: () -> CounterState, action: CounterAction): Flow<CounterAction> = flow {
                     if (action is CounterAction.FetchData) {
                         throw RuntimeException("test error")
                     }
                     emit(action)
                 }
-        }
+            }
 
-        val store = createStore(
-            initialState = CounterState(),
-            reducer = counterReducer,
-            middlewares = listOf(throwingMiddleware),
-            errorProcessor = errorProcessor,
-            logger = logger,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = CounterState(),
+                reducer = counterReducer,
+                middlewares = listOf(throwingMiddleware),
+                errorProcessor = errorProcessor,
+                logger = logger,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             awaitItem()
@@ -253,13 +259,14 @@ class StoreLoggerTest {
     @Test
     fun `onDispatchAfterClose is called when dispatching after close`() = runTest {
         val logger = TestLogger()
-        val store = createStore(
-            initialState = CounterState(),
-            reducer = counterReducer,
-            errorProcessor = testErrorProcessor,
-            logger = logger,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = CounterState(),
+                reducer = counterReducer,
+                errorProcessor = testErrorProcessor,
+                logger = logger,
+                scope = backgroundScope,
+            )
 
         store.close()
 
@@ -277,19 +284,25 @@ class StoreLoggerTest {
     fun `NoOpStoreLogger subclass with overrides receives callbacks`() = runTest {
         val reducedActions = mutableListOf<CounterAction>()
 
-        val subclassLogger = object : NoOpStoreLogger<CounterState, CounterAction>() {
-            override fun onStateReduced(action: CounterAction, previousState: CounterState, newState: CounterState) {
-                reducedActions.add(action)
+        val subclassLogger =
+            object : NoOpStoreLogger<CounterState, CounterAction>() {
+                override fun onStateReduced(
+                    action: CounterAction,
+                    previousState: CounterState,
+                    newState: CounterState,
+                ) {
+                    reducedActions.add(action)
+                }
             }
-        }
 
-        val store = createStore(
-            initialState = CounterState(),
-            reducer = counterReducer,
-            errorProcessor = testErrorProcessor,
-            logger = subclassLogger,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = CounterState(),
+                reducer = counterReducer,
+                errorProcessor = testErrorProcessor,
+                logger = subclassLogger,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             awaitItem()

--- a/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/StoreTest.kt
+++ b/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/StoreTest.kt
@@ -3,8 +3,8 @@ package io.flowdux
 import app.cash.turbine.test
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
-import kotlin.test.assertEquals
 import kotlin.test.Test
+import kotlin.test.assertEquals
 
 /**
  * Core store functionality tests.
@@ -19,89 +19,88 @@ import kotlin.test.Test
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class StoreTest {
-
     @Test
-    fun `store initializes with initial state`() =
-        runTest {
-            val store = createStore(
+    fun `store initializes with initial state`() = runTest {
+        val store =
+            createStore(
                 initialState = CounterState(count = 5),
                 reducer = counterReducer,
                 errorProcessor = testErrorProcessor,
                 scope = backgroundScope,
             )
 
-            assertEquals(5, store.currentState.count)
-        }
+        assertEquals(5, store.currentState.count)
+    }
 
     @Test
-    fun `dispatch increment action updates state`() =
-        runTest {
-            val store = createStore(
+    fun `dispatch increment action updates state`() = runTest {
+        val store =
+            createStore(
                 initialState = CounterState(),
                 reducer = counterReducer,
                 errorProcessor = testErrorProcessor,
                 scope = backgroundScope,
             )
 
-            store.state.test {
-                assertEquals(0, awaitItem().count)
+        store.state.test {
+            assertEquals(0, awaitItem().count)
 
-                store.dispatch(CounterAction.Increment)
-                assertEquals(1, awaitItem().count)
+            store.dispatch(CounterAction.Increment)
+            assertEquals(1, awaitItem().count)
 
-                cancelAndIgnoreRemainingEvents()
-            }
+            cancelAndIgnoreRemainingEvents()
         }
+    }
 
     @Test
-    fun `dispatch multiple actions updates state correctly`() =
-        runTest {
-            val store = createStore(
+    fun `dispatch multiple actions updates state correctly`() = runTest {
+        val store =
+            createStore(
                 initialState = CounterState(),
                 reducer = counterReducer,
                 errorProcessor = testErrorProcessor,
                 scope = backgroundScope,
             )
 
-            store.state.test {
-                assertEquals(0, awaitItem().count)
+        store.state.test {
+            assertEquals(0, awaitItem().count)
 
-                store.dispatch(CounterAction.Increment)
-                assertEquals(1, awaitItem().count)
+            store.dispatch(CounterAction.Increment)
+            assertEquals(1, awaitItem().count)
 
-                store.dispatch(CounterAction.Increment)
-                assertEquals(2, awaitItem().count)
+            store.dispatch(CounterAction.Increment)
+            assertEquals(2, awaitItem().count)
 
-                store.dispatch(CounterAction.Decrement)
-                assertEquals(1, awaitItem().count)
+            store.dispatch(CounterAction.Decrement)
+            assertEquals(1, awaitItem().count)
 
-                store.dispatch(CounterAction.Add(10))
-                assertEquals(11, awaitItem().count)
+            store.dispatch(CounterAction.Add(10))
+            assertEquals(11, awaitItem().count)
 
-                cancelAndIgnoreRemainingEvents()
-            }
+            cancelAndIgnoreRemainingEvents()
         }
+    }
 
     @Test
-    fun `state flow emits updates`() =
-        runTest {
-            val store = createStore(
+    fun `state flow emits updates`() = runTest {
+        val store =
+            createStore(
                 initialState = CounterState(),
                 reducer = counterReducer,
                 errorProcessor = testErrorProcessor,
                 scope = backgroundScope,
             )
 
-            store.state.test {
-                assertEquals(0, awaitItem().count)
+        store.state.test {
+            assertEquals(0, awaitItem().count)
 
-                store.dispatch(CounterAction.Increment)
-                assertEquals(1, awaitItem().count)
+            store.dispatch(CounterAction.Increment)
+            assertEquals(1, awaitItem().count)
 
-                store.dispatch(CounterAction.Add(5))
-                assertEquals(6, awaitItem().count)
+            store.dispatch(CounterAction.Add(5))
+            assertEquals(6, awaitItem().count)
 
-                cancelAndIgnoreRemainingEvents()
-            }
+            cancelAndIgnoreRemainingEvents()
         }
+    }
 }

--- a/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/TestFixtures.kt
+++ b/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/TestFixtures.kt
@@ -15,27 +15,33 @@ data class CounterState(val count: Int = 0) : State
 
 sealed interface CounterAction : Action {
     object Increment : CounterAction
+
     object Decrement : CounterAction
+
     data class Add(val value: Int) : CounterAction
+
     data class SetValue(val value: Int) : CounterAction
+
     data class FetchData(val id: String) : CounterAction
+
     data class FetchDataSuccess(val id: String, val value: Int) : CounterAction
+
     data class FetchDataError(val id: String, val error: String) : CounterAction
+
     object Reset : CounterAction
 
-    data class StreamConnected(
-        private val valueFlow: Flow<Int>,
-    ) : CounterAction, FlowHolderAction {
+    data class StreamConnected(private val valueFlow: Flow<Int>) :
+        CounterAction,
+        FlowHolderAction {
         override fun toFlowAction(): Flow<Action> = valueFlow.map { Add(it) }
     }
 
-    data class MultiStreamConnected(
-        private val flow1: Flow<Int>,
-        private val flow2: Flow<Int>,
-    ) : CounterAction, FlowHolderAction {
+    data class MultiStreamConnected(private val flow1: Flow<Int>, private val flow2: Flow<Int>) :
+        CounterAction,
+        FlowHolderAction {
         override fun toFlowAction() = listOf(
             flow1.map { Add(it) },
-            flow2.map { Add(it) }
+            flow2.map { Add(it) },
         ).merge()
     }
 
@@ -43,10 +49,9 @@ sealed interface CounterAction : Action {
      * Cancelable infinite stream action (default cancelable = true).
      * When a new instance is dispatched, the previous stream is cancelled.
      */
-    data class InfiniteStreamAction(
-        val id: String,
-        val emitInterval: Long = 100L,
-    ) : CounterAction, FlowHolderAction {
+    data class InfiniteStreamAction(val id: String, val emitInterval: Long = 100L) :
+        CounterAction,
+        FlowHolderAction {
         override fun toFlowAction(): Flow<Action> = flow {
             while (true) {
                 delay(emitInterval)
@@ -59,11 +64,9 @@ sealed interface CounterAction : Action {
      * Concurrent FlowHolderAction using Concurrent strategy.
      * Multiple streams can run concurrently.
      */
-    data class NonCancelableStreamAction(
-        val id: String,
-        val values: List<Int>,
-        val delayBetween: Long = 50L,
-    ) : CounterAction, FlowHolderAction {
+    data class NonCancelableStreamAction(val id: String, val values: List<Int>, val delayBetween: Long = 50L) :
+        CounterAction,
+        FlowHolderAction {
         override val strategy: ExecutionStrategy get() = concurrent()
 
         override fun toFlowAction(): Flow<Action> = flow {
@@ -79,10 +82,9 @@ sealed interface CounterAction : Action {
      * This is a different type from InfiniteStreamAction, used to test that
      * different cancelable types don't cancel each other.
      */
-    data class SecondaryStreamAction(
-        val id: String,
-        val emitInterval: Long = 100L,
-    ) : CounterAction, FlowHolderAction {
+    data class SecondaryStreamAction(val id: String, val emitInterval: Long = 100L) :
+        CounterAction,
+        FlowHolderAction {
         override fun toFlowAction(): Flow<Action> = flow {
             while (true) {
                 delay(emitInterval)
@@ -95,11 +97,9 @@ sealed interface CounterAction : Action {
      * FlowHolderAction using TakeLeading strategy.
      * First execution runs, subsequent ones are ignored until completion.
      */
-    data class TakeLeadingStreamAction(
-        val id: String,
-        val values: List<Int>,
-        val delayBetween: Long = 50L,
-    ) : CounterAction, FlowHolderAction {
+    data class TakeLeadingStreamAction(val id: String, val values: List<Int>, val delayBetween: Long = 50L) :
+        CounterAction,
+        FlowHolderAction {
         override val strategy: ExecutionStrategy get() = takeLeading()
 
         override fun toFlowAction(): Flow<Action> = flow {
@@ -114,11 +114,9 @@ sealed interface CounterAction : Action {
      * FlowHolderAction using Debounce strategy.
      * Waits for the specified duration after the last action before executing.
      */
-    data class DebouncedStreamAction(
-        val id: String,
-        val value: Int,
-        val debounceMs: Long = 100L,
-    ) : CounterAction, FlowHolderAction {
+    data class DebouncedStreamAction(val id: String, val value: Int, val debounceMs: Long = 100L) :
+        CounterAction,
+        FlowHolderAction {
         override val strategy: ExecutionStrategy get() = debounce(debounceMs)
 
         override fun toFlowAction(): Flow<Action> = flow {
@@ -130,11 +128,9 @@ sealed interface CounterAction : Action {
      * FlowHolderAction using Throttle strategy.
      * Executes immediately, then ignores subsequent actions for the window duration.
      */
-    data class ThrottledStreamAction(
-        val id: String,
-        val value: Int,
-        val throttleMs: Long = 100L,
-    ) : CounterAction, FlowHolderAction {
+    data class ThrottledStreamAction(val id: String, val value: Int, val throttleMs: Long = 100L) :
+        CounterAction,
+        FlowHolderAction {
         override val strategy: ExecutionStrategy get() = throttle(throttleMs)
 
         override fun toFlowAction(): Flow<Action> = flow {
@@ -147,9 +143,9 @@ sealed interface CounterAction : Action {
      * Uses Concurrent strategy to avoid cancellation issues with recursive calls.
      * Used to test recursive processing of nested FlowHolderActions.
      */
-    data class NestedFlowHolderAction(
-        val innerAction: FlowHolderAction,
-    ) : CounterAction, FlowHolderAction {
+    data class NestedFlowHolderAction(val innerAction: FlowHolderAction) :
+        CounterAction,
+        FlowHolderAction {
         override val strategy: ExecutionStrategy get() = concurrent()
 
         override fun toFlowAction(): Flow<Action> = flow {
@@ -162,9 +158,9 @@ sealed interface CounterAction : Action {
      * FlowHolderAction with explicit Dispatch delivery mode.
      * Inner actions are re-dispatched through the full middleware pipeline.
      */
-    data class DispatchDeliveryStreamAction(
-        private val valueFlow: Flow<Int>,
-    ) : CounterAction, FlowHolderAction {
+    data class DispatchDeliveryStreamAction(private val valueFlow: Flow<Int>) :
+        CounterAction,
+        FlowHolderAction {
         override val delivery: FlowActionDelivery get() = FlowActionDelivery.Dispatch
 
         override fun toFlowAction(): Flow<Action> = valueFlow.map { Add(it) }
@@ -209,8 +205,7 @@ val counterReducer =
         }
     }
 
-val testErrorProcessor = object : ErrorProcessor<CounterAction> {
-    override fun process(throwable: Throwable): Flow<CounterAction> {
-        return emptyFlow()
+val testErrorProcessor =
+    object : ErrorProcessor<CounterAction> {
+        override fun process(throwable: Throwable): Flow<CounterAction> = emptyFlow()
     }
-}

--- a/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/strategy/ConcurrencyStrategyTest.kt
+++ b/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/strategy/ConcurrencyStrategyTest.kt
@@ -3,11 +3,11 @@ package io.flowdux.strategy
 import app.cash.turbine.test
 import io.flowdux.Middleware
 import io.flowdux.createStore
+import io.flowdux.sequential
 import io.flowdux.strategy.ExecutionStrategyTestBase.TestAction
 import io.flowdux.strategy.ExecutionStrategyTestBase.TestState
 import io.flowdux.strategy.ExecutionStrategyTestBase.testErrorProcessor
 import io.flowdux.strategy.ExecutionStrategyTestBase.testReducer
-import io.flowdux.sequential
 import io.flowdux.takeLatest
 import io.flowdux.takeLeading
 import kotlinx.coroutines.CoroutineScope
@@ -19,38 +19,39 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-import kotlin.test.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ConcurrencyStrategyTest {
-
     class TakeLatestTests {
-
         @Test
         fun `takeLatest cancels previous execution when new action arrives`() = runTest {
             val executionOrder = mutableListOf<String>()
 
-            val middleware = object : Middleware<TestState, TestAction> {
-                override val processors = buildProcessors {
-                    on<TestAction.Fetch>(takeLatest()) { state, action ->
-                        executionOrder.add("start-${action.id}")
-                        delay(100)
-                        executionOrder.add("end-${action.id}")
-                        emit(TestAction.FetchSuccess(action.id, "result-${action.id}"))
-                    }
+            val middleware =
+                object : Middleware<TestState, TestAction> {
+                    override val processors =
+                        buildProcessors {
+                            on<TestAction.Fetch>(takeLatest()) { state, action ->
+                                executionOrder.add("start-${action.id}")
+                                delay(100)
+                                executionOrder.add("end-${action.id}")
+                                emit(TestAction.FetchSuccess(action.id, "result-${action.id}"))
+                            }
+                        }
                 }
-            }
 
-            val store = createStore(
-                initialState = TestState(),
-                reducer = testReducer,
-                middlewares = listOf(middleware),
-                errorProcessor = testErrorProcessor,
-                scope = backgroundScope,
-            )
+            val store =
+                createStore(
+                    initialState = TestState(),
+                    reducer = testReducer,
+                    middlewares = listOf(middleware),
+                    errorProcessor = testErrorProcessor,
+                    scope = backgroundScope,
+                )
 
             store.state.test {
                 assertEquals(emptyList<String>(), awaitItem().values)
@@ -83,29 +84,32 @@ class ConcurrencyStrategyTest {
             val completedActionsA = mutableListOf<String>()
             val completedActionsB = mutableListOf<String>()
 
-            val middleware = object : Middleware<TestState, TestAction> {
-                override val processors = buildProcessors {
-                    // Use separate takeLatest instances for different key groups
-                    on<TestAction.Fetch>(takeLatest()) { state, action ->
-                        delay(100)
-                        completedActionsA.add(action.id)
-                        emit(TestAction.FetchSuccess(action.id, "result-${action.id}"))
-                    }
-                    on<TestAction.Search>(takeLatest()) { state, action ->
-                        delay(100)
-                        completedActionsB.add(action.query)
-                        emit(TestAction.SearchResult(action.query, listOf(action.query)))
-                    }
+            val middleware =
+                object : Middleware<TestState, TestAction> {
+                    override val processors =
+                        buildProcessors {
+                            // Use separate takeLatest instances for different key groups
+                            on<TestAction.Fetch>(takeLatest()) { state, action ->
+                                delay(100)
+                                completedActionsA.add(action.id)
+                                emit(TestAction.FetchSuccess(action.id, "result-${action.id}"))
+                            }
+                            on<TestAction.Search>(takeLatest()) { state, action ->
+                                delay(100)
+                                completedActionsB.add(action.query)
+                                emit(TestAction.SearchResult(action.query, listOf(action.query)))
+                            }
+                        }
                 }
-            }
 
-            val store = createStore(
-                initialState = TestState(),
-                reducer = testReducer,
-                middlewares = listOf(middleware),
-                errorProcessor = testErrorProcessor,
-                scope = backgroundScope,
-            )
+            val store =
+                createStore(
+                    initialState = TestState(),
+                    reducer = testReducer,
+                    middlewares = listOf(middleware),
+                    errorProcessor = testErrorProcessor,
+                    scope = backgroundScope,
+                )
 
             store.state.test {
                 assertEquals(emptyList<String>(), awaitItem().values)
@@ -134,28 +138,30 @@ class ConcurrencyStrategyTest {
     }
 
     class TakeLeadingTests {
-
         @Test
         fun `takeLeading ignores actions while one is processing`() = runTest {
             val executionCount = mutableListOf<String>()
 
-            val middleware = object : Middleware<TestState, TestAction> {
-                override val processors = buildProcessors {
-                    on<TestAction.Fetch>(takeLeading()) { state, action ->
-                        executionCount.add(action.id)
-                        delay(100)
-                        emit(TestAction.FetchSuccess(action.id, "result-${action.id}"))
-                    }
+            val middleware =
+                object : Middleware<TestState, TestAction> {
+                    override val processors =
+                        buildProcessors {
+                            on<TestAction.Fetch>(takeLeading()) { state, action ->
+                                executionCount.add(action.id)
+                                delay(100)
+                                emit(TestAction.FetchSuccess(action.id, "result-${action.id}"))
+                            }
+                        }
                 }
-            }
 
-            val store = createStore(
-                initialState = TestState(),
-                reducer = testReducer,
-                middlewares = listOf(middleware),
-                errorProcessor = testErrorProcessor,
-                scope = backgroundScope,
-            )
+            val store =
+                createStore(
+                    initialState = TestState(),
+                    reducer = testReducer,
+                    middlewares = listOf(middleware),
+                    errorProcessor = testErrorProcessor,
+                    scope = backgroundScope,
+                )
 
             store.state.test {
                 assertEquals(emptyList<String>(), awaitItem().values)
@@ -180,23 +186,26 @@ class ConcurrencyStrategyTest {
         fun `takeLeading allows new action after previous completes`() = runTest {
             val executionOrder = mutableListOf<String>()
 
-            val middleware = object : Middleware<TestState, TestAction> {
-                override val processors = buildProcessors {
-                    on<TestAction.Click>(takeLeading()) { state, action ->
-                        executionOrder.add(action.buttonId)
-                        delay(50)
-                        emit(TestAction.ClickProcessed(action.buttonId))
-                    }
+            val middleware =
+                object : Middleware<TestState, TestAction> {
+                    override val processors =
+                        buildProcessors {
+                            on<TestAction.Click>(takeLeading()) { state, action ->
+                                executionOrder.add(action.buttonId)
+                                delay(50)
+                                emit(TestAction.ClickProcessed(action.buttonId))
+                            }
+                        }
                 }
-            }
 
-            val store = createStore(
-                initialState = TestState(),
-                reducer = testReducer,
-                middlewares = listOf(middleware),
-                errorProcessor = testErrorProcessor,
-                scope = backgroundScope,
-            )
+            val store =
+                createStore(
+                    initialState = TestState(),
+                    reducer = testReducer,
+                    middlewares = listOf(middleware),
+                    errorProcessor = testErrorProcessor,
+                    scope = backgroundScope,
+                )
 
             store.state.test {
                 assertEquals(emptyList<String>(), awaitItem().values)
@@ -219,29 +228,31 @@ class ConcurrencyStrategyTest {
     }
 
     class SequentialTests {
-
         @Test
         fun `sequential processes all actions in order`() = runTest {
             val executionOrder = mutableListOf<String>()
 
-            val middleware = object : Middleware<TestState, TestAction> {
-                override val processors = buildProcessors {
-                    on<TestAction.Fetch>(sequential()) { _, action ->
-                        executionOrder.add("start-${action.id}")
-                        delay(50)
-                        executionOrder.add("end-${action.id}")
-                        emit(TestAction.FetchSuccess(action.id, "result-${action.id}"))
-                    }
+            val middleware =
+                object : Middleware<TestState, TestAction> {
+                    override val processors =
+                        buildProcessors {
+                            on<TestAction.Fetch>(sequential()) { _, action ->
+                                executionOrder.add("start-${action.id}")
+                                delay(50)
+                                executionOrder.add("end-${action.id}")
+                                emit(TestAction.FetchSuccess(action.id, "result-${action.id}"))
+                            }
+                        }
                 }
-            }
 
-            val store = createStore(
-                initialState = TestState(),
-                reducer = testReducer,
-                middlewares = listOf(middleware),
-                errorProcessor = testErrorProcessor,
-                scope = backgroundScope,
-            )
+            val store =
+                createStore(
+                    initialState = TestState(),
+                    reducer = testReducer,
+                    middlewares = listOf(middleware),
+                    errorProcessor = testErrorProcessor,
+                    scope = backgroundScope,
+                )
 
             store.state.test {
                 assertEquals(emptyList<String>(), awaitItem().values)
@@ -262,7 +273,7 @@ class ConcurrencyStrategyTest {
                 // Verify order: each action should start and end before the next starts
                 assertEquals(
                     listOf("start-1", "end-1", "start-2", "end-2", "start-3", "end-3"),
-                    executionOrder
+                    executionOrder,
                 )
 
                 cancelAndIgnoreRemainingEvents()
@@ -274,33 +285,38 @@ class ConcurrencyStrategyTest {
             val sequentialExecutions = mutableListOf<String>()
             val leadingExecutions = mutableListOf<String>()
 
-            val sequentialMiddleware = object : Middleware<TestState, TestAction> {
-                override val processors = buildProcessors {
-                    on<TestAction.Fetch>(sequential()) { _, action ->
-                        sequentialExecutions.add(action.id)
-                        delay(50)
-                        emit(TestAction.FetchSuccess(action.id, action.id))
-                    }
+            val sequentialMiddleware =
+                object : Middleware<TestState, TestAction> {
+                    override val processors =
+                        buildProcessors {
+                            on<TestAction.Fetch>(sequential()) { _, action ->
+                                sequentialExecutions.add(action.id)
+                                delay(50)
+                                emit(TestAction.FetchSuccess(action.id, action.id))
+                            }
+                        }
                 }
-            }
 
-            val leadingMiddleware = object : Middleware<TestState, TestAction> {
-                override val processors = buildProcessors {
-                    on<TestAction.Search>(takeLeading()) { _, action ->
-                        leadingExecutions.add(action.query)
-                        delay(50)
-                        emit(TestAction.SearchResult(action.query, listOf(action.query)))
-                    }
+            val leadingMiddleware =
+                object : Middleware<TestState, TestAction> {
+                    override val processors =
+                        buildProcessors {
+                            on<TestAction.Search>(takeLeading()) { _, action ->
+                                leadingExecutions.add(action.query)
+                                delay(50)
+                                emit(TestAction.SearchResult(action.query, listOf(action.query)))
+                            }
+                        }
                 }
-            }
 
-            val store = createStore(
-                initialState = TestState(),
-                reducer = testReducer,
-                middlewares = listOf(sequentialMiddleware, leadingMiddleware),
-                errorProcessor = testErrorProcessor,
-                scope = backgroundScope,
-            )
+            val store =
+                createStore(
+                    initialState = TestState(),
+                    reducer = testReducer,
+                    middlewares = listOf(sequentialMiddleware, leadingMiddleware),
+                    errorProcessor = testErrorProcessor,
+                    scope = backgroundScope,
+                )
 
             store.state.test {
                 assertEquals(emptyList<String>(), awaitItem().values)
@@ -333,32 +349,35 @@ class ConcurrencyStrategyTest {
         fun `sequential with group processes different action types in order`() = runTest {
             val executionOrder = mutableListOf<String>()
 
-            val middleware = object : Middleware<TestState, TestAction> {
-                override val processors = buildProcessors {
-                    group(sequential()) {
-                        on<TestAction.Fetch> { _, action ->
-                            executionOrder.add("fetch-start-${action.id}")
-                            delay(50)
-                            executionOrder.add("fetch-end-${action.id}")
-                            emit(TestAction.FetchSuccess(action.id, action.id))
+            val middleware =
+                object : Middleware<TestState, TestAction> {
+                    override val processors =
+                        buildProcessors {
+                            group(sequential()) {
+                                on<TestAction.Fetch> { _, action ->
+                                    executionOrder.add("fetch-start-${action.id}")
+                                    delay(50)
+                                    executionOrder.add("fetch-end-${action.id}")
+                                    emit(TestAction.FetchSuccess(action.id, action.id))
+                                }
+                                on<TestAction.Search> { _, action ->
+                                    executionOrder.add("search-start-${action.query}")
+                                    delay(50)
+                                    executionOrder.add("search-end-${action.query}")
+                                    emit(TestAction.SearchResult(action.query, listOf(action.query)))
+                                }
+                            }
                         }
-                        on<TestAction.Search> { _, action ->
-                            executionOrder.add("search-start-${action.query}")
-                            delay(50)
-                            executionOrder.add("search-end-${action.query}")
-                            emit(TestAction.SearchResult(action.query, listOf(action.query)))
-                        }
-                    }
                 }
-            }
 
-            val store = createStore(
-                initialState = TestState(),
-                reducer = testReducer,
-                middlewares = listOf(middleware),
-                errorProcessor = testErrorProcessor,
-                scope = backgroundScope,
-            )
+            val store =
+                createStore(
+                    initialState = TestState(),
+                    reducer = testReducer,
+                    middlewares = listOf(middleware),
+                    errorProcessor = testErrorProcessor,
+                    scope = backgroundScope,
+                )
 
             store.state.test {
                 assertEquals(emptyList<String>(), awaitItem().values)
@@ -377,11 +396,14 @@ class ConcurrencyStrategyTest {
                 // All actions should process sequentially across types
                 assertEquals(
                     listOf(
-                        "fetch-start-1", "fetch-end-1",
-                        "search-start-a", "search-end-a",
-                        "fetch-start-2", "fetch-end-2"
+                        "fetch-start-1",
+                        "fetch-end-1",
+                        "search-start-a",
+                        "search-end-a",
+                        "fetch-start-2",
+                        "fetch-end-2",
                     ),
-                    executionOrder
+                    executionOrder,
                 )
 
                 cancelAndIgnoreRemainingEvents()
@@ -394,32 +416,35 @@ class ConcurrencyStrategyTest {
             val timestamps = mutableListOf<Pair<String, Long>>()
             val startTime = testScheduler.currentTime
 
-            val middleware = object : Middleware<TestState, TestAction> {
-                override val processors = buildProcessors {
-                    on<TestAction.Fetch>(sequential()) { _, action ->
-                        val eventName = "start-${action.id}"
-                        executionOrder.add(eventName)
-                        timestamps.add(eventName to (testScheduler.currentTime - startTime))
+            val middleware =
+                object : Middleware<TestState, TestAction> {
+                    override val processors =
+                        buildProcessors {
+                            on<TestAction.Fetch>(sequential()) { _, action ->
+                                val eventName = "start-${action.id}"
+                                executionOrder.add(eventName)
+                                timestamps.add(eventName to (testScheduler.currentTime - startTime))
 
-                        // First action takes much longer
-                        val processingTime = if (action.id == "1") 300L else 50L
-                        delay(processingTime)
+                                // First action takes much longer
+                                val processingTime = if (action.id == "1") 300L else 50L
+                                delay(processingTime)
 
-                        val endName = "end-${action.id}"
-                        executionOrder.add(endName)
-                        timestamps.add(endName to (testScheduler.currentTime - startTime))
-                        emit(TestAction.FetchSuccess(action.id, "result-${action.id}"))
-                    }
+                                val endName = "end-${action.id}"
+                                executionOrder.add(endName)
+                                timestamps.add(endName to (testScheduler.currentTime - startTime))
+                                emit(TestAction.FetchSuccess(action.id, "result-${action.id}"))
+                            }
+                        }
                 }
-            }
 
-            val store = createStore(
-                initialState = TestState(),
-                reducer = testReducer,
-                middlewares = listOf(middleware),
-                errorProcessor = testErrorProcessor,
-                scope = backgroundScope,
-            )
+            val store =
+                createStore(
+                    initialState = TestState(),
+                    reducer = testReducer,
+                    middlewares = listOf(middleware),
+                    errorProcessor = testErrorProcessor,
+                    scope = backgroundScope,
+                )
 
             store.state.test {
                 assertEquals(emptyList<String>(), awaitItem().values)
@@ -439,16 +464,22 @@ class ConcurrencyStrategyTest {
                 // Verify strict sequential order
                 assertEquals(
                     listOf("start-1", "end-1", "start-2", "end-2", "start-3", "end-3"),
-                    executionOrder
+                    executionOrder,
                 )
 
                 // Verify timing: action 2 should not start until action 1 ends at 300ms
                 val start2Time = timestamps.find { it.first == "start-2" }!!.second
-                assertTrue(start2Time >= 300, "Action 2 should start after action 1 ends (300ms), but started at $start2Time")
+                assertTrue(
+                    start2Time >= 300,
+                    "Action 2 should start after action 1 ends (300ms), but started at $start2Time",
+                )
 
                 // Action 3 should start after action 2 ends (300 + 50 = 350ms)
                 val start3Time = timestamps.find { it.first == "start-3" }!!.second
-                assertTrue(start3Time >= 350, "Action 3 should start after action 2 ends (350ms), but started at $start3Time")
+                assertTrue(
+                    start3Time >= 350,
+                    "Action 3 should start after action 2 ends (350ms), but started at $start3Time",
+                )
 
                 cancelAndIgnoreRemainingEvents()
             }
@@ -459,34 +490,38 @@ class ConcurrencyStrategyTest {
             val executionOrder = mutableListOf<String>()
             var errorCount = 0
 
-            val errorProcessor = object : io.flowdux.ErrorProcessor<TestAction> {
-                override fun process(throwable: Throwable): kotlinx.coroutines.flow.Flow<TestAction> {
-                    errorCount++
-                    return kotlinx.coroutines.flow.emptyFlow()
-                }
-            }
-
-            val middleware = object : Middleware<TestState, TestAction> {
-                override val processors = buildProcessors {
-                    on<TestAction.Fetch>(sequential()) { _, action ->
-                        executionOrder.add("start-${action.id}")
-                        if (action.id == "2") {
-                            throw RuntimeException("Action 2 fails")
-                        }
-                        delay(50)
-                        executionOrder.add("end-${action.id}")
-                        emit(TestAction.FetchSuccess(action.id, "result-${action.id}"))
+            val errorProcessor =
+                object : io.flowdux.ErrorProcessor<TestAction> {
+                    override fun process(throwable: Throwable): kotlinx.coroutines.flow.Flow<TestAction> {
+                        errorCount++
+                        return kotlinx.coroutines.flow.emptyFlow()
                     }
                 }
-            }
 
-            val store = createStore(
-                initialState = TestState(),
-                reducer = testReducer,
-                middlewares = listOf(middleware),
-                errorProcessor = errorProcessor,
-                scope = backgroundScope,
-            )
+            val middleware =
+                object : Middleware<TestState, TestAction> {
+                    override val processors =
+                        buildProcessors {
+                            on<TestAction.Fetch>(sequential()) { _, action ->
+                                executionOrder.add("start-${action.id}")
+                                if (action.id == "2") {
+                                    throw RuntimeException("Action 2 fails")
+                                }
+                                delay(50)
+                                executionOrder.add("end-${action.id}")
+                                emit(TestAction.FetchSuccess(action.id, "result-${action.id}"))
+                            }
+                        }
+                }
+
+            val store =
+                createStore(
+                    initialState = TestState(),
+                    reducer = testReducer,
+                    middlewares = listOf(middleware),
+                    errorProcessor = errorProcessor,
+                    scope = backgroundScope,
+                )
 
             store.state.test {
                 assertEquals(emptyList<String>(), awaitItem().values)
@@ -505,42 +540,43 @@ class ConcurrencyStrategyTest {
                 // Verify order: action 2 started but failed, then action 3 executed
                 assertEquals(
                     listOf("start-1", "end-1", "start-2", "start-3", "end-3"),
-                    executionOrder
+                    executionOrder,
                 )
                 assertEquals(1, errorCount)
 
                 cancelAndIgnoreRemainingEvents()
             }
         }
-
     }
 
     class RealDispatcherTests {
-
         @Test
         fun `takeLatest cancels previous execution with real dispatcher`() = runBlocking {
             // Large timing margins are needed for CI (especially iosSimulatorArm64).
             val executionOrder = mutableListOf<String>()
             val storeScope = CoroutineScope(Dispatchers.Default + Job())
 
-            val middleware = object : Middleware<TestState, TestAction> {
-                override val processors = buildProcessors {
-                    on<TestAction.Fetch>(takeLatest()) { _, action ->
-                        executionOrder.add("start-${action.id}")
-                        delay(500)
-                        executionOrder.add("end-${action.id}")
-                        emit(TestAction.FetchSuccess(action.id, "result-${action.id}"))
-                    }
+            val middleware =
+                object : Middleware<TestState, TestAction> {
+                    override val processors =
+                        buildProcessors {
+                            on<TestAction.Fetch>(takeLatest()) { _, action ->
+                                executionOrder.add("start-${action.id}")
+                                delay(500)
+                                executionOrder.add("end-${action.id}")
+                                emit(TestAction.FetchSuccess(action.id, "result-${action.id}"))
+                            }
+                        }
                 }
-            }
 
-            val store = createStore(
-                initialState = TestState(),
-                reducer = testReducer,
-                middlewares = listOf(middleware),
-                errorProcessor = testErrorProcessor,
-                scope = storeScope,
-            )
+            val store =
+                createStore(
+                    initialState = TestState(),
+                    reducer = testReducer,
+                    middlewares = listOf(middleware),
+                    errorProcessor = testErrorProcessor,
+                    scope = storeScope,
+                )
 
             try {
                 store.state.test {

--- a/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/strategy/ExecutionStrategyTestBase.kt
+++ b/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/strategy/ExecutionStrategyTestBase.kt
@@ -11,29 +11,35 @@ import kotlinx.coroutines.flow.emptyFlow
  * Shared test utilities for ExecutionStrategy tests.
  */
 object ExecutionStrategyTestBase {
-
     // Test-specific state and actions
     data class TestState(val values: List<String> = emptyList()) : State
 
     sealed interface TestAction : Action {
         data class Fetch(val id: String) : TestAction
+
         data class FetchSuccess(val id: String, val result: String) : TestAction
+
         data class Search(val query: String) : TestAction
+
         data class SearchResult(val query: String, val results: List<String>) : TestAction
+
         data class Click(val buttonId: String) : TestAction
+
         data class ClickProcessed(val buttonId: String) : TestAction
     }
 
-    val testReducer = Reducer<TestState, TestAction> { state, action ->
-        when (action) {
-            is TestAction.FetchSuccess -> state.copy(values = state.values + action.result)
-            is TestAction.SearchResult -> state.copy(values = action.results)
-            is TestAction.ClickProcessed -> state.copy(values = state.values + action.buttonId)
-            else -> state
+    val testReducer =
+        Reducer<TestState, TestAction> { state, action ->
+            when (action) {
+                is TestAction.FetchSuccess -> state.copy(values = state.values + action.result)
+                is TestAction.SearchResult -> state.copy(values = action.results)
+                is TestAction.ClickProcessed -> state.copy(values = state.values + action.buttonId)
+                else -> state
+            }
         }
-    }
 
-    val testErrorProcessor = object : ErrorProcessor<TestAction> {
-        override fun process(throwable: Throwable): Flow<TestAction> = emptyFlow()
-    }
+    val testErrorProcessor =
+        object : ErrorProcessor<TestAction> {
+            override fun process(throwable: Throwable): Flow<TestAction> = emptyFlow()
+        }
 }

--- a/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/strategy/ResilienceStrategyTest.kt
+++ b/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/strategy/ResilienceStrategyTest.kt
@@ -23,15 +23,14 @@ import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
-import kotlin.test.Test
 import kotlin.time.Duration.Companion.milliseconds
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ResilienceStrategyTest {
-
     @Test
     fun `retry has correct category`() {
         assertEquals(StrategyCategory.RESILIENCE, retry(3).category)
@@ -43,22 +42,25 @@ class ResilienceStrategyTest {
         val attemptCount = mutableListOf<Int>()
         var attempt = 0
 
-        val middleware = object : Middleware<TestState, TestAction> {
-            override val processors = buildProcessors {
-                on<TestAction.Fetch>(retry(3)) { _, action ->
-                    attemptCount.add(++attempt)
-                    emit(TestAction.FetchSuccess(action.id, "result-${action.id}"))
-                }
+        val middleware =
+            object : Middleware<TestState, TestAction> {
+                override val processors =
+                    buildProcessors {
+                        on<TestAction.Fetch>(retry(3)) { _, action ->
+                            attemptCount.add(++attempt)
+                            emit(TestAction.FetchSuccess(action.id, "result-${action.id}"))
+                        }
+                    }
             }
-        }
 
-        val store = createStore(
-            initialState = TestState(),
-            reducer = testReducer,
-            middlewares = listOf(middleware),
-            errorProcessor = testErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = TestState(),
+                reducer = testReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             assertEquals(emptyList<String>(), awaitItem().values)
@@ -78,25 +80,28 @@ class ResilienceStrategyTest {
         val attemptCount = mutableListOf<Int>()
         var attempt = 0
 
-        val middleware = object : Middleware<TestState, TestAction> {
-            override val processors = buildProcessors {
-                on<TestAction.Fetch>(retry(3)) { _, action ->
-                    attemptCount.add(++attempt)
-                    if (attempt < 3) {
-                        throw RuntimeException("Simulated failure $attempt")
+        val middleware =
+            object : Middleware<TestState, TestAction> {
+                override val processors =
+                    buildProcessors {
+                        on<TestAction.Fetch>(retry(3)) { _, action ->
+                            attemptCount.add(++attempt)
+                            if (attempt < 3) {
+                                throw RuntimeException("Simulated failure $attempt")
+                            }
+                            emit(TestAction.FetchSuccess(action.id, "result-${action.id}"))
+                        }
                     }
-                    emit(TestAction.FetchSuccess(action.id, "result-${action.id}"))
-                }
             }
-        }
 
-        val store = createStore(
-            initialState = TestState(),
-            reducer = testReducer,
-            middlewares = listOf(middleware),
-            errorProcessor = testErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = TestState(),
+                reducer = testReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             assertEquals(emptyList<String>(), awaitItem().values)
@@ -117,29 +122,33 @@ class ResilienceStrategyTest {
         var attempt = 0
         var caughtException: Throwable? = null
 
-        val errorProcessor = object : ErrorProcessor<TestAction> {
-            override fun process(throwable: Throwable): Flow<TestAction> {
-                caughtException = throwable
-                return emptyFlow()
-            }
-        }
-
-        val middleware = object : Middleware<TestState, TestAction> {
-            override val processors = buildProcessors {
-                on<TestAction.Fetch>(retry(3)) { _, _ ->
-                    attemptCount.add(++attempt)
-                    throw RuntimeException("Always fails")
+        val errorProcessor =
+            object : ErrorProcessor<TestAction> {
+                override fun process(throwable: Throwable): Flow<TestAction> {
+                    caughtException = throwable
+                    return emptyFlow()
                 }
             }
-        }
 
-        val store = createStore(
-            initialState = TestState(),
-            reducer = testReducer,
-            middlewares = listOf(middleware),
-            errorProcessor = errorProcessor,
-            scope = backgroundScope,
-        )
+        val middleware =
+            object : Middleware<TestState, TestAction> {
+                override val processors =
+                    buildProcessors {
+                        on<TestAction.Fetch>(retry(3)) { _, _ ->
+                            attemptCount.add(++attempt)
+                            throw RuntimeException("Always fails")
+                        }
+                    }
+            }
+
+        val store =
+            createStore(
+                initialState = TestState(),
+                reducer = testReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = errorProcessor,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             assertEquals(emptyList<String>(), awaitItem().values)
@@ -161,30 +170,34 @@ class ResilienceStrategyTest {
         var attempt = 0
         var caughtException: Throwable? = null
 
-        val errorProcessor = object : ErrorProcessor<TestAction> {
-            override fun process(throwable: Throwable): Flow<TestAction> {
-                caughtException = throwable
-                return emptyFlow()
-            }
-        }
-
-        // Only retry on IllegalStateException, not on IllegalArgumentException
-        val middleware = object : Middleware<TestState, TestAction> {
-            override val processors = buildProcessors {
-                on<TestAction.Fetch>(retry(3) { it is IllegalStateException }) { _, _ ->
-                    attemptCount.add(++attempt)
-                    throw IllegalArgumentException("Non-retryable")
+        val errorProcessor =
+            object : ErrorProcessor<TestAction> {
+                override fun process(throwable: Throwable): Flow<TestAction> {
+                    caughtException = throwable
+                    return emptyFlow()
                 }
             }
-        }
 
-        val store = createStore(
-            initialState = TestState(),
-            reducer = testReducer,
-            middlewares = listOf(middleware),
-            errorProcessor = errorProcessor,
-            scope = backgroundScope,
-        )
+        // Only retry on IllegalStateException, not on IllegalArgumentException
+        val middleware =
+            object : Middleware<TestState, TestAction> {
+                override val processors =
+                    buildProcessors {
+                        on<TestAction.Fetch>(retry(3) { it is IllegalStateException }) { _, _ ->
+                            attemptCount.add(++attempt)
+                            throw IllegalArgumentException("Non-retryable")
+                        }
+                    }
+            }
+
+        val store =
+            createStore(
+                initialState = TestState(),
+                reducer = testReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = errorProcessor,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             assertEquals(emptyList<String>(), awaitItem().values)
@@ -205,30 +218,35 @@ class ResilienceStrategyTest {
         var attempt = 0
         val startTime = testScheduler.currentTime
 
-        val middleware = object : Middleware<TestState, TestAction> {
-            override val processors = buildProcessors {
-                on<TestAction.Fetch>(retryWithBackoff(
-                    maxAttempts = 4,
-                    initialDelay = 100.milliseconds,
-                    factor = 2.0
-                )) { _, action ->
-                    attemptTimes.add(testScheduler.currentTime - startTime)
-                    attempt++
-                    if (attempt < 4) {
-                        throw RuntimeException("Simulated failure $attempt")
+        val middleware =
+            object : Middleware<TestState, TestAction> {
+                override val processors =
+                    buildProcessors {
+                        on<TestAction.Fetch>(
+                            retryWithBackoff(
+                                maxAttempts = 4,
+                                initialDelay = 100.milliseconds,
+                                factor = 2.0,
+                            ),
+                        ) { _, action ->
+                            attemptTimes.add(testScheduler.currentTime - startTime)
+                            attempt++
+                            if (attempt < 4) {
+                                throw RuntimeException("Simulated failure $attempt")
+                            }
+                            emit(TestAction.FetchSuccess(action.id, "result-${action.id}"))
+                        }
                     }
-                    emit(TestAction.FetchSuccess(action.id, "result-${action.id}"))
-                }
             }
-        }
 
-        val store = createStore(
-            initialState = TestState(),
-            reducer = testReducer,
-            middlewares = listOf(middleware),
-            errorProcessor = testErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = TestState(),
+                reducer = testReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             assertEquals(emptyList<String>(), awaitItem().values)
@@ -259,23 +277,26 @@ class ResilienceStrategyTest {
         val attemptCount = mutableListOf<Int>()
         var attempt = 0
 
-        val middleware = object : Middleware<TestState, TestAction> {
-            override val processors = buildProcessors {
-                on<TestAction.Fetch>(retry(3)) { _, action ->
-                    attemptCount.add(++attempt)
-                    delay(100) // This will be cancelled
-                    emit(TestAction.FetchSuccess(action.id, "result-${action.id}"))
-                }
+        val middleware =
+            object : Middleware<TestState, TestAction> {
+                override val processors =
+                    buildProcessors {
+                        on<TestAction.Fetch>(retry(3)) { _, action ->
+                            attemptCount.add(++attempt)
+                            delay(100) // This will be cancelled
+                            emit(TestAction.FetchSuccess(action.id, "result-${action.id}"))
+                        }
+                    }
             }
-        }
 
-        val store = createStore(
-            initialState = TestState(),
-            reducer = testReducer,
-            middlewares = listOf(middleware),
-            errorProcessor = testErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = TestState(),
+                reducer = testReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             assertEquals(emptyList<String>(), awaitItem().values)
@@ -301,31 +322,36 @@ class ResilienceStrategyTest {
         var attempt = 0
         val startTime = testScheduler.currentTime
 
-        val middleware = object : Middleware<TestState, TestAction> {
-            override val processors = buildProcessors {
-                on<TestAction.Fetch>(retryWithBackoff(
-                    maxAttempts = 5,
-                    initialDelay = 100.milliseconds,
-                    maxDelay = 150.milliseconds, // Cap at 150ms
-                    factor = 2.0
-                )) { _, action ->
-                    attemptTimes.add(testScheduler.currentTime - startTime)
-                    attempt++
-                    if (attempt < 5) {
-                        throw RuntimeException("Simulated failure $attempt")
+        val middleware =
+            object : Middleware<TestState, TestAction> {
+                override val processors =
+                    buildProcessors {
+                        on<TestAction.Fetch>(
+                            retryWithBackoff(
+                                maxAttempts = 5,
+                                initialDelay = 100.milliseconds,
+                                maxDelay = 150.milliseconds, // Cap at 150ms
+                                factor = 2.0,
+                            ),
+                        ) { _, action ->
+                            attemptTimes.add(testScheduler.currentTime - startTime)
+                            attempt++
+                            if (attempt < 5) {
+                                throw RuntimeException("Simulated failure $attempt")
+                            }
+                            emit(TestAction.FetchSuccess(action.id, "result-${action.id}"))
+                        }
                     }
-                    emit(TestAction.FetchSuccess(action.id, "result-${action.id}"))
-                }
             }
-        }
 
-        val store = createStore(
-            initialState = TestState(),
-            reducer = testReducer,
-            middlewares = listOf(middleware),
-            errorProcessor = testErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = TestState(),
+                reducer = testReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             assertEquals(emptyList<String>(), awaitItem().values)
@@ -364,9 +390,10 @@ class ResilienceStrategyTest {
 
     @Test
     fun `chaining two resilience strategies throws exception`() {
-        val exception = assertFailsWith<IllegalArgumentException> {
-            retry(3) then retryWithBackoff(3, 100.milliseconds)
-        }
+        val exception =
+            assertFailsWith<IllegalArgumentException> {
+                retry(3) then retryWithBackoff(3, 100.milliseconds)
+            }
         assertTrue(exception.message!!.contains("RESILIENCE"))
     }
 
@@ -375,33 +402,40 @@ class ResilienceStrategyTest {
         // Large timing margins are needed for CI (especially iosSimulatorArm64).
         val attemptTimes = mutableListOf<Long>()
         var attempt = 0
-        val startMark = kotlin.time.TimeSource.Monotonic.markNow()
+        val startMark =
+            kotlin.time.TimeSource.Monotonic
+                .markNow()
         val storeScope = CoroutineScope(Dispatchers.Default + Job())
 
-        val middleware = object : Middleware<TestState, TestAction> {
-            override val processors = buildProcessors {
-                on<TestAction.Fetch>(retryWithBackoff(
-                    maxAttempts = 3,
-                    initialDelay = 200.milliseconds,
-                    factor = 2.0
-                )) { _, action ->
-                    attemptTimes.add(startMark.elapsedNow().inWholeMilliseconds)
-                    attempt++
-                    if (attempt < 3) {
-                        throw RuntimeException("Simulated failure $attempt")
+        val middleware =
+            object : Middleware<TestState, TestAction> {
+                override val processors =
+                    buildProcessors {
+                        on<TestAction.Fetch>(
+                            retryWithBackoff(
+                                maxAttempts = 3,
+                                initialDelay = 200.milliseconds,
+                                factor = 2.0,
+                            ),
+                        ) { _, action ->
+                            attemptTimes.add(startMark.elapsedNow().inWholeMilliseconds)
+                            attempt++
+                            if (attempt < 3) {
+                                throw RuntimeException("Simulated failure $attempt")
+                            }
+                            emit(TestAction.FetchSuccess(action.id, "result-${action.id}"))
+                        }
                     }
-                    emit(TestAction.FetchSuccess(action.id, "result-${action.id}"))
-                }
             }
-        }
 
-        val store = createStore(
-            initialState = TestState(),
-            reducer = testReducer,
-            middlewares = listOf(middleware),
-            errorProcessor = testErrorProcessor,
-            scope = storeScope,
-        )
+        val store =
+            createStore(
+                initialState = TestState(),
+                reducer = testReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = testErrorProcessor,
+                scope = storeScope,
+            )
 
         try {
             store.state.test {
@@ -441,31 +475,36 @@ class ResilienceStrategyTest {
         var attempt = 0
         val startTime = testScheduler.currentTime
 
-        val middleware = object : Middleware<TestState, TestAction> {
-            override val processors = buildProcessors {
-                on<TestAction.Fetch>(retryWithBackoff(
-                    maxAttempts = 4,
-                    initialDelay = 100.milliseconds,
-                    factor = 2.0,
-                    jitter = 0.5 // 50% jitter
-                )) { _, action ->
-                    attemptTimes.add(testScheduler.currentTime - startTime)
-                    attempt++
-                    if (attempt < 4) {
-                        throw RuntimeException("Simulated failure $attempt")
+        val middleware =
+            object : Middleware<TestState, TestAction> {
+                override val processors =
+                    buildProcessors {
+                        on<TestAction.Fetch>(
+                            retryWithBackoff(
+                                maxAttempts = 4,
+                                initialDelay = 100.milliseconds,
+                                factor = 2.0,
+                                jitter = 0.5, // 50% jitter
+                            ),
+                        ) { _, action ->
+                            attemptTimes.add(testScheduler.currentTime - startTime)
+                            attempt++
+                            if (attempt < 4) {
+                                throw RuntimeException("Simulated failure $attempt")
+                            }
+                            emit(TestAction.FetchSuccess(action.id, "result-${action.id}"))
+                        }
                     }
-                    emit(TestAction.FetchSuccess(action.id, "result-${action.id}"))
-                }
             }
-        }
 
-        val store = createStore(
-            initialState = TestState(),
-            reducer = testReducer,
-            middlewares = listOf(middleware),
-            errorProcessor = testErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = TestState(),
+                reducer = testReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             assertEquals(emptyList<String>(), awaitItem().values)
@@ -520,31 +559,36 @@ class ResilienceStrategyTest {
             var attempt = 0
             val startTime = testScheduler.currentTime
 
-            val middleware = object : Middleware<TestState, TestAction> {
-                override val processors = buildProcessors {
-                    on<TestAction.Fetch>(retryWithBackoff(
-                        maxAttempts = 2,
-                        initialDelay = 100.milliseconds,
-                        factor = 2.0,
-                        jitter = 1.0 // 100% jitter for maximum variation
-                    )) { _, action ->
-                        attemptTimes.add(testScheduler.currentTime - startTime)
-                        attempt++
-                        if (attempt < 2) {
-                            throw RuntimeException("Simulated failure $attempt")
+            val middleware =
+                object : Middleware<TestState, TestAction> {
+                    override val processors =
+                        buildProcessors {
+                            on<TestAction.Fetch>(
+                                retryWithBackoff(
+                                    maxAttempts = 2,
+                                    initialDelay = 100.milliseconds,
+                                    factor = 2.0,
+                                    jitter = 1.0, // 100% jitter for maximum variation
+                                ),
+                            ) { _, action ->
+                                attemptTimes.add(testScheduler.currentTime - startTime)
+                                attempt++
+                                if (attempt < 2) {
+                                    throw RuntimeException("Simulated failure $attempt")
+                                }
+                                emit(TestAction.FetchSuccess(action.id, "result-${action.id}"))
+                            }
                         }
-                        emit(TestAction.FetchSuccess(action.id, "result-${action.id}"))
-                    }
                 }
-            }
 
-            val store = createStore(
-                initialState = TestState(),
-                reducer = testReducer,
-                middlewares = listOf(middleware),
-                errorProcessor = testErrorProcessor,
-                scope = backgroundScope,
-            )
+            val store =
+                createStore(
+                    initialState = TestState(),
+                    reducer = testReducer,
+                    middlewares = listOf(middleware),
+                    errorProcessor = testErrorProcessor,
+                    scope = backgroundScope,
+                )
 
             store.state.test {
                 assertEquals(emptyList<String>(), awaitItem().values)
@@ -580,8 +624,10 @@ class ResilienceStrategyTest {
         // Check that we got some variation (not all delays are identical)
         // With 100% jitter over 10 runs, we expect variation (at least 2 unique values)
         val uniqueDelays = allDelays.distinct()
-        assertTrue(uniqueDelays.size >= 2,
-            "Expected at least 2 unique delays with jitter, but got ${uniqueDelays.size}: $uniqueDelays")
+        assertTrue(
+            uniqueDelays.size >= 2,
+            "Expected at least 2 unique delays with jitter, but got ${uniqueDelays.size}: $uniqueDelays",
+        )
     }
 
     @Test
@@ -590,31 +636,36 @@ class ResilienceStrategyTest {
         var attempt = 0
         val startTime = testScheduler.currentTime
 
-        val middleware = object : Middleware<TestState, TestAction> {
-            override val processors = buildProcessors {
-                on<TestAction.Fetch>(retryWithBackoff(
-                    maxAttempts = 3,
-                    initialDelay = 100.milliseconds,
-                    factor = 2.0,
-                    jitter = 0.0 // No jitter
-                )) { _, action ->
-                    attemptTimes.add(testScheduler.currentTime - startTime)
-                    attempt++
-                    if (attempt < 3) {
-                        throw RuntimeException("Simulated failure $attempt")
+        val middleware =
+            object : Middleware<TestState, TestAction> {
+                override val processors =
+                    buildProcessors {
+                        on<TestAction.Fetch>(
+                            retryWithBackoff(
+                                maxAttempts = 3,
+                                initialDelay = 100.milliseconds,
+                                factor = 2.0,
+                                jitter = 0.0, // No jitter
+                            ),
+                        ) { _, action ->
+                            attemptTimes.add(testScheduler.currentTime - startTime)
+                            attempt++
+                            if (attempt < 3) {
+                                throw RuntimeException("Simulated failure $attempt")
+                            }
+                            emit(TestAction.FetchSuccess(action.id, "result-${action.id}"))
+                        }
                     }
-                    emit(TestAction.FetchSuccess(action.id, "result-${action.id}"))
-                }
             }
-        }
 
-        val store = createStore(
-            initialState = TestState(),
-            reducer = testReducer,
-            middlewares = listOf(middleware),
-            errorProcessor = testErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = TestState(),
+                reducer = testReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             assertEquals(emptyList<String>(), awaitItem().values)

--- a/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/strategy/StrategyChainingTest.kt
+++ b/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/strategy/StrategyChainingTest.kt
@@ -21,11 +21,11 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-import kotlin.test.Test
 import kotlin.time.Duration.Companion.milliseconds
 
 @OptIn(ExperimentalCoroutinesApi::class)

--- a/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/strategy/StrategyGroupTest.kt
+++ b/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/strategy/StrategyGroupTest.kt
@@ -21,46 +21,48 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-import kotlin.test.Test
 import kotlin.time.Duration.Companion.milliseconds
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class StrategyGroupTest {
-
     @Test
     fun `group shares strategy instance across different action types`() = runTest {
         val executionOrder = mutableListOf<String>()
 
-        val middleware = object : Middleware<TestState, TestAction> {
-            override val processors = buildProcessors {
-                // Both Fetch and Search share the same takeLatest instance
-                group(takeLatest()) {
-                    on<TestAction.Fetch> { _, action ->
-                        executionOrder.add("fetch-start-${action.id}")
-                        delay(100)
-                        executionOrder.add("fetch-end-${action.id}")
-                        emit(TestAction.FetchSuccess(action.id, "result-${action.id}"))
+        val middleware =
+            object : Middleware<TestState, TestAction> {
+                override val processors =
+                    buildProcessors {
+                        // Both Fetch and Search share the same takeLatest instance
+                        group(takeLatest()) {
+                            on<TestAction.Fetch> { _, action ->
+                                executionOrder.add("fetch-start-${action.id}")
+                                delay(100)
+                                executionOrder.add("fetch-end-${action.id}")
+                                emit(TestAction.FetchSuccess(action.id, "result-${action.id}"))
+                            }
+                            on<TestAction.Search> { _, action ->
+                                executionOrder.add("search-start-${action.query}")
+                                delay(100)
+                                executionOrder.add("search-end-${action.query}")
+                                emit(TestAction.SearchResult(action.query, listOf(action.query)))
+                            }
+                        }
                     }
-                    on<TestAction.Search> { _, action ->
-                        executionOrder.add("search-start-${action.query}")
-                        delay(100)
-                        executionOrder.add("search-end-${action.query}")
-                        emit(TestAction.SearchResult(action.query, listOf(action.query)))
-                    }
-                }
             }
-        }
 
-        val store = createStore(
-            initialState = TestState(),
-            reducer = testReducer,
-            middlewares = listOf(middleware),
-            errorProcessor = testErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = TestState(),
+                reducer = testReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             assertEquals(emptyList<String>(), awaitItem().values)
@@ -89,30 +91,33 @@ class StrategyGroupTest {
     fun `group with takeLeading blocks across different action types`() = runTest {
         val executionOrder = mutableListOf<String>()
 
-        val middleware = object : Middleware<TestState, TestAction> {
-            override val processors = buildProcessors {
-                group(takeLeading()) {
-                    on<TestAction.Fetch> { _, action ->
-                        executionOrder.add("fetch-${action.id}")
-                        delay(100)
-                        emit(TestAction.FetchSuccess(action.id, action.id))
+        val middleware =
+            object : Middleware<TestState, TestAction> {
+                override val processors =
+                    buildProcessors {
+                        group(takeLeading()) {
+                            on<TestAction.Fetch> { _, action ->
+                                executionOrder.add("fetch-${action.id}")
+                                delay(100)
+                                emit(TestAction.FetchSuccess(action.id, action.id))
+                            }
+                            on<TestAction.Search> { _, action ->
+                                executionOrder.add("search-${action.query}")
+                                delay(100)
+                                emit(TestAction.SearchResult(action.query, listOf(action.query)))
+                            }
+                        }
                     }
-                    on<TestAction.Search> { _, action ->
-                        executionOrder.add("search-${action.query}")
-                        delay(100)
-                        emit(TestAction.SearchResult(action.query, listOf(action.query)))
-                    }
-                }
             }
-        }
 
-        val store = createStore(
-            initialState = TestState(),
-            reducer = testReducer,
-            middlewares = listOf(middleware),
-            errorProcessor = testErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = TestState(),
+                reducer = testReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             assertEquals(emptyList<String>(), awaitItem().values)
@@ -137,32 +142,35 @@ class StrategyGroupTest {
         val groupAExecutions = mutableListOf<String>()
         val groupBExecutions = mutableListOf<String>()
 
-        val middleware = object : Middleware<TestState, TestAction> {
-            override val processors = buildProcessors {
-                group(takeLatest()) {
-                    on<TestAction.Fetch> { _, action ->
-                        delay(50)
-                        groupAExecutions.add(action.id)
-                        emit(TestAction.FetchSuccess(action.id, action.id))
+        val middleware =
+            object : Middleware<TestState, TestAction> {
+                override val processors =
+                    buildProcessors {
+                        group(takeLatest()) {
+                            on<TestAction.Fetch> { _, action ->
+                                delay(50)
+                                groupAExecutions.add(action.id)
+                                emit(TestAction.FetchSuccess(action.id, action.id))
+                            }
+                        }
+                        group(takeLatest()) {
+                            on<TestAction.Search> { _, action ->
+                                delay(50)
+                                groupBExecutions.add(action.query)
+                                emit(TestAction.SearchResult(action.query, listOf(action.query)))
+                            }
+                        }
                     }
-                }
-                group(takeLatest()) {
-                    on<TestAction.Search> { _, action ->
-                        delay(50)
-                        groupBExecutions.add(action.query)
-                        emit(TestAction.SearchResult(action.query, listOf(action.query)))
-                    }
-                }
             }
-        }
 
-        val store = createStore(
-            initialState = TestState(),
-            reducer = testReducer,
-            middlewares = listOf(middleware),
-            errorProcessor = testErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = TestState(),
+                reducer = testReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             assertEquals(emptyList<String>(), awaitItem().values)
@@ -192,28 +200,31 @@ class StrategyGroupTest {
     fun `group with debounce resets timer across different action types`() = runTest {
         val executionOrder = mutableListOf<String>()
 
-        val middleware = object : Middleware<TestState, TestAction> {
-            override val processors = buildProcessors {
-                group(debounce(100.milliseconds)) {
-                    on<TestAction.Fetch> { _, action ->
-                        executionOrder.add("fetch-${action.id}")
-                        emit(TestAction.FetchSuccess(action.id, action.id))
+        val middleware =
+            object : Middleware<TestState, TestAction> {
+                override val processors =
+                    buildProcessors {
+                        group(debounce(100.milliseconds)) {
+                            on<TestAction.Fetch> { _, action ->
+                                executionOrder.add("fetch-${action.id}")
+                                emit(TestAction.FetchSuccess(action.id, action.id))
+                            }
+                            on<TestAction.Search> { _, action ->
+                                executionOrder.add("search-${action.query}")
+                                emit(TestAction.SearchResult(action.query, listOf(action.query)))
+                            }
+                        }
                     }
-                    on<TestAction.Search> { _, action ->
-                        executionOrder.add("search-${action.query}")
-                        emit(TestAction.SearchResult(action.query, listOf(action.query)))
-                    }
-                }
             }
-        }
 
-        val store = createStore(
-            initialState = TestState(),
-            reducer = testReducer,
-            middlewares = listOf(middleware),
-            errorProcessor = testErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = TestState(),
+                reducer = testReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             assertEquals(emptyList<String>(), awaitItem().values)
@@ -240,28 +251,31 @@ class StrategyGroupTest {
         val executionOrder = mutableListOf<String>()
         val storeScope = CoroutineScope(Dispatchers.Default + Job())
 
-        val middleware = object : Middleware<TestState, TestAction> {
-            override val processors = buildProcessors {
-                group(throttle(500.milliseconds)) {
-                    on<TestAction.Fetch> { _, action ->
-                        executionOrder.add("fetch-${action.id}")
-                        emit(TestAction.FetchSuccess(action.id, action.id))
+        val middleware =
+            object : Middleware<TestState, TestAction> {
+                override val processors =
+                    buildProcessors {
+                        group(throttle(500.milliseconds)) {
+                            on<TestAction.Fetch> { _, action ->
+                                executionOrder.add("fetch-${action.id}")
+                                emit(TestAction.FetchSuccess(action.id, action.id))
+                            }
+                            on<TestAction.Search> { _, action ->
+                                executionOrder.add("search-${action.query}")
+                                emit(TestAction.SearchResult(action.query, listOf(action.query)))
+                            }
+                        }
                     }
-                    on<TestAction.Search> { _, action ->
-                        executionOrder.add("search-${action.query}")
-                        emit(TestAction.SearchResult(action.query, listOf(action.query)))
-                    }
-                }
             }
-        }
 
-        val store = createStore(
-            initialState = TestState(),
-            reducer = testReducer,
-            middlewares = listOf(middleware),
-            errorProcessor = testErrorProcessor,
-            scope = storeScope,
-        )
+        val store =
+            createStore(
+                initialState = TestState(),
+                reducer = testReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = testErrorProcessor,
+                scope = storeScope,
+            )
 
         try {
             store.state.test {
@@ -294,38 +308,41 @@ class StrategyGroupTest {
     fun `group with retry retries failed actions within the group`() = runTest {
         val attemptCounts = mutableMapOf<String, Int>()
 
-        val middleware = object : Middleware<TestState, TestAction> {
-            override val processors = buildProcessors {
-                group(retry(3)) {
-                    on<TestAction.Fetch> { _, action ->
-                        val key = "fetch-${action.id}"
-                        val count = attemptCounts.getOrPut(key) { 0 } + 1
-                        attemptCounts[key] = count
-                        if (action.id == "fail" && count < 3) {
-                            throw RuntimeException("Simulated failure $count")
+        val middleware =
+            object : Middleware<TestState, TestAction> {
+                override val processors =
+                    buildProcessors {
+                        group(retry(3)) {
+                            on<TestAction.Fetch> { _, action ->
+                                val key = "fetch-${action.id}"
+                                val count = attemptCounts.getOrPut(key) { 0 } + 1
+                                attemptCounts[key] = count
+                                if (action.id == "fail" && count < 3) {
+                                    throw RuntimeException("Simulated failure $count")
+                                }
+                                emit(TestAction.FetchSuccess(action.id, "result-${action.id}"))
+                            }
+                            on<TestAction.Search> { _, action ->
+                                val key = "search-${action.query}"
+                                val count = attemptCounts.getOrPut(key) { 0 } + 1
+                                attemptCounts[key] = count
+                                if (action.query == "fail" && count < 2) {
+                                    throw RuntimeException("Simulated failure $count")
+                                }
+                                emit(TestAction.SearchResult(action.query, listOf(action.query)))
+                            }
                         }
-                        emit(TestAction.FetchSuccess(action.id, "result-${action.id}"))
                     }
-                    on<TestAction.Search> { _, action ->
-                        val key = "search-${action.query}"
-                        val count = attemptCounts.getOrPut(key) { 0 } + 1
-                        attemptCounts[key] = count
-                        if (action.query == "fail" && count < 2) {
-                            throw RuntimeException("Simulated failure $count")
-                        }
-                        emit(TestAction.SearchResult(action.query, listOf(action.query)))
-                    }
-                }
             }
-        }
 
-        val store = createStore(
-            initialState = TestState(),
-            reducer = testReducer,
-            middlewares = listOf(middleware),
-            errorProcessor = testErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = TestState(),
+                reducer = testReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             assertEquals(emptyList<String>(), awaitItem().values)
@@ -348,7 +365,7 @@ class StrategyGroupTest {
             // Verify retry counts
             assertEquals(3, attemptCounts["fetch-fail"]) // Fetch "fail" retried 3 times
             assertEquals(2, attemptCounts["search-fail"]) // Search "fail" retried 2 times
-            assertEquals(1, attemptCounts["fetch-ok"])   // Fetch "ok" succeeded first time
+            assertEquals(1, attemptCounts["fetch-ok"]) // Fetch "ok" succeeded first time
 
             cancelAndIgnoreRemainingEvents()
         }

--- a/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/strategy/TimingStrategyTest.kt
+++ b/kotlin/flowdux/src/commonTest/kotlin/io/flowdux/strategy/TimingStrategyTest.kt
@@ -18,35 +18,36 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
-import kotlin.test.assertEquals
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.milliseconds
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TimingStrategyTest {
-
     class DebounceTests {
-
         @Test
         fun `debounce delays execution and cancels on rapid actions`() = runTest {
             val searchResults = mutableListOf<String>()
 
-            val middleware = object : Middleware<TestState, TestAction> {
-                override val processors = buildProcessors {
-                    on<TestAction.Search>(debounce(100.milliseconds)) { state, action ->
-                        searchResults.add(action.query)
-                        emit(TestAction.SearchResult(action.query, listOf("result-${action.query}")))
-                    }
+            val middleware =
+                object : Middleware<TestState, TestAction> {
+                    override val processors =
+                        buildProcessors {
+                            on<TestAction.Search>(debounce(100.milliseconds)) { state, action ->
+                                searchResults.add(action.query)
+                                emit(TestAction.SearchResult(action.query, listOf("result-${action.query}")))
+                            }
+                        }
                 }
-            }
 
-            val store = createStore(
-                initialState = TestState(),
-                reducer = testReducer,
-                middlewares = listOf(middleware),
-                errorProcessor = testErrorProcessor,
-                scope = backgroundScope,
-            )
+            val store =
+                createStore(
+                    initialState = TestState(),
+                    reducer = testReducer,
+                    middlewares = listOf(middleware),
+                    errorProcessor = testErrorProcessor,
+                    scope = backgroundScope,
+                )
 
             store.state.test {
                 assertEquals(emptyList<String>(), awaitItem().values)
@@ -74,22 +75,25 @@ class TimingStrategyTest {
         fun `debounce executes after quiet period`() = runTest {
             val executedQueries = mutableListOf<String>()
 
-            val middleware = object : Middleware<TestState, TestAction> {
-                override val processors = buildProcessors {
-                    on<TestAction.Search>(debounce(50.milliseconds)) { state, action ->
-                        executedQueries.add(action.query)
-                        emit(TestAction.SearchResult(action.query, listOf(action.query)))
-                    }
+            val middleware =
+                object : Middleware<TestState, TestAction> {
+                    override val processors =
+                        buildProcessors {
+                            on<TestAction.Search>(debounce(50.milliseconds)) { state, action ->
+                                executedQueries.add(action.query)
+                                emit(TestAction.SearchResult(action.query, listOf(action.query)))
+                            }
+                        }
                 }
-            }
 
-            val store = createStore(
-                initialState = TestState(),
-                reducer = testReducer,
-                middlewares = listOf(middleware),
-                errorProcessor = testErrorProcessor,
-                scope = backgroundScope,
-            )
+            val store =
+                createStore(
+                    initialState = TestState(),
+                    reducer = testReducer,
+                    middlewares = listOf(middleware),
+                    errorProcessor = testErrorProcessor,
+                    scope = backgroundScope,
+                )
 
             store.state.test {
                 assertEquals(emptyList<String>(), awaitItem().values)
@@ -112,7 +116,6 @@ class TimingStrategyTest {
     }
 
     class ThrottleTests {
-
         @Test
         fun `throttle limits execution rate`() = runBlocking {
             // Throttle uses real time (TimeSource.Monotonic), so we use runBlocking.
@@ -120,22 +123,25 @@ class TimingStrategyTest {
             val executedClicks = mutableListOf<String>()
             val storeScope = CoroutineScope(Dispatchers.Default + Job())
 
-            val middleware = object : Middleware<TestState, TestAction> {
-                override val processors = buildProcessors {
-                    on<TestAction.Click>(throttle(500.milliseconds)) { _, action ->
-                        executedClicks.add(action.buttonId)
-                        emit(TestAction.ClickProcessed(action.buttonId))
-                    }
+            val middleware =
+                object : Middleware<TestState, TestAction> {
+                    override val processors =
+                        buildProcessors {
+                            on<TestAction.Click>(throttle(500.milliseconds)) { _, action ->
+                                executedClicks.add(action.buttonId)
+                                emit(TestAction.ClickProcessed(action.buttonId))
+                            }
+                        }
                 }
-            }
 
-            val store = createStore(
-                initialState = TestState(),
-                reducer = testReducer,
-                middlewares = listOf(middleware),
-                errorProcessor = testErrorProcessor,
-                scope = storeScope,
-            )
+            val store =
+                createStore(
+                    initialState = TestState(),
+                    reducer = testReducer,
+                    middlewares = listOf(middleware),
+                    errorProcessor = testErrorProcessor,
+                    scope = storeScope,
+                )
 
             try {
                 store.state.test {
@@ -171,22 +177,25 @@ class TimingStrategyTest {
             val executedClicks = mutableListOf<String>()
             val storeScope = CoroutineScope(Dispatchers.Default + Job())
 
-            val middleware = object : Middleware<TestState, TestAction> {
-                override val processors = buildProcessors {
-                    on<TestAction.Click>(throttle(100.milliseconds)) { _, action ->
-                        executedClicks.add(action.buttonId)
-                        emit(TestAction.ClickProcessed(action.buttonId))
-                    }
+            val middleware =
+                object : Middleware<TestState, TestAction> {
+                    override val processors =
+                        buildProcessors {
+                            on<TestAction.Click>(throttle(100.milliseconds)) { _, action ->
+                                executedClicks.add(action.buttonId)
+                                emit(TestAction.ClickProcessed(action.buttonId))
+                            }
+                        }
                 }
-            }
 
-            val store = createStore(
-                initialState = TestState(),
-                reducer = testReducer,
-                middlewares = listOf(middleware),
-                errorProcessor = testErrorProcessor,
-                scope = storeScope,
-            )
+            val store =
+                createStore(
+                    initialState = TestState(),
+                    reducer = testReducer,
+                    middlewares = listOf(middleware),
+                    errorProcessor = testErrorProcessor,
+                    scope = storeScope,
+                )
 
             try {
                 store.state.test {

--- a/kotlin/remote/auth/build.gradle.kts
+++ b/kotlin/remote/auth/build.gradle.kts
@@ -13,7 +13,7 @@ mavenPublishing {
 }
 
 // JitPack only publishes JVM artifacts to avoid variant resolution issues for JVM/Android consumers
-val isJitPack = System.getenv("JITPACK") == "true"
+val isJitPack = providers.environmentVariable("JITPACK").map { it == "true" }.getOrElse(false)
 
 kotlin {
     jvm()

--- a/kotlin/remote/auth/src/commonMain/kotlin/io/flowdux/remote/auth/AuthConfig.kt
+++ b/kotlin/remote/auth/src/commonMain/kotlin/io/flowdux/remote/auth/AuthConfig.kt
@@ -12,10 +12,7 @@ import kotlin.time.Duration.Companion.seconds
  *   Used by [io.flowdux.remote.auth.server.AuthServerConnection] only; the client
  *   manages its own retry via `refreshProvider`.
  */
-data class AuthConfig(
-    val handshakeTimeout: Duration = 10.seconds,
-    val maxAuthAttempts: Int = 1,
-) {
+data class AuthConfig(val handshakeTimeout: Duration = 10.seconds, val maxAuthAttempts: Int = 1) {
     init {
         require(maxAuthAttempts >= 1) {
             "maxAuthAttempts must be at least 1, but was $maxAuthAttempts"

--- a/kotlin/remote/auth/src/commonMain/kotlin/io/flowdux/remote/auth/AuthProtocol.kt
+++ b/kotlin/remote/auth/src/commonMain/kotlin/io/flowdux/remote/auth/AuthProtocol.kt
@@ -19,7 +19,6 @@ import kotlinx.serialization.json.put
  * ```
  */
 internal object AuthProtocol {
-
     private const val TYPE_KEY = "type"
     private const val TYPE_AUTH = "auth"
     private const val TYPE_AUTH_OK = "auth_ok"
@@ -30,24 +29,21 @@ internal object AuthProtocol {
     private val json = Json { ignoreUnknownKeys = true }
 
     /** Encode a client → server auth request with the given [token]. */
-    fun encodeAuthRequest(token: String): String =
-        buildJsonObject {
-            put(TYPE_KEY, TYPE_AUTH)
-            put(TOKEN_KEY, token)
-        }.toString()
+    fun encodeAuthRequest(token: String): String = buildJsonObject {
+        put(TYPE_KEY, TYPE_AUTH)
+        put(TOKEN_KEY, token)
+    }.toString()
 
     /** Encode a server → client auth success response. */
-    fun encodeAuthSuccess(): String =
-        buildJsonObject {
-            put(TYPE_KEY, TYPE_AUTH_OK)
-        }.toString()
+    fun encodeAuthSuccess(): String = buildJsonObject {
+        put(TYPE_KEY, TYPE_AUTH_OK)
+    }.toString()
 
     /** Encode a server → client auth error response with the given [reason]. */
-    fun encodeAuthError(reason: String): String =
-        buildJsonObject {
-            put(TYPE_KEY, TYPE_AUTH_ERROR)
-            put(REASON_KEY, reason)
-        }.toString()
+    fun encodeAuthError(reason: String): String = buildJsonObject {
+        put(TYPE_KEY, TYPE_AUTH_ERROR)
+        put(REASON_KEY, reason)
+    }.toString()
 
     /** Check whether a raw message is an auth protocol message. */
     fun isAuthMessage(raw: String): Boolean {
@@ -84,5 +80,6 @@ internal object AuthProtocol {
 /** Server-side auth response parsed from wire protocol. */
 internal sealed interface AuthProtocolResponse {
     data object Success : AuthProtocolResponse
+
     data class Error(val reason: String) : AuthProtocolResponse
 }

--- a/kotlin/remote/auth/src/commonMain/kotlin/io/flowdux/remote/auth/client/ClientAuthExt.kt
+++ b/kotlin/remote/auth/src/commonMain/kotlin/io/flowdux/remote/auth/client/ClientAuthExt.kt
@@ -12,10 +12,8 @@ import io.flowdux.remote.auth.AuthConfig
  *     .typedJson<SharedAction>()
  * ```
  */
-fun ClientConnection.withAuth(
-    token: String,
-    config: AuthConfig = AuthConfig(),
-): ClientConnection = AuthClientConnection(this, { token }, config)
+fun ClientConnection.withAuth(token: String, config: AuthConfig = AuthConfig()): ClientConnection =
+    AuthClientConnection(this, { token }, config)
 
 /**
  * Add authentication to a client connection with a token provider lambda.
@@ -26,10 +24,8 @@ fun ClientConnection.withAuth(
  *     .typedJson<SharedAction>()
  * ```
  */
-fun ClientConnection.withAuth(
-    config: AuthConfig = AuthConfig(),
-    token: suspend () -> String,
-): ClientConnection = AuthClientConnection(this, token, config)
+fun ClientConnection.withAuth(config: AuthConfig = AuthConfig(), token: suspend () -> String): ClientConnection =
+    AuthClientConnection(this, token, config)
 
 /**
  * Add authentication with token refresh support.

--- a/kotlin/remote/auth/src/commonMain/kotlin/io/flowdux/remote/auth/server/AuthResult.kt
+++ b/kotlin/remote/auth/src/commonMain/kotlin/io/flowdux/remote/auth/server/AuthResult.kt
@@ -26,9 +26,7 @@ sealed interface AuthResult<out P : AuthPrincipal> {
  * // principal is guaranteed to be non-null here
  * ```
  */
-inline fun <P : AuthPrincipal> AuthResult<P>.getOrElse(
-    onFailure: (reason: String) -> Nothing,
-): P = when (this) {
+inline fun <P : AuthPrincipal> AuthResult<P>.getOrElse(onFailure: (reason: String) -> Nothing): P = when (this) {
     is AuthResult.Success -> principal
     is AuthResult.Failure -> onFailure(reason)
 }

--- a/kotlin/remote/auth/src/commonMain/kotlin/io/flowdux/remote/auth/server/AuthServerConnection.kt
+++ b/kotlin/remote/auth/src/commonMain/kotlin/io/flowdux/remote/auth/server/AuthServerConnection.kt
@@ -36,7 +36,6 @@ class AuthServerConnection<P : AuthPrincipal>(
     private val verifier: AuthVerifier<P>,
     private val config: AuthConfig = AuthConfig(),
 ) : ServerConnection {
-
     private val _principal = CompletableDeferred<P>()
     private val rawChannel = Channel<String>(Channel.UNLIMITED)
     private val messageChannel = Channel<String>(Channel.UNLIMITED)
@@ -72,75 +71,82 @@ class AuthServerConnection<P : AuthPrincipal>(
     @OptIn(ExperimentalCoroutinesApi::class)
     suspend fun awaitAuth(scope: CoroutineScope): AuthResult<P> {
         // Bridge delegate.incoming into rawChannel
-        val bridgeJob = scope.launch {
-            delegate.incoming.collect { rawChannel.send(it) }
-            rawChannel.close()
-        }
-
-        val result = try {
-            withTimeoutOrNull(config.handshakeTimeout) {
-                var lastFailure: AuthResult.Failure? = null
-
-                repeat(config.maxAuthAttempts) {
-                    val message = rawChannel.receiveCatching().getOrNull()
-                        ?: return@withTimeoutOrNull (lastFailure
-                            ?: AuthResult.Failure("Connection closed before auth"))
-
-                    if (!AuthProtocol.isAuthMessage(message)) {
-                        val reason = "Expected auth message, got: ${message.take(50)}"
-                        delegate.send(AuthProtocol.encodeAuthError(reason))
-                        return@withTimeoutOrNull AuthResult.Failure(reason)
-                    }
-
-                    val token = try {
-                        AuthProtocol.decodeAuthRequest(message)
-                    } catch (e: Exception) {
-                        val reason = "Malformed auth message: ${e.message}"
-                        delegate.send(AuthProtocol.encodeAuthError(reason))
-                        return@withTimeoutOrNull AuthResult.Failure(reason)
-                    }
-
-                    val verifyResult = try {
-                        verifier.verify(token)
-                    } catch (e: Exception) {
-                        val reason = "Verifier error: ${e.message}"
-                        delegate.send(AuthProtocol.encodeAuthError(reason))
-                        return@withTimeoutOrNull AuthResult.Failure(reason)
-                    }
-
-                    when (verifyResult) {
-                        is AuthResult.Success -> {
-                            _principal.complete(verifyResult.principal)
-                            delegate.send(AuthProtocol.encodeAuthSuccess())
-                            // Start forwarding remaining messages (filtering auth protocol)
-                            scope.launch {
-                                for (raw in rawChannel) {
-                                    if (!AuthProtocol.isAuthMessage(raw)) {
-                                        messageChannel.send(raw)
-                                    }
-                                }
-                                messageChannel.close()
-                            }
-                            return@withTimeoutOrNull verifyResult
-                        }
-
-                        is AuthResult.Failure -> {
-                            delegate.send(AuthProtocol.encodeAuthError(verifyResult.reason))
-                            lastFailure = verifyResult
-                        }
-                    }
-                }
-
-                lastFailure ?: AuthResult.Failure("Auth failed")
-            } ?: AuthResult.Failure("Auth handshake timed out")
-        } finally {
-            // On failure/timeout, clean up channels so consumers don't hang
-            if (!_principal.isCompleted) {
-                bridgeJob.cancel()
+        val bridgeJob =
+            scope.launch {
+                delegate.incoming.collect { rawChannel.send(it) }
                 rawChannel.close()
-                messageChannel.close()
             }
-        }
+
+        val result =
+            try {
+                withTimeoutOrNull(config.handshakeTimeout) {
+                    var lastFailure: AuthResult.Failure? = null
+
+                    repeat(config.maxAuthAttempts) {
+                        val message =
+                            rawChannel.receiveCatching().getOrNull()
+                                ?: return@withTimeoutOrNull (
+                                    lastFailure
+                                        ?: AuthResult.Failure("Connection closed before auth")
+                                    )
+
+                        if (!AuthProtocol.isAuthMessage(message)) {
+                            val reason = "Expected auth message, got: ${message.take(50)}"
+                            delegate.send(AuthProtocol.encodeAuthError(reason))
+                            return@withTimeoutOrNull AuthResult.Failure(reason)
+                        }
+
+                        val token =
+                            try {
+                                AuthProtocol.decodeAuthRequest(message)
+                            } catch (e: Exception) {
+                                val reason = "Malformed auth message: ${e.message}"
+                                delegate.send(AuthProtocol.encodeAuthError(reason))
+                                return@withTimeoutOrNull AuthResult.Failure(reason)
+                            }
+
+                        val verifyResult =
+                            try {
+                                verifier.verify(token)
+                            } catch (e: Exception) {
+                                val reason = "Verifier error: ${e.message}"
+                                delegate.send(AuthProtocol.encodeAuthError(reason))
+                                return@withTimeoutOrNull AuthResult.Failure(reason)
+                            }
+
+                        when (verifyResult) {
+                            is AuthResult.Success -> {
+                                _principal.complete(verifyResult.principal)
+                                delegate.send(AuthProtocol.encodeAuthSuccess())
+                                // Start forwarding remaining messages (filtering auth protocol)
+                                scope.launch {
+                                    for (raw in rawChannel) {
+                                        if (!AuthProtocol.isAuthMessage(raw)) {
+                                            messageChannel.send(raw)
+                                        }
+                                    }
+                                    messageChannel.close()
+                                }
+                                return@withTimeoutOrNull verifyResult
+                            }
+
+                            is AuthResult.Failure -> {
+                                delegate.send(AuthProtocol.encodeAuthError(verifyResult.reason))
+                                lastFailure = verifyResult
+                            }
+                        }
+                    }
+
+                    lastFailure ?: AuthResult.Failure("Auth failed")
+                } ?: AuthResult.Failure("Auth handshake timed out")
+            } finally {
+                // On failure/timeout, clean up channels so consumers don't hang
+                if (!_principal.isCompleted) {
+                    bridgeJob.cancel()
+                    rawChannel.close()
+                    messageChannel.close()
+                }
+            }
 
         return result
     }

--- a/kotlin/remote/auth/src/commonMain/kotlin/io/flowdux/remote/auth/server/AuthServerConnection.kt
+++ b/kotlin/remote/auth/src/commonMain/kotlin/io/flowdux/remote/auth/server/AuthServerConnection.kt
@@ -3,6 +3,7 @@ package io.flowdux.remote.auth.server
 import io.flowdux.remote.auth.AuthConfig
 import io.flowdux.remote.auth.AuthProtocol
 import io.flowdux.remote.server.connection.ServerConnection
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -18,24 +19,44 @@ import kotlinx.coroutines.withTimeoutOrNull
  * Call [awaitAuth] to wait for the client's auth message, verify it, and
  * start forwarding non-auth messages to [incoming].
  *
+ * Error messages sent to the client are intentionally generic ("Authentication failed")
+ * to prevent information leakage. Use [onAuthError] to receive detailed error
+ * information for server-side logging and diagnostics.
+ *
  * Usage:
  * ```kotlin
- * val authed = KtorWebSocketServerConnection(session).withAuth(jwtVerifier)
+ * val authed = KtorWebSocketServerConnection(session)
+ *     .withAuth(jwtVerifier, AuthConfig()) { detail -> logger.warn("Auth failed: $detail") }
  *
- * val principal = authed.awaitAuth(scope).getOrElse { reason ->
- *     session.close(CloseReason(CloseReason.Codes.VIOLATED_POLICY, reason))
+ * val principal = authed.awaitAuth(scope).getOrElse {
+ *     // Use a generic message for the close reason — do NOT forward
+ *     // AuthResult.Failure.reason to the client as it may contain details.
+ *     session.close(CloseReason(CloseReason.Codes.VIOLATED_POLICY, "Authentication failed"))
  *     return@webSocket
  * }
  *
  * // use authed as a normal ServerConnection
  * server.handleClient(principal.userId, authed.typedJsonAs<...>())
  * ```
+ *
+ * @param onAuthError Optional callback invoked with detailed error information when
+ *   authentication fails. Use this for server-side logging instead of relying on
+ *   client-facing error messages, which are intentionally sanitized.
  */
 class AuthServerConnection<P : AuthPrincipal>(
     private val delegate: ServerConnection,
     private val verifier: AuthVerifier<P>,
     private val config: AuthConfig = AuthConfig(),
+    private val onAuthError: ((String) -> Unit)? = null,
 ) : ServerConnection {
+
+    /** Binary-compatible constructor for code compiled against versions without [onAuthError]. */
+    constructor(
+        delegate: ServerConnection,
+        verifier: AuthVerifier<P>,
+        config: AuthConfig,
+    ) : this(delegate, verifier, config, null)
+
     private val _principal = CompletableDeferred<P>()
     private val rawChannel = Channel<String>(Channel.UNLIMITED)
     private val messageChannel = Channel<String>(Channel.UNLIMITED)
@@ -91,27 +112,29 @@ class AuthServerConnection<P : AuthPrincipal>(
                                     )
 
                         if (!AuthProtocol.isAuthMessage(message)) {
-                            val reason = "Expected auth message, got: ${message.take(50)}"
-                            delegate.send(AuthProtocol.encodeAuthError(reason))
-                            return@withTimeoutOrNull AuthResult.Failure(reason)
+                            notifyAuthError("Expected auth message, got: ${message.take(50)}")
+                            delegate.send(AuthProtocol.encodeAuthError(CLIENT_ERROR_MESSAGE))
+                            return@withTimeoutOrNull AuthResult.Failure("Expected auth message")
                         }
 
                         val token =
                             try {
                                 AuthProtocol.decodeAuthRequest(message)
                             } catch (e: Exception) {
-                                val reason = "Malformed auth message: ${e.message}"
-                                delegate.send(AuthProtocol.encodeAuthError(reason))
-                                return@withTimeoutOrNull AuthResult.Failure(reason)
+                                notifyAuthError("Malformed auth message: ${e.message}")
+                                delegate.send(AuthProtocol.encodeAuthError(CLIENT_ERROR_MESSAGE))
+                                return@withTimeoutOrNull AuthResult.Failure("Malformed auth message")
                             }
 
                         val verifyResult =
                             try {
                                 verifier.verify(token)
+                            } catch (e: CancellationException) {
+                                throw e
                             } catch (e: Exception) {
-                                val reason = "Verifier error: ${e.message}"
-                                delegate.send(AuthProtocol.encodeAuthError(reason))
-                                return@withTimeoutOrNull AuthResult.Failure(reason)
+                                notifyAuthError("Verifier error: ${e.message}")
+                                delegate.send(AuthProtocol.encodeAuthError(CLIENT_ERROR_MESSAGE))
+                                return@withTimeoutOrNull AuthResult.Failure(CLIENT_ERROR_MESSAGE)
                             }
 
                         when (verifyResult) {
@@ -131,7 +154,8 @@ class AuthServerConnection<P : AuthPrincipal>(
                             }
 
                             is AuthResult.Failure -> {
-                                delegate.send(AuthProtocol.encodeAuthError(verifyResult.reason))
+                                notifyAuthError(verifyResult.reason)
+                                delegate.send(AuthProtocol.encodeAuthError(CLIENT_ERROR_MESSAGE))
                                 lastFailure = verifyResult
                             }
                         }
@@ -149,5 +173,20 @@ class AuthServerConnection<P : AuthPrincipal>(
             }
 
         return result
+    }
+
+    /** Invoke [onAuthError] safely so a throwing callback never disrupts the auth protocol. */
+    private fun notifyAuthError(detail: String) {
+        try {
+            onAuthError?.invoke(detail)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            // Never let a logging callback abort the auth handshake
+        }
+    }
+
+    private companion object {
+        const val CLIENT_ERROR_MESSAGE = "Authentication failed"
     }
 }

--- a/kotlin/remote/auth/src/commonMain/kotlin/io/flowdux/remote/auth/server/ServerAuthExt.kt
+++ b/kotlin/remote/auth/src/commonMain/kotlin/io/flowdux/remote/auth/server/ServerAuthExt.kt
@@ -9,8 +9,8 @@ import io.flowdux.remote.server.connection.ServerConnection
  * ```kotlin
  * val authed = KtorWebSocketServerConnection(session).withAuth(jwtVerifier)
  *
- * val principal = authed.awaitAuth(scope).getOrElse { reason ->
- *     session.close(CloseReason(CloseReason.Codes.VIOLATED_POLICY, reason))
+ * val principal = authed.awaitAuth(scope).getOrElse {
+ *     session.close(CloseReason(CloseReason.Codes.VIOLATED_POLICY, "Authentication failed"))
  *     return@webSocket
  * }
  *
@@ -22,3 +22,15 @@ fun <P : AuthPrincipal> ServerConnection.withAuth(
     verifier: AuthVerifier<P>,
     config: AuthConfig = AuthConfig(),
 ): AuthServerConnection<P> = AuthServerConnection(this, verifier, config)
+
+/**
+ * Add authentication to a server connection with a verifier and an error callback.
+ *
+ * @param onAuthError Callback invoked with detailed error information when
+ *   authentication fails. Use this for server-side logging.
+ */
+fun <P : AuthPrincipal> ServerConnection.withAuth(
+    verifier: AuthVerifier<P>,
+    config: AuthConfig,
+    onAuthError: ((String) -> Unit)?,
+): AuthServerConnection<P> = AuthServerConnection(this, verifier, config, onAuthError)

--- a/kotlin/remote/auth/src/commonTest/kotlin/io/flowdux/remote/auth/AuthProtocolTest.kt
+++ b/kotlin/remote/auth/src/commonTest/kotlin/io/flowdux/remote/auth/AuthProtocolTest.kt
@@ -8,7 +8,6 @@ import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 class AuthProtocolTest {
-
     @Test
     fun encodeAuthRequest_producesValidJson() {
         val encoded = AuthProtocol.encodeAuthRequest("my-token-123")

--- a/kotlin/remote/auth/src/commonTest/kotlin/io/flowdux/remote/auth/TestFixtures.kt
+++ b/kotlin/remote/auth/src/commonTest/kotlin/io/flowdux/remote/auth/TestFixtures.kt
@@ -16,17 +16,11 @@ import kotlinx.coroutines.flow.receiveAsFlow
 
 // ── Test Principal ──
 
-data class TestPrincipal(
-    val userId: String,
-    val name: String = "Test User",
-) : AuthPrincipal
+data class TestPrincipal(val userId: String, val name: String = "Test User") : AuthPrincipal
 
 // ── Mock ClientConnection (raw string level) ──
 
-class MockClientConnection(
-    private val autoConnect: Boolean = true,
-) : ClientConnection {
-
+class MockClientConnection(private val autoConnect: Boolean = true) : ClientConnection {
     private val _connectionState = MutableStateFlow(ConnectionState.DISCONNECTED)
     override val connectionState: StateFlow<ConnectionState> = _connectionState.asStateFlow()
 
@@ -70,7 +64,6 @@ class MockClientConnection(
 // ── Mock ServerConnection (raw string level) ──
 
 class MockServerConnection : ServerConnection {
-
     override val isActive: Boolean = true
     private val incomingChannel = Channel<String>(Channel.UNLIMITED)
     override val incoming: Flow<String> = incomingChannel.receiveAsFlow()
@@ -95,14 +88,16 @@ class MockServerConnection : ServerConnection {
 // ── Test Verifiers ──
 
 /** Always-accept verifier that returns a [TestPrincipal]. */
-val acceptAllVerifier = AuthVerifier<TestPrincipal> { token ->
-    AuthResult.Success(TestPrincipal(userId = token, name = "User $token"))
-}
+val acceptAllVerifier =
+    AuthVerifier<TestPrincipal> { token ->
+        AuthResult.Success(TestPrincipal(userId = token, name = "User $token"))
+    }
 
 /** Always-reject verifier. */
-val rejectAllVerifier = AuthVerifier<TestPrincipal> { _ ->
-    AuthResult.Failure("Access denied")
-}
+val rejectAllVerifier =
+    AuthVerifier<TestPrincipal> { _ ->
+        AuthResult.Failure("Access denied")
+    }
 
 /** Verifier that accepts only a specific token. */
 fun tokenVerifier(validToken: String) = AuthVerifier<TestPrincipal> { token ->
@@ -114,6 +109,7 @@ fun tokenVerifier(validToken: String) = AuthVerifier<TestPrincipal> { token ->
 }
 
 /** Verifier that throws an exception (simulates JWT library crash). */
-val throwingVerifier = AuthVerifier<TestPrincipal> { _ ->
-    throw RuntimeException("JWT decode failed")
-}
+val throwingVerifier =
+    AuthVerifier<TestPrincipal> { _ ->
+        throw RuntimeException("JWT decode failed")
+    }

--- a/kotlin/remote/auth/src/commonTest/kotlin/io/flowdux/remote/auth/client/AuthClientConnectionTest.kt
+++ b/kotlin/remote/auth/src/commonTest/kotlin/io/flowdux/remote/auth/client/AuthClientConnectionTest.kt
@@ -14,18 +14,17 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
-import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
 
 class AuthClientConnectionTest {
-
     @Test
     fun happyPath_connectsAndAuthenticates() = runTest {
         val mock = MockClientConnection()
-        val authConn = AuthClientConnection(
-            delegate = mock,
-            tokenProvider = {"valid-token" },
-        )
+        val authConn =
+            AuthClientConnection(
+                delegate = mock,
+                tokenProvider = { "valid-token" },
+            )
 
         // Launch connect in background (it suspends for connection lifetime)
         val connectJob = launch { authConn.connect() }
@@ -48,10 +47,11 @@ class AuthClientConnectionTest {
     @Test
     fun happyPath_forwardsNonAuthMessages() = runTest {
         val mock = MockClientConnection()
-        val authConn = AuthClientConnection(
-            delegate = mock,
-            tokenProvider = {"token" },
-        )
+        val authConn =
+            AuthClientConnection(
+                delegate = mock,
+                tokenProvider = { "token" },
+            )
 
         val connectJob = launch { authConn.connect() }
 
@@ -81,17 +81,19 @@ class AuthClientConnectionTest {
     @Test
     fun authRejected_throwsAuthenticationException() = runTest {
         val mock = MockClientConnection()
-        val authConn = AuthClientConnection(
-            delegate = mock,
-            tokenProvider = {"bad-token" },
-        )
+        val authConn =
+            AuthClientConnection(
+                delegate = mock,
+                tokenProvider = { "bad-token" },
+            )
 
-        val ex = assertFailsWith<AuthenticationException> {
-            launch {
-                mock.simulateIncoming(AuthProtocol.encodeAuthError("Invalid credentials"))
+        val ex =
+            assertFailsWith<AuthenticationException> {
+                launch {
+                    mock.simulateIncoming(AuthProtocol.encodeAuthError("Invalid credentials"))
+                }
+                authConn.connect()
             }
-            authConn.connect()
-        }
 
         assertTrue(ex.message!!.contains("Authentication rejected by server"))
         assertTrue(ex.message!!.contains("Invalid credentials"))
@@ -100,15 +102,17 @@ class AuthClientConnectionTest {
     @Test
     fun timeout_throwsAuthenticationException() = runTest {
         val mock = MockClientConnection()
-        val authConn = AuthClientConnection(
-            delegate = mock,
-            tokenProvider = {"token" },
-            config = AuthConfig(handshakeTimeout = 100.milliseconds),
-        )
+        val authConn =
+            AuthClientConnection(
+                delegate = mock,
+                tokenProvider = { "token" },
+                config = AuthConfig(handshakeTimeout = 100.milliseconds),
+            )
 
-        val ex = assertFailsWith<AuthenticationException> {
-            authConn.connect()
-        }
+        val ex =
+            assertFailsWith<AuthenticationException> {
+                authConn.connect()
+            }
 
         assertEquals("Auth handshake timed out", ex.message)
     }
@@ -116,10 +120,11 @@ class AuthClientConnectionTest {
     @Test
     fun preAuthMessages_areNotForwarded() = runTest {
         val mock = MockClientConnection()
-        val authConn = AuthClientConnection(
-            delegate = mock,
-            tokenProvider = {"token" },
-        )
+        val authConn =
+            AuthClientConnection(
+                delegate = mock,
+                tokenProvider = { "token" },
+            )
 
         val connectJob = launch { authConn.connect() }
 
@@ -149,10 +154,11 @@ class AuthClientConnectionTest {
     @Test
     fun connectionState_becomesDisconnectedAfterTransportCloses() = runTest {
         val mock = MockClientConnection()
-        val authConn = AuthClientConnection(
-            delegate = mock,
-            tokenProvider = {"token" },
-        )
+        val authConn =
+            AuthClientConnection(
+                delegate = mock,
+                tokenProvider = { "token" },
+            )
 
         val connectJob = launch { authConn.connect() }
 
@@ -171,10 +177,11 @@ class AuthClientConnectionTest {
     @Test
     fun sendBeforeAuth_suspendsUntilAuthThenProceeds() = runTest {
         val mock = MockClientConnection()
-        val authConn = AuthClientConnection(
-            delegate = mock,
-            tokenProvider = {"token" },
-        )
+        val authConn =
+            AuthClientConnection(
+                delegate = mock,
+                tokenProvider = { "token" },
+            )
 
         val connectJob = launch { authConn.connect() }
 
@@ -202,10 +209,11 @@ class AuthClientConnectionTest {
     @Test
     fun authError_reasonIncludedInException() = runTest {
         val mock = MockClientConnection()
-        val authConn = AuthClientConnection(
-            delegate = mock,
-            tokenProvider = {"bad-token" },
-        )
+        val authConn =
+            AuthClientConnection(
+                delegate = mock,
+                tokenProvider = { "bad-token" },
+            )
 
         launch {
             mock.simulateIncoming(AuthProtocol.encodeAuthError("Token expired at 2025-01-01"))
@@ -218,10 +226,11 @@ class AuthClientConnectionTest {
     @Test
     fun sendAfterAuthFailure_throwsAuthenticationException() = runTest {
         val mock = MockClientConnection()
-        val authConn = AuthClientConnection(
-            delegate = mock,
-            tokenProvider = {"bad-token" },
-        )
+        val authConn =
+            AuthClientConnection(
+                delegate = mock,
+                tokenProvider = { "bad-token" },
+            )
 
         // Connect and fail auth
         launch {
@@ -241,14 +250,15 @@ class AuthClientConnectionTest {
     fun refreshOnAuthError_retriesAndSucceeds() = runTest {
         val mock = MockClientConnection()
         var refreshCalled = false
-        val authConn = AuthClientConnection(
-            delegate = mock,
-            tokenProvider = {"expired-token" },
-            refreshProvider = {
-                refreshCalled = true
-                "fresh-token"
-            },
-        )
+        val authConn =
+            AuthClientConnection(
+                delegate = mock,
+                tokenProvider = { "expired-token" },
+                refreshProvider = {
+                    refreshCalled = true
+                    "fresh-token"
+                },
+            )
 
         val connectJob = launch { authConn.connect() }
 
@@ -274,18 +284,20 @@ class AuthClientConnectionTest {
     @Test
     fun refreshReturnsNull_propagatesOriginalFailure() = runTest {
         val mock = MockClientConnection()
-        val authConn = AuthClientConnection(
-            delegate = mock,
-            tokenProvider = {"expired-token" },
-            refreshProvider = { null },
-        )
+        val authConn =
+            AuthClientConnection(
+                delegate = mock,
+                tokenProvider = { "expired-token" },
+                refreshProvider = { null },
+            )
 
-        val ex = assertFailsWith<AuthenticationException> {
-            launch {
-                mock.simulateIncoming(AuthProtocol.encodeAuthError("Token expired"))
+        val ex =
+            assertFailsWith<AuthenticationException> {
+                launch {
+                    mock.simulateIncoming(AuthProtocol.encodeAuthError("Token expired"))
+                }
+                authConn.connect()
             }
-            authConn.connect()
-        }
 
         assertTrue(ex.message!!.contains("Token expired"))
     }
@@ -293,18 +305,20 @@ class AuthClientConnectionTest {
     @Test
     fun refreshThrows_propagatesOriginalFailure() = runTest {
         val mock = MockClientConnection()
-        val authConn = AuthClientConnection(
-            delegate = mock,
-            tokenProvider = {"expired-token" },
-            refreshProvider = { throw RuntimeException("Refresh server down") },
-        )
+        val authConn =
+            AuthClientConnection(
+                delegate = mock,
+                tokenProvider = { "expired-token" },
+                refreshProvider = { throw RuntimeException("Refresh server down") },
+            )
 
-        val ex = assertFailsWith<AuthenticationException> {
-            launch {
-                mock.simulateIncoming(AuthProtocol.encodeAuthError("Token expired"))
+        val ex =
+            assertFailsWith<AuthenticationException> {
+                launch {
+                    mock.simulateIncoming(AuthProtocol.encodeAuthError("Token expired"))
+                }
+                authConn.connect()
             }
-            authConn.connect()
-        }
 
         assertTrue(ex.message!!.contains("Token expired"))
     }
@@ -312,22 +326,24 @@ class AuthClientConnectionTest {
     @Test
     fun refreshSucceedsButSecondAuthRejected_throws() = runTest {
         val mock = MockClientConnection()
-        val authConn = AuthClientConnection(
-            delegate = mock,
-            tokenProvider = {"expired-token" },
-            refreshProvider = { "also-bad-token" },
-        )
+        val authConn =
+            AuthClientConnection(
+                delegate = mock,
+                tokenProvider = { "expired-token" },
+                refreshProvider = { "also-bad-token" },
+            )
 
-        val ex = assertFailsWith<AuthenticationException> {
-            launch {
-                // First: reject initial token
-                mock.simulateIncoming(AuthProtocol.encodeAuthError("Token expired"))
-                delay(100)
-                // Second: reject refreshed token too
-                mock.simulateIncoming(AuthProtocol.encodeAuthError("Still invalid"))
+        val ex =
+            assertFailsWith<AuthenticationException> {
+                launch {
+                    // First: reject initial token
+                    mock.simulateIncoming(AuthProtocol.encodeAuthError("Token expired"))
+                    delay(100)
+                    // Second: reject refreshed token too
+                    mock.simulateIncoming(AuthProtocol.encodeAuthError("Still invalid"))
+                }
+                authConn.connect()
             }
-            authConn.connect()
-        }
 
         // Error reason should be from the second rejection
         assertTrue(ex.message!!.contains("Still invalid"))
@@ -336,11 +352,12 @@ class AuthClientConnectionTest {
     @Test
     fun refreshOnAuthError_messagesForwardedAfterRetry() = runTest {
         val mock = MockClientConnection()
-        val authConn = AuthClientConnection(
-            delegate = mock,
-            tokenProvider = {"expired-token" },
-            refreshProvider = { "fresh-token" },
-        )
+        val authConn =
+            AuthClientConnection(
+                delegate = mock,
+                tokenProvider = { "expired-token" },
+                refreshProvider = { "fresh-token" },
+            )
 
         val connectJob = launch { authConn.connect() }
 
@@ -366,21 +383,23 @@ class AuthClientConnectionTest {
     @Test
     fun refreshTimeout_propagatesOriginalFailure() = runTest {
         val mock = MockClientConnection()
-        val authConn = AuthClientConnection(
-            delegate = mock,
-            tokenProvider = {"expired-token" },
-            config = AuthConfig(handshakeTimeout = 200.milliseconds),
-            refreshProvider = { "fresh-token" },
-        )
+        val authConn =
+            AuthClientConnection(
+                delegate = mock,
+                tokenProvider = { "expired-token" },
+                config = AuthConfig(handshakeTimeout = 200.milliseconds),
+                refreshProvider = { "fresh-token" },
+            )
 
-        val ex = assertFailsWith<AuthenticationException> {
-            launch {
-                // Reject initial token
-                mock.simulateIncoming(AuthProtocol.encodeAuthError("Token expired"))
-                // Don't send any response to the retry — let it timeout
+        val ex =
+            assertFailsWith<AuthenticationException> {
+                launch {
+                    // Reject initial token
+                    mock.simulateIncoming(AuthProtocol.encodeAuthError("Token expired"))
+                    // Don't send any response to the retry — let it timeout
+                }
+                authConn.connect()
             }
-            authConn.connect()
-        }
 
         // Should fail with the original error (refresh timed out)
         assertTrue(ex.message!!.contains("Token expired"))

--- a/kotlin/remote/auth/src/commonTest/kotlin/io/flowdux/remote/auth/server/AuthResultTest.kt
+++ b/kotlin/remote/auth/src/commonTest/kotlin/io/flowdux/remote/auth/server/AuthResultTest.kt
@@ -6,7 +6,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 class AuthResultTest {
-
     @Test
     fun getOrElse_returnsPrincipalOnSuccess() {
         val principal = TestPrincipal(userId = "user-1", name = "Alice")
@@ -20,11 +19,12 @@ class AuthResultTest {
     fun getOrElse_invokesOnFailureWithReason() {
         val result: AuthResult<TestPrincipal> = AuthResult.Failure("Invalid token")
 
-        val exception = assertFailsWith<IllegalStateException> {
-            result.getOrElse { reason ->
-                throw IllegalStateException("Auth failed: $reason")
+        val exception =
+            assertFailsWith<IllegalStateException> {
+                result.getOrElse { reason ->
+                    throw IllegalStateException("Auth failed: $reason")
+                }
             }
-        }
         assertEquals("Auth failed: Invalid token", exception.message)
     }
 
@@ -39,7 +39,9 @@ class AuthResultTest {
                 capturedReason = r
                 throw RuntimeException("stop")
             }
-        } catch (_: RuntimeException) { /* expected */ }
+        } catch (_: RuntimeException) {
+            // expected
+        }
 
         assertEquals(reason, capturedReason)
     }

--- a/kotlin/remote/auth/src/commonTest/kotlin/io/flowdux/remote/auth/server/AuthServerConnectionTest.kt
+++ b/kotlin/remote/auth/src/commonTest/kotlin/io/flowdux/remote/auth/server/AuthServerConnectionTest.kt
@@ -17,14 +17,14 @@ import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
 
 class AuthServerConnectionTest {
-
     @Test
     fun happyPath_authenticatesAndForwardsMessages() = runTest {
         val mock = MockServerConnection()
-        val authConn = AuthServerConnection(
-            delegate = mock,
-            verifier = acceptAllVerifier,
-        )
+        val authConn =
+            AuthServerConnection(
+                delegate = mock,
+                verifier = acceptAllVerifier,
+            )
 
         // Send auth request from "client"
         mock.simulateIncoming(AuthProtocol.encodeAuthRequest("user-42"))
@@ -55,10 +55,11 @@ class AuthServerConnectionTest {
     @Test
     fun invalidToken_returnsFailure() = runTest {
         val mock = MockServerConnection()
-        val authConn = AuthServerConnection(
-            delegate = mock,
-            verifier = rejectAllVerifier,
-        )
+        val authConn =
+            AuthServerConnection(
+                delegate = mock,
+                verifier = rejectAllVerifier,
+            )
 
         mock.simulateIncoming(AuthProtocol.encodeAuthRequest("bad-token"))
 
@@ -76,10 +77,11 @@ class AuthServerConnectionTest {
     @Test
     fun nonAuthFirstMessage_returnsFailure() = runTest {
         val mock = MockServerConnection()
-        val authConn = AuthServerConnection(
-            delegate = mock,
-            verifier = acceptAllVerifier,
-        )
+        val authConn =
+            AuthServerConnection(
+                delegate = mock,
+                verifier = acceptAllVerifier,
+            )
 
         // Send a non-auth message as the first message
         mock.simulateIncoming("""{"type":"action","data":"oops"}""")
@@ -97,11 +99,12 @@ class AuthServerConnectionTest {
     @Test
     fun timeout_returnsFailure() = runTest {
         val mock = MockServerConnection()
-        val authConn = AuthServerConnection(
-            delegate = mock,
-            verifier = acceptAllVerifier,
-            config = AuthConfig(handshakeTimeout = 100.milliseconds),
-        )
+        val authConn =
+            AuthServerConnection(
+                delegate = mock,
+                verifier = acceptAllVerifier,
+                config = AuthConfig(handshakeTimeout = 100.milliseconds),
+            )
 
         // Don't send any message — should timeout
         val result = authConn.awaitAuth(backgroundScope)
@@ -114,10 +117,11 @@ class AuthServerConnectionTest {
     fun specificTokenVerifier_acceptsValidToken() = runTest {
         val mock = MockServerConnection()
         val verifier = tokenVerifier("secret-123")
-        val authConn = AuthServerConnection(
-            delegate = mock,
-            verifier = verifier,
-        )
+        val authConn =
+            AuthServerConnection(
+                delegate = mock,
+                verifier = verifier,
+            )
 
         mock.simulateIncoming(AuthProtocol.encodeAuthRequest("secret-123"))
         val result = authConn.awaitAuth(backgroundScope)
@@ -129,10 +133,11 @@ class AuthServerConnectionTest {
     fun specificTokenVerifier_rejectsInvalidToken() = runTest {
         val mock = MockServerConnection()
         val verifier = tokenVerifier("secret-123")
-        val authConn = AuthServerConnection(
-            delegate = mock,
-            verifier = verifier,
-        )
+        val authConn =
+            AuthServerConnection(
+                delegate = mock,
+                verifier = verifier,
+            )
 
         mock.simulateIncoming(AuthProtocol.encodeAuthRequest("wrong-token"))
         val result = authConn.awaitAuth(backgroundScope)
@@ -143,10 +148,11 @@ class AuthServerConnectionTest {
     @Test
     fun authMessages_filteredFromForwarding() = runTest {
         val mock = MockServerConnection()
-        val authConn = AuthServerConnection(
-            delegate = mock,
-            verifier = acceptAllVerifier,
-        )
+        val authConn =
+            AuthServerConnection(
+                delegate = mock,
+                verifier = acceptAllVerifier,
+            )
 
         mock.simulateIncoming(AuthProtocol.encodeAuthRequest("user-1"))
         val result = authConn.awaitAuth(backgroundScope)
@@ -168,10 +174,11 @@ class AuthServerConnectionTest {
     @Test
     fun connectionClosedBeforeAuth_returnsFailure() = runTest {
         val mock = MockServerConnection()
-        val authConn = AuthServerConnection(
-            delegate = mock,
-            verifier = acceptAllVerifier,
-        )
+        val authConn =
+            AuthServerConnection(
+                delegate = mock,
+                verifier = acceptAllVerifier,
+            )
 
         // Close the connection before sending any message
         mock.closeIncoming()
@@ -185,10 +192,11 @@ class AuthServerConnectionTest {
     @Test
     fun malformedAuthMessage_returnsFailure() = runTest {
         val mock = MockServerConnection()
-        val authConn = AuthServerConnection(
-            delegate = mock,
-            verifier = acceptAllVerifier,
-        )
+        val authConn =
+            AuthServerConnection(
+                delegate = mock,
+                verifier = acceptAllVerifier,
+            )
 
         // Send an auth message with missing token field
         mock.simulateIncoming("""{"type":"auth"}""")
@@ -205,10 +213,11 @@ class AuthServerConnectionTest {
     @Test
     fun verifierThrows_returnsFailureAndSendsAuthError() = runTest {
         val mock = MockServerConnection()
-        val authConn = AuthServerConnection(
-            delegate = mock,
-            verifier = throwingVerifier,
-        )
+        val authConn =
+            AuthServerConnection(
+                delegate = mock,
+                verifier = throwingVerifier,
+            )
 
         mock.simulateIncoming(AuthProtocol.encodeAuthRequest("any-token"))
 
@@ -225,10 +234,11 @@ class AuthServerConnectionTest {
     @Test
     fun authOkAsFirstMessage_returnsFailure() = runTest {
         val mock = MockServerConnection()
-        val authConn = AuthServerConnection(
-            delegate = mock,
-            verifier = acceptAllVerifier,
-        )
+        val authConn =
+            AuthServerConnection(
+                delegate = mock,
+                verifier = acceptAllVerifier,
+            )
 
         // Client sends auth_ok instead of auth request — unexpected auth type
         mock.simulateIncoming(AuthProtocol.encodeAuthSuccess())
@@ -246,11 +256,12 @@ class AuthServerConnectionTest {
     fun retryAuth_secondAttemptSucceeds() = runTest {
         val mock = MockServerConnection()
         val verifier = tokenVerifier("valid-token")
-        val authConn = AuthServerConnection(
-            delegate = mock,
-            verifier = verifier,
-            config = AuthConfig(maxAuthAttempts = 2),
-        )
+        val authConn =
+            AuthServerConnection(
+                delegate = mock,
+                verifier = verifier,
+                config = AuthConfig(maxAuthAttempts = 2),
+            )
 
         // First: bad token, Second: valid token
         mock.simulateIncoming(AuthProtocol.encodeAuthRequest("bad-token"))
@@ -270,11 +281,12 @@ class AuthServerConnectionTest {
     @Test
     fun retryAuth_bothAttemptsFail() = runTest {
         val mock = MockServerConnection()
-        val authConn = AuthServerConnection(
-            delegate = mock,
-            verifier = rejectAllVerifier,
-            config = AuthConfig(maxAuthAttempts = 2),
-        )
+        val authConn =
+            AuthServerConnection(
+                delegate = mock,
+                verifier = rejectAllVerifier,
+                config = AuthConfig(maxAuthAttempts = 2),
+            )
 
         mock.simulateIncoming(AuthProtocol.encodeAuthRequest("bad-1"))
         mock.simulateIncoming(AuthProtocol.encodeAuthRequest("bad-2"))
@@ -293,11 +305,12 @@ class AuthServerConnectionTest {
     fun retryAuth_messagesForwardedAfterRetrySuccess() = runTest {
         val mock = MockServerConnection()
         val verifier = tokenVerifier("valid-token")
-        val authConn = AuthServerConnection(
-            delegate = mock,
-            verifier = verifier,
-            config = AuthConfig(maxAuthAttempts = 2),
-        )
+        val authConn =
+            AuthServerConnection(
+                delegate = mock,
+                verifier = verifier,
+                config = AuthConfig(maxAuthAttempts = 2),
+            )
 
         mock.simulateIncoming(AuthProtocol.encodeAuthRequest("bad-token"))
         mock.simulateIncoming(AuthProtocol.encodeAuthRequest("valid-token"))
@@ -317,11 +330,12 @@ class AuthServerConnectionTest {
     fun defaultMaxAttempts_singleAttemptOnly() = runTest {
         val mock = MockServerConnection()
         val verifier = tokenVerifier("valid-token")
-        val authConn = AuthServerConnection(
-            delegate = mock,
-            verifier = verifier,
-            // default: maxAuthAttempts = 1
-        )
+        val authConn =
+            AuthServerConnection(
+                delegate = mock,
+                verifier = verifier,
+                // default: maxAuthAttempts = 1
+            )
 
         mock.simulateIncoming(AuthProtocol.encodeAuthRequest("bad-token"))
 

--- a/kotlin/remote/auth/src/commonTest/kotlin/io/flowdux/remote/auth/server/AuthServerConnectionTest.kt
+++ b/kotlin/remote/auth/src/commonTest/kotlin/io/flowdux/remote/auth/server/AuthServerConnectionTest.kt
@@ -12,6 +12,7 @@ import io.flowdux.remote.auth.tokenVerifier
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
@@ -68,10 +69,11 @@ class AuthServerConnectionTest {
         assertIs<AuthResult.Failure>(result)
         assertEquals("Access denied", result.reason)
 
-        // Verify auth_error was sent back
+        // Verify sanitized auth_error was sent back (no detailed reason leaked)
         assertEquals(1, mock.sentMessages.size)
         assertTrue(mock.sentMessages[0].contains("auth_error"))
-        assertTrue(mock.sentMessages[0].contains("Access denied"))
+        assertTrue(mock.sentMessages[0].contains("Authentication failed"))
+        assertFalse(mock.sentMessages[0].contains("Access denied"))
     }
 
     @Test
@@ -211,7 +213,7 @@ class AuthServerConnectionTest {
     }
 
     @Test
-    fun verifierThrows_returnsFailureAndSendsAuthError() = runTest {
+    fun verifierThrows_returnsFailureWithSanitizedMessage() = runTest {
         val mock = MockServerConnection()
         val authConn =
             AuthServerConnection(
@@ -224,11 +226,12 @@ class AuthServerConnectionTest {
         val result = authConn.awaitAuth(backgroundScope)
 
         assertIs<AuthResult.Failure>(result)
-        assertTrue(result.reason.contains("Verifier error"))
-        assertTrue(result.reason.contains("JWT decode failed"))
+        // Sanitized: no internal exception details exposed
+        assertEquals("Authentication failed", result.reason)
 
-        // Verify auth_error was sent back (not a crash)
+        // Verify sanitized auth_error was sent back (no internal details)
         assertTrue(mock.sentMessages.any { it.contains("auth_error") })
+        assertTrue(mock.sentMessages.all { !it.contains("JWT decode failed") })
     }
 
     @Test
@@ -345,5 +348,103 @@ class AuthServerConnectionTest {
         assertIs<AuthResult.Failure>(result)
         assertEquals("Invalid token", result.reason)
         assertEquals(1, mock.sentMessages.size)
+    }
+
+    // --- onAuthError callback tests ---
+
+    @Test
+    fun onAuthError_receivesDetailForVerifierException() = runTest {
+        val mock = MockServerConnection()
+        val errors = mutableListOf<String>()
+        val authConn =
+            AuthServerConnection(
+                delegate = mock,
+                verifier = throwingVerifier,
+                onAuthError = { errors.add(it) },
+            )
+
+        mock.simulateIncoming(AuthProtocol.encodeAuthRequest("any-token"))
+        authConn.awaitAuth(backgroundScope)
+
+        assertEquals(1, errors.size)
+        assertTrue(errors[0].contains("Verifier error"))
+        assertTrue(errors[0].contains("JWT decode failed"))
+    }
+
+    @Test
+    fun onAuthError_receivesDetailForNonAuthMessage() = runTest {
+        val mock = MockServerConnection()
+        val errors = mutableListOf<String>()
+        val authConn =
+            AuthServerConnection(
+                delegate = mock,
+                verifier = acceptAllVerifier,
+                onAuthError = { errors.add(it) },
+            )
+
+        mock.simulateIncoming("""{"type":"action","data":"oops"}""")
+        authConn.awaitAuth(backgroundScope)
+
+        assertEquals(1, errors.size)
+        assertTrue(errors[0].contains("Expected auth message"))
+        assertTrue(errors[0].contains("action"))
+    }
+
+    @Test
+    fun onAuthError_receivesDetailForMalformedAuth() = runTest {
+        val mock = MockServerConnection()
+        val errors = mutableListOf<String>()
+        val authConn =
+            AuthServerConnection(
+                delegate = mock,
+                verifier = acceptAllVerifier,
+                onAuthError = { errors.add(it) },
+            )
+
+        mock.simulateIncoming("""{"type":"auth"}""")
+        authConn.awaitAuth(backgroundScope)
+
+        assertEquals(1, errors.size)
+        assertTrue(errors[0].contains("Malformed auth message"))
+    }
+
+    @Test
+    fun onAuthError_receivesReasonForVerifierRejection() = runTest {
+        val mock = MockServerConnection()
+        val errors = mutableListOf<String>()
+        val authConn =
+            AuthServerConnection(
+                delegate = mock,
+                verifier = rejectAllVerifier,
+                onAuthError = { errors.add(it) },
+            )
+
+        mock.simulateIncoming(AuthProtocol.encodeAuthRequest("bad-token"))
+        authConn.awaitAuth(backgroundScope)
+
+        assertEquals(1, errors.size)
+        assertEquals("Access denied", errors[0])
+    }
+
+    @Test
+    fun wireMessages_neverContainInternalDetails() = runTest {
+        val mock = MockServerConnection()
+        val authConn =
+            AuthServerConnection(
+                delegate = mock,
+                verifier = throwingVerifier,
+            )
+
+        mock.simulateIncoming(AuthProtocol.encodeAuthRequest("any-token"))
+        authConn.awaitAuth(backgroundScope)
+
+        // Wire messages must only contain the generic error
+        for (msg in mock.sentMessages) {
+            if (msg.contains("auth_error")) {
+                assertTrue(msg.contains("Authentication failed"))
+                assertTrue(!msg.contains("JWT decode failed"))
+                assertTrue(!msg.contains("Verifier error"))
+            }
+        }
     }
 }

--- a/kotlin/remote/client/build.gradle.kts
+++ b/kotlin/remote/client/build.gradle.kts
@@ -12,7 +12,7 @@ mavenPublishing {
 }
 
 // JitPack only publishes JVM artifacts to avoid variant resolution issues for JVM/Android consumers
-val isJitPack = System.getenv("JITPACK") == "true"
+val isJitPack = providers.environmentVariable("JITPACK").map { it == "true" }.getOrElse(false)
 
 kotlin {
     jvm()

--- a/kotlin/remote/client/src/commonMain/kotlin/io/flowdux/remote/ClientConnection.kt
+++ b/kotlin/remote/client/src/commonMain/kotlin/io/flowdux/remote/ClientConnection.kt
@@ -42,8 +42,8 @@ enum class ConnectionState {
     /**
      * Attempting to re-establish a lost connection.
      *
-     * Reserved for future auto-reconnect implementations.
-     * Not currently emitted by any built-in connection class.
+     * Emitted by [ReconnectingClientConnection] when the underlying connection drops
+     * and a reconnection attempt is in progress.
      */
     RECONNECTING,
 }

--- a/kotlin/remote/client/src/commonMain/kotlin/io/flowdux/remote/ClientConnection.kt
+++ b/kotlin/remote/client/src/commonMain/kotlin/io/flowdux/remote/ClientConnection.kt
@@ -32,10 +32,13 @@ interface ClientConnection {
 enum class ConnectionState {
     /** Not connected to the server. */
     DISCONNECTED,
+
     /** Connection attempt in progress. */
     CONNECTING,
+
     /** Actively connected and ready to send/receive. */
     CONNECTED,
+
     /**
      * Attempting to re-establish a lost connection.
      *

--- a/kotlin/remote/client/src/commonMain/kotlin/io/flowdux/remote/CreateClientStore.kt
+++ b/kotlin/remote/client/src/commonMain/kotlin/io/flowdux/remote/CreateClientStore.kt
@@ -69,14 +69,15 @@ fun <S : State, A : Action> createClientStore(
     // Order: additionalMiddlewares -> syncMiddleware -> forwarder
     val allMiddlewares = additionalMiddlewares + syncMiddleware + forwarder
 
-    store = createStore(
-        initialState = initialState,
-        middlewares = allMiddlewares,
-        reducer = reducer,
-        errorProcessor = errorProcessor,
-        logger = logger,
-        scope = scope,
-        concurrency = concurrency,
-    )
+    store =
+        createStore(
+            initialState = initialState,
+            middlewares = allMiddlewares,
+            reducer = reducer,
+            errorProcessor = errorProcessor,
+            logger = logger,
+            scope = scope,
+            concurrency = concurrency,
+        )
     return store
 }

--- a/kotlin/remote/client/src/commonMain/kotlin/io/flowdux/remote/ReconnectingClientConnection.kt
+++ b/kotlin/remote/client/src/commonMain/kotlin/io/flowdux/remote/ReconnectingClientConnection.kt
@@ -1,0 +1,264 @@
+package io.flowdux.remote
+
+import io.flowdux.Action
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ClosedSendChannelException
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.supervisorScope
+import kotlin.concurrent.Volatile
+import kotlin.concurrent.atomics.AtomicBoolean
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+
+/**
+ * A [TypedClientConnection] decorator that automatically reconnects when the
+ * underlying connection drops.
+ *
+ * Each reconnection creates a **new** inner connection via [connectionFactory],
+ * supporting single-use transport implementations like [io.flowdux.remote.ktor.KtorWebSocketClientConnection].
+ *
+ * ## Usage
+ *
+ * ```kotlin
+ * val reconnecting = ReconnectingClientConnection(
+ *     connectionFactory = { DefaultTypedClientConnection(KtorWebSocketClientConnection(url), codec, messageCodec) },
+ *     config = ReconnectionConfig(maxAttempts = 10),
+ *     onEvent = { event -> logger.info("Reconnection: $event") },
+ * )
+ * val middleware = MySyncMiddleware(reconnecting, scope)
+ * ```
+ *
+ * ## Backpressure
+ *
+ * The shared [incoming] channel uses [Channel.BUFFERED]. When the buffer fills,
+ * the inner connection's forwarding coroutine suspends until the consumer collects.
+ *
+ * ## Lifecycle
+ *
+ * This connection supports multiple connect/disconnect cycles. The [incoming] channel
+ * remains open across [disconnect] calls so that [SyncMiddleware]'s reusable
+ * `ServerListenerAction` can continue collecting. Call [disconnect] to stop
+ * the reconnection loop and the current inner connection.
+ *
+ * @param connectionFactory Factory that creates a fresh [TypedClientConnection] for each
+ *        connection attempt. Must return a new instance every time.
+ * @param config Reconnection strategy configuration.
+ * @param onEvent Optional callback for reconnection lifecycle events. Exceptions thrown
+ *        by this callback are silently caught to avoid disrupting the reconnection loop.
+ */
+@OptIn(ExperimentalAtomicApi::class)
+class ReconnectingClientConnection<A : Action>(
+    private val connectionFactory: () -> TypedClientConnection<A>,
+    private val config: ReconnectionConfig = ReconnectionConfig(),
+    private val onEvent: ((ReconnectionEvent) -> Unit)? = null,
+) : TypedClientConnection<A> {
+
+    private val _connectionState = MutableStateFlow(ConnectionState.DISCONNECTED)
+    override val connectionState: StateFlow<ConnectionState> = _connectionState.asStateFlow()
+
+    private val incomingChannel = Channel<A>(Channel.BUFFERED)
+    override val incoming: Flow<A> = incomingChannel.receiveAsFlow()
+
+    @Volatile
+    private var currentConnection: TypedClientConnection<A>? = null
+
+    @Volatile
+    private var stopped = false
+
+    /**
+     * Send a typed action to the server.
+     *
+     * @throws IllegalStateException if the connection is not in [ConnectionState.CONNECTED] state.
+     */
+    override suspend fun send(action: A) {
+        check(_connectionState.value == ConnectionState.CONNECTED) { "Cannot send: not connected" }
+        val conn = currentConnection ?: error("Cannot send: not connected")
+        conn.send(action)
+    }
+
+    /**
+     * Establish the connection and automatically reconnect on failure.
+     *
+     * This method suspends until [disconnect] is called or all reconnection
+     * attempts are exhausted. The initial connection counts as attempt 0.
+     * The attempt counter resets to 0 after each successful connection,
+     * so transient failures do not accumulate across stable sessions.
+     *
+     * [disconnect] sets a stop flag that the reconnection loop checks after each
+     * backoff delay. When used via [SyncMiddleware], the coroutine running this
+     * method is also cancelled by `stopConnection()`, which immediately interrupts
+     * any in-progress backoff delay.
+     */
+    override suspend fun connect() {
+        stopped = false
+        var attempt = 0
+        var lastException: Exception? = null
+
+        while (!stopped && attempt < config.maxAttempts) {
+            if (!applyBackoff(attempt)) return
+            val result = attemptConnection(attempt)
+            when {
+                result.exception is CancellationException -> throw result.exception
+                result.exception != null -> {
+                    lastException = result.exception
+                    if (stopped) return
+                    safeOnEvent(ReconnectionEvent.AttemptFailed(attempt, config.maxAttempts, result.exception))
+                    attempt++
+                }
+                stopped -> return
+                result.wasConnected -> {
+                    attempt = 1
+                    lastException = null
+                }
+                else -> attempt++
+            }
+        }
+
+        if (!stopped && attempt >= config.maxAttempts) {
+            _connectionState.value = ConnectionState.DISCONNECTED
+            safeOnEvent(ReconnectionEvent.RetriesExhausted(config.maxAttempts, lastException))
+        }
+    }
+
+    /**
+     * Apply backoff delay for reconnection attempts.
+     *
+     * @return `false` if the loop should exit (stopped during backoff), `true` to continue.
+     */
+    private suspend fun applyBackoff(attempt: Int): Boolean {
+        if (attempt == 0) {
+            _connectionState.value = ConnectionState.CONNECTING
+        } else {
+            _connectionState.value = ConnectionState.RECONNECTING
+            val backoffDelay = config.delayForAttempt(attempt - 1)
+            safeOnEvent(ReconnectionEvent.AttemptStarted(attempt, config.maxAttempts, backoffDelay))
+            delay(backoffDelay)
+        }
+        return !stopped
+    }
+
+    /**
+     * Result of a single connection attempt.
+     *
+     * @param wasConnected Whether the connection was successfully established before it dropped.
+     * @param exception The exception that caused the attempt to fail, or `null` for clean termination.
+     */
+    private class AttemptResult(val wasConnected: Boolean, val exception: Exception?)
+
+    /**
+     * Execute a single connection attempt: create a connection, run it, and return the result.
+     */
+    private suspend fun attemptConnection(attempt: Int): AttemptResult {
+        try {
+            val conn = connectionFactory()
+            currentConnection = conn
+            if (stopped) {
+                conn.disconnect()
+                currentConnection = null
+                return AttemptResult(wasConnected = false, exception = null)
+            }
+            val wasConnected = runInnerConnection(conn, attempt)
+            currentConnection = null
+            return AttemptResult(wasConnected = wasConnected, exception = null)
+        } catch (e: CancellationException) {
+            currentConnection = null
+            return AttemptResult(wasConnected = false, exception = e)
+        } catch (e: Exception) {
+            currentConnection = null
+            return AttemptResult(wasConnected = false, exception = e)
+        }
+    }
+
+    /**
+     * Run the inner connection session within a [supervisorScope], forwarding
+     * incoming actions and monitoring state until the connection terminates.
+     *
+     * @return `true` if the connection was successfully established at some point.
+     */
+    private suspend fun runInnerConnection(conn: TypedClientConnection<A>, attempt: Int): Boolean {
+        val wasConnected = AtomicBoolean(false)
+        supervisorScope {
+            val forwardJob: Job = launch { forwardIncoming(conn) }
+            val stateJob: Job = launch { monitorState(conn, attempt, wasConnected) }
+            try {
+                conn.connect()
+            } finally {
+                stateJob.cancel()
+                forwardJob.cancel()
+            }
+        }
+        return wasConnected.load()
+    }
+
+    /** Forward incoming actions from inner connection to the shared channel. */
+    private suspend fun forwardIncoming(conn: TypedClientConnection<A>) {
+        conn.incoming.collect { action ->
+            try {
+                incomingChannel.send(action)
+            } catch (_: ClosedSendChannelException) {
+                // Channel closed — stop forwarding
+            }
+        }
+    }
+
+    /** Monitor inner connection state and propagate to the outer connection state. */
+    private suspend fun monitorState(conn: TypedClientConnection<A>, attempt: Int, wasConnected: AtomicBoolean) {
+        conn.connectionState.collect { state ->
+            if (stopped) return@collect
+            when (state) {
+                ConnectionState.CONNECTED -> {
+                    wasConnected.store(true)
+                    _connectionState.value = ConnectionState.CONNECTED
+                    safeOnEvent(ReconnectionEvent.Connected(attempt))
+                }
+                ConnectionState.CONNECTING -> {
+                    if (_connectionState.value != ConnectionState.RECONNECTING) {
+                        _connectionState.value = ConnectionState.CONNECTING
+                    }
+                }
+                ConnectionState.DISCONNECTED -> {
+                    // Will be handled when connect() returns
+                }
+                ConnectionState.RECONNECTING -> {
+                    _connectionState.value = ConnectionState.RECONNECTING
+                }
+            }
+        }
+    }
+
+    /**
+     * Stop the reconnection loop and disconnect the current inner connection.
+     *
+     * Sets a stop flag that the reconnection loop checks after each backoff
+     * delay and before each connection attempt. When used via [SyncMiddleware],
+     * `stopConnection()` also cancels the coroutine running [connect], which
+     * immediately interrupts any in-progress backoff delay.
+     *
+     * The shared [incoming] channel remains open so that this instance can be
+     * reused with a subsequent [connect] call (matching [SyncMiddleware]'s
+     * `startConnection()`/`stopConnection()` lifecycle).
+     */
+    override suspend fun disconnect() {
+        stopped = true
+        _connectionState.value = ConnectionState.DISCONNECTED
+        currentConnection?.disconnect()
+        currentConnection = null
+    }
+
+    private fun safeOnEvent(event: ReconnectionEvent) {
+        try {
+            onEvent?.invoke(event)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            // Swallow callback errors to avoid disrupting the reconnection loop.
+        }
+    }
+}

--- a/kotlin/remote/client/src/commonMain/kotlin/io/flowdux/remote/ReconnectionConfig.kt
+++ b/kotlin/remote/client/src/commonMain/kotlin/io/flowdux/remote/ReconnectionConfig.kt
@@ -1,0 +1,46 @@
+package io.flowdux.remote
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Configuration for automatic reconnection with exponential backoff.
+ *
+ * @param maxAttempts Maximum number of consecutive reconnection attempts before giving up.
+ *        Set to [Int.MAX_VALUE] for unlimited retries.
+ * @param initialDelay Delay before the first reconnection attempt.
+ * @param maxDelay Upper bound for the backoff delay. The delay never exceeds this value.
+ * @param factor Multiplier applied to the delay after each failed attempt.
+ * @param jitterFactor Random jitter factor (0.0–1.0) to avoid thundering-herd reconnections.
+ *        The actual delay is `delay * (1 - random(0, jitterFactor))`.
+ */
+data class ReconnectionConfig(
+    val maxAttempts: Int = 5,
+    val initialDelay: Duration = 1.seconds,
+    val maxDelay: Duration = 30.seconds,
+    val factor: Double = 2.0,
+    val jitterFactor: Double = 0.1,
+) {
+    init {
+        require(maxAttempts > 0) { "maxAttempts must be positive, was $maxAttempts" }
+        require(initialDelay > Duration.ZERO) { "initialDelay must be positive, was $initialDelay" }
+        require(maxDelay >= initialDelay) { "maxDelay ($maxDelay) must be >= initialDelay ($initialDelay)" }
+        require(factor >= 1.0) { "factor must be >= 1.0, was $factor" }
+        require(jitterFactor in 0.0..1.0) { "jitterFactor must be in 0.0..1.0, was $jitterFactor" }
+    }
+
+    /**
+     * Calculate the delay for the given [attempt] (0-based) with optional jitter.
+     *
+     * @return delay duration, always at least 1 millisecond to prevent tight retry loops.
+     */
+    internal fun delayForAttempt(attempt: Int, random: () -> Double = { kotlin.random.Random.nextDouble() }): Duration {
+        var delay = initialDelay
+        repeat(attempt) {
+            delay = (delay * factor).coerceAtMost(maxDelay)
+        }
+        val jitter = delay * jitterFactor * random()
+        return (delay - jitter).coerceAtLeast(1.milliseconds)
+    }
+}

--- a/kotlin/remote/client/src/commonMain/kotlin/io/flowdux/remote/ReconnectionEvent.kt
+++ b/kotlin/remote/client/src/commonMain/kotlin/io/flowdux/remote/ReconnectionEvent.kt
@@ -1,0 +1,23 @@
+package io.flowdux.remote
+
+import kotlin.time.Duration
+
+/**
+ * Events emitted during the automatic reconnection lifecycle.
+ *
+ * Subscribe to these events via the `onEvent` callback in [ReconnectingClientConnection]
+ * for logging, UI updates, or triggering state re-synchronization.
+ */
+sealed interface ReconnectionEvent {
+    /** A reconnection attempt is about to start. */
+    data class AttemptStarted(val attempt: Int, val maxAttempts: Int, val delay: Duration) : ReconnectionEvent
+
+    /** The connection was (re-)established successfully. */
+    data class Connected(val attempt: Int) : ReconnectionEvent
+
+    /** A single reconnection attempt failed. More attempts may follow. */
+    data class AttemptFailed(val attempt: Int, val maxAttempts: Int, val cause: Throwable) : ReconnectionEvent
+
+    /** All reconnection attempts have been exhausted. */
+    data class RetriesExhausted(val maxAttempts: Int, val lastCause: Throwable?) : ReconnectionEvent
+}

--- a/kotlin/remote/client/src/commonMain/kotlin/io/flowdux/remote/ServerSharedActionForwarder.kt
+++ b/kotlin/remote/client/src/commonMain/kotlin/io/flowdux/remote/ServerSharedActionForwarder.kt
@@ -23,10 +23,8 @@ import kotlinx.coroutines.flow.flowOf
  *
  * @param dispatch Function to re-dispatch actions through the full Store pipeline.
  */
-internal class ServerSharedActionForwarder<S : State, A : Action>(
-    private val dispatch: (A) -> Unit,
-) : Middleware<S, A> {
-
+internal class ServerSharedActionForwarder<S : State, A : Action>(private val dispatch: (A) -> Unit) :
+    Middleware<S, A> {
     override val processors: ActionProcessorMap<S, A> = emptyMap()
 
     override fun process(getState: () -> S, action: A): Flow<A> {

--- a/kotlin/remote/client/src/commonMain/kotlin/io/flowdux/remote/SyncMiddleware.kt
+++ b/kotlin/remote/client/src/commonMain/kotlin/io/flowdux/remote/SyncMiddleware.kt
@@ -74,7 +74,6 @@ open class SyncMiddleware<S : State, A : Action>(
     scope: CoroutineScope? = null,
     private val onConnectionError: ((Throwable) -> A)? = null,
 ) : Middleware<S, A> {
-
     private val actualScope: CoroutineScope = scope ?: CoroutineScope(SupervisorJob() + Dispatchers.Default)
     private val connectionMutex = Mutex()
     private var connectionJob: Job? = null
@@ -106,15 +105,16 @@ open class SyncMiddleware<S : State, A : Action>(
     protected suspend fun FlowCollector<A>.startConnection() {
         connectionMutex.withLock {
             connectionJob?.cancel()
-            connectionJob = actualScope.launch {
-                try {
-                    connection.connect()
-                } catch (e: CancellationException) {
-                    throw e // Propagate cancellation
-                } catch (e: Exception) {
-                    onConnectionError?.invoke(e)?.let { errorChannel.send(it) }
+            connectionJob =
+                actualScope.launch {
+                    try {
+                        connection.connect()
+                    } catch (e: CancellationException) {
+                        throw e // Propagate cancellation
+                    } catch (e: Exception) {
+                        onConnectionError?.invoke(e)?.let { errorChannel.send(it) }
+                    }
                 }
-            }
             if (!listenerEmitted) {
                 listenerEmitted = true
                 emit(ServerListenerAction() as A)

--- a/kotlin/remote/client/src/commonTest/kotlin/io/flowdux/remote/ReconnectingClientConnectionTest.kt
+++ b/kotlin/remote/client/src/commonTest/kotlin/io/flowdux/remote/ReconnectingClientConnectionTest.kt
@@ -1,0 +1,527 @@
+package io.flowdux.remote
+
+import app.cash.turbine.test
+import io.flowdux.Action
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+class ReconnectingClientConnectionTest {
+
+    // -- ReconnectionConfig tests --
+
+    @Test
+    fun configValidatesMaxAttempts() {
+        assertFailsWith<IllegalArgumentException> {
+            ReconnectionConfig(maxAttempts = 0)
+        }
+    }
+
+    @Test
+    fun configValidatesInitialDelay() {
+        assertFailsWith<IllegalArgumentException> {
+            ReconnectionConfig(initialDelay = 0.milliseconds)
+        }
+    }
+
+    @Test
+    fun configValidatesMaxDelayGreaterThanInitial() {
+        assertFailsWith<IllegalArgumentException> {
+            ReconnectionConfig(initialDelay = 10.seconds, maxDelay = 1.seconds)
+        }
+    }
+
+    @Test
+    fun configValidatesFactorMinimum() {
+        assertFailsWith<IllegalArgumentException> {
+            ReconnectionConfig(factor = 0.5)
+        }
+    }
+
+    @Test
+    fun configValidatesJitterRange() {
+        assertFailsWith<IllegalArgumentException> {
+            ReconnectionConfig(jitterFactor = 1.5)
+        }
+    }
+
+    @Test
+    fun delayForAttemptAppliesExponentialBackoff() {
+        val config = ReconnectionConfig(
+            initialDelay = 100.milliseconds,
+            maxDelay = 10.seconds,
+            factor = 2.0,
+            jitterFactor = 0.0, // no jitter for deterministic test
+        )
+        assertEquals(100.milliseconds, config.delayForAttempt(0) { 0.0 })
+        assertEquals(200.milliseconds, config.delayForAttempt(1) { 0.0 })
+        assertEquals(400.milliseconds, config.delayForAttempt(2) { 0.0 })
+        assertEquals(800.milliseconds, config.delayForAttempt(3) { 0.0 })
+    }
+
+    @Test
+    fun delayForAttemptCapsAtMaxDelay() {
+        val config = ReconnectionConfig(
+            initialDelay = 1.seconds,
+            maxDelay = 5.seconds,
+            factor = 10.0,
+            jitterFactor = 0.0,
+        )
+        // attempt 0 = 1s, attempt 1 = 10s → capped to 5s
+        assertEquals(5.seconds, config.delayForAttempt(1) { 0.0 })
+    }
+
+    @Test
+    fun delayForAttemptAppliesJitter() {
+        val config = ReconnectionConfig(
+            initialDelay = 1.seconds,
+            maxDelay = 30.seconds,
+            factor = 2.0,
+            jitterFactor = 0.5,
+        )
+        // With random = 1.0: delay = 1000 - (1000 * 0.5 * 1.0) = 500ms
+        assertEquals(500.milliseconds, config.delayForAttempt(0) { 1.0 })
+        // With random = 0.0: delay = 1000 - 0 = 1000ms (no jitter)
+        assertEquals(1.seconds, config.delayForAttempt(0) { 0.0 })
+    }
+
+    // -- ReconnectingClientConnection tests --
+
+    @Test
+    fun initialConnectionSucceeds() = runTest {
+        val events = mutableListOf<ReconnectionEvent>()
+        val innerConnection = SuspendingMockConnection<TestAction>()
+
+        val conn = ReconnectingClientConnection(
+            connectionFactory = { innerConnection },
+            config = ReconnectionConfig(maxAttempts = 3, initialDelay = 10.milliseconds),
+            onEvent = { events.add(it) },
+        )
+
+        conn.connectionState.test {
+            assertEquals(ConnectionState.DISCONNECTED, awaitItem())
+
+            val connectJob = launch { conn.connect() }
+            assertEquals(ConnectionState.CONNECTING, awaitItem())
+
+            innerConnection.completeConnect()
+            assertEquals(ConnectionState.CONNECTED, awaitItem())
+
+            conn.disconnect()
+            assertEquals(ConnectionState.DISCONNECTED, awaitItem())
+
+            connectJob.join()
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        val connected = events.filterIsInstance<ReconnectionEvent.Connected>()
+        assertEquals(1, connected.size)
+        assertEquals(0, connected[0].attempt)
+    }
+
+    @Test
+    fun reconnectsAfterConnectionDrop() = runTest {
+        val events = mutableListOf<ReconnectionEvent>()
+        var connectCount = 0
+        val connections = mutableListOf<SuspendingMockConnection<TestAction>>()
+
+        val conn = ReconnectingClientConnection(
+            connectionFactory = {
+                SuspendingMockConnection<TestAction>().also {
+                    connectCount++
+                    connections.add(it)
+                }
+            },
+            config = ReconnectionConfig(
+                maxAttempts = 3,
+                initialDelay = 10.milliseconds,
+                maxDelay = 50.milliseconds,
+                jitterFactor = 0.0,
+            ),
+            onEvent = { events.add(it) },
+        )
+
+        conn.connectionState.test {
+            assertEquals(ConnectionState.DISCONNECTED, awaitItem())
+
+            val connectJob = launch { conn.connect() }
+
+            // Initial connection
+            assertEquals(ConnectionState.CONNECTING, awaitItem())
+            connections[0].completeConnect()
+            assertEquals(ConnectionState.CONNECTED, awaitItem())
+
+            // Simulate connection drop
+            connections[0].simulateDisconnect()
+            assertEquals(ConnectionState.RECONNECTING, awaitItem())
+
+            // Wait for backoff + new connection creation
+            withTimeoutOrNull(2000) {
+                while (connections.size < 2) {
+                    delay(10)
+                }
+            }
+            assertNotNull(connections.getOrNull(1), "Second connection should be created")
+            connections[1].completeConnect()
+            assertEquals(ConnectionState.CONNECTED, awaitItem())
+
+            // Clean disconnect
+            conn.disconnect()
+            assertEquals(ConnectionState.DISCONNECTED, awaitItem())
+
+            connectJob.join()
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        assertEquals(2, connectCount)
+        assertTrue(events.any { it is ReconnectionEvent.AttemptStarted && it.attempt == 1 })
+    }
+
+    @Test
+    fun forwardsIncomingActionsAcrossReconnections() = runTest {
+        val connections = mutableListOf<SuspendingMockConnection<TestAction>>()
+
+        val conn = ReconnectingClientConnection(
+            connectionFactory = {
+                SuspendingMockConnection<TestAction>().also { connections.add(it) }
+            },
+            config = ReconnectionConfig(
+                maxAttempts = 3,
+                initialDelay = 10.milliseconds,
+                jitterFactor = 0.0,
+            ),
+        )
+
+        conn.incoming.test {
+            val connectJob = launch { conn.connect() }
+            delay(50)
+
+            // First connection
+            connections[0].completeConnect()
+            delay(50)
+            connections[0].simulateServerAction(TestAction.Add(10))
+            assertEquals(TestAction.Add(10), awaitItem())
+
+            // Drop and reconnect
+            connections[0].simulateDisconnect()
+            // Wait for backoff + new connection creation
+            withTimeoutOrNull(2000) {
+                while (connections.size < 2) {
+                    delay(10)
+                }
+            }
+            assertNotNull(connections.getOrNull(1), "Second connection should be created")
+            connections[1].completeConnect()
+            delay(50)
+
+            // Actions from new connection should still arrive
+            connections[1].simulateServerAction(TestAction.Add(20))
+            assertEquals(TestAction.Add(20), awaitItem())
+
+            conn.disconnect()
+            connectJob.join()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun retriesExhaustedWhenAllAttemptsFail() = runTest {
+        val events = mutableListOf<ReconnectionEvent>()
+        var connectCount = 0
+
+        val conn = ReconnectingClientConnection(
+            connectionFactory = {
+                connectCount++
+                FailingMockConnection(TestConnectionException("fail $connectCount"))
+            },
+            config = ReconnectionConfig(
+                maxAttempts = 3,
+                initialDelay = 10.milliseconds,
+                maxDelay = 50.milliseconds,
+                jitterFactor = 0.0,
+            ),
+            onEvent = { events.add(it) },
+        )
+
+        conn.connect()
+
+        assertEquals(3, connectCount)
+        assertEquals(ConnectionState.DISCONNECTED, conn.connectionState.value)
+        val exhausted = events.filterIsInstance<ReconnectionEvent.RetriesExhausted>()
+        assertEquals(1, exhausted.size)
+        assertNotNull(exhausted[0].lastCause, "lastCause should contain the last failure")
+        assertEquals(3, events.filterIsInstance<ReconnectionEvent.AttemptFailed>().size)
+    }
+
+    @Test
+    fun disconnectStopsReconnectionLoop() = runTest {
+        val events = mutableListOf<ReconnectionEvent>()
+        val connections = mutableListOf<SuspendingMockConnection<TestAction>>()
+
+        val conn = ReconnectingClientConnection(
+            connectionFactory = {
+                SuspendingMockConnection<TestAction>().also { connections.add(it) }
+            },
+            config = ReconnectionConfig(
+                maxAttempts = 10,
+                initialDelay = 10.milliseconds,
+                jitterFactor = 0.0,
+            ),
+            onEvent = { events.add(it) },
+        )
+
+        val connectJob = launch { conn.connect() }
+
+        // Connect and verify
+        delay(50)
+        connections[0].completeConnect()
+        delay(50)
+        assertEquals(ConnectionState.CONNECTED, conn.connectionState.value)
+
+        // Disconnect mid-connection
+        conn.disconnect()
+        connectJob.join()
+
+        assertEquals(ConnectionState.DISCONNECTED, conn.connectionState.value)
+        // Should NOT have exhausted retries
+        assertTrue(events.none { it is ReconnectionEvent.RetriesExhausted })
+    }
+
+    @Test
+    fun sendDelegatestoCurrentConnection() = runTest {
+        val connections = mutableListOf<SuspendingMockConnection<TestAction>>()
+
+        val conn = ReconnectingClientConnection(
+            connectionFactory = {
+                SuspendingMockConnection<TestAction>().also { connections.add(it) }
+            },
+            config = ReconnectionConfig(maxAttempts = 3, initialDelay = 10.milliseconds),
+        )
+
+        val connectJob = launch { conn.connect() }
+
+        delay(50)
+        connections[0].completeConnect()
+        delay(50)
+
+        conn.send(TestAction.Add(42))
+        assertEquals(1, connections[0].sentActions.size)
+        assertEquals(TestAction.Add(42), connections[0].sentActions[0])
+
+        conn.disconnect()
+        connectJob.join()
+    }
+
+    @Test
+    fun sendThrowsWhenNotConnected() = runTest {
+        val conn = ReconnectingClientConnection<TestAction>(
+            connectionFactory = { SuspendingMockConnection() },
+            config = ReconnectionConfig(maxAttempts = 3, initialDelay = 10.milliseconds),
+        )
+
+        assertFailsWith<IllegalStateException> {
+            conn.send(TestAction.Add(1))
+        }
+    }
+
+    @Test
+    fun eventCallbackExceptionsAreSwallowed() = runTest {
+        val conn = ReconnectingClientConnection(
+            connectionFactory = { FailingMockConnection<TestAction>(TestConnectionException("fail")) },
+            config = ReconnectionConfig(
+                maxAttempts = 2,
+                initialDelay = 10.milliseconds,
+                jitterFactor = 0.0,
+            ),
+            onEvent = { throw TestConnectionException("callback error") },
+        )
+
+        // Should not throw despite callback errors
+        conn.connect()
+        assertEquals(ConnectionState.DISCONNECTED, conn.connectionState.value)
+    }
+
+    @Test
+    fun firstConnectionFailureTriggersReconnect() = runTest {
+        val events = mutableListOf<ReconnectionEvent>()
+        var callCount = 0
+        val connections = mutableListOf<SuspendingMockConnection<TestAction>>()
+
+        val conn = ReconnectingClientConnection(
+            connectionFactory = {
+                callCount++
+                if (callCount == 1) {
+                    FailingMockConnection(TestConnectionException("initial failure"))
+                } else {
+                    SuspendingMockConnection<TestAction>().also { connections.add(it) }
+                }
+            },
+            config = ReconnectionConfig(
+                maxAttempts = 3,
+                initialDelay = 10.milliseconds,
+                jitterFactor = 0.0,
+            ),
+            onEvent = { events.add(it) },
+        )
+
+        val connectJob = launch { conn.connect() }
+
+        // Wait for first failure + backoff + second connection
+        delay(100)
+        assertNotNull(connections.firstOrNull(), "Second connection should have been created")
+        connections[0].completeConnect()
+        delay(50)
+
+        assertEquals(ConnectionState.CONNECTED, conn.connectionState.value)
+        assertTrue(events.any { it is ReconnectionEvent.AttemptFailed && it.attempt == 0 })
+        assertTrue(events.any { it is ReconnectionEvent.Connected && it.attempt == 1 })
+
+        conn.disconnect()
+        connectJob.join()
+    }
+
+    @Test
+    fun resetAttemptsAfterSuccessfulConnection() = runTest {
+        val events = mutableListOf<ReconnectionEvent>()
+        val connections = mutableListOf<SuspendingMockConnection<TestAction>>()
+
+        val conn = ReconnectingClientConnection(
+            connectionFactory = {
+                SuspendingMockConnection<TestAction>().also { connections.add(it) }
+            },
+            config = ReconnectionConfig(
+                maxAttempts = 2,
+                initialDelay = 10.milliseconds,
+                jitterFactor = 0.0,
+            ),
+            onEvent = { events.add(it) },
+        )
+
+        val connectJob = launch { conn.connect() }
+
+        // First connection succeeds
+        delay(50)
+        connections[0].completeConnect()
+        delay(50)
+        assertEquals(ConnectionState.CONNECTED, conn.connectionState.value)
+
+        // Drop connection — attempt counter resets to 1 after successful connection
+        connections[0].simulateDisconnect()
+        withTimeoutOrNull(2000) {
+            while (connections.size < 2) {
+                delay(10)
+            }
+        }
+        assertNotNull(connections.getOrNull(1), "Second connection should be created")
+        connections[1].completeConnect()
+        delay(50)
+        assertEquals(ConnectionState.CONNECTED, conn.connectionState.value)
+
+        // Drop again — attempt counter resets again since connection was successful
+        // Without reset, maxAttempts=2 would be exhausted here
+        connections[1].simulateDisconnect()
+        withTimeoutOrNull(2000) {
+            while (connections.size < 3) {
+                delay(10)
+            }
+        }
+        assertNotNull(connections.getOrNull(2), "Third connection should be created (attempt reset)")
+        connections[2].completeConnect()
+        delay(50)
+        assertEquals(ConnectionState.CONNECTED, conn.connectionState.value)
+
+        conn.disconnect()
+        connectJob.join()
+
+        // Should NOT have exhausted retries since counter resets each time
+        assertTrue(events.none { it is ReconnectionEvent.RetriesExhausted })
+        assertEquals(3, connections.size)
+    }
+
+    // -- Test helpers --
+
+    /** Specific exception for test assertions instead of generic RuntimeException. */
+    private class TestConnectionException(message: String) : Exception(message)
+
+    /**
+     * Mock connection that suspends in [connect] until explicitly completed.
+     * Supports simulating connection drops and server actions.
+     */
+    private class SuspendingMockConnection<A : Action> : TypedClientConnection<A> {
+        private val _connectionState = MutableStateFlow(ConnectionState.DISCONNECTED)
+        override val connectionState: StateFlow<ConnectionState> = _connectionState.asStateFlow()
+
+        private val incomingChannel = Channel<A>(Channel.BUFFERED)
+        override val incoming: Flow<A> = incomingChannel.receiveAsFlow()
+
+        val sentActions = mutableListOf<A>()
+
+        private val connectSignal = CompletableDeferred<Unit>()
+        private val disconnectSignal = CompletableDeferred<Unit>()
+
+        override suspend fun send(action: A) {
+            sentActions.add(action)
+        }
+
+        override suspend fun connect() {
+            _connectionState.value = ConnectionState.CONNECTING
+            connectSignal.await()
+            _connectionState.value = ConnectionState.CONNECTED
+            try {
+                disconnectSignal.await()
+            } finally {
+                _connectionState.value = ConnectionState.DISCONNECTED
+            }
+        }
+
+        override suspend fun disconnect() {
+            _connectionState.value = ConnectionState.DISCONNECTED
+            disconnectSignal.complete(Unit)
+        }
+
+        fun completeConnect() {
+            connectSignal.complete(Unit)
+        }
+
+        fun simulateDisconnect() {
+            disconnectSignal.complete(Unit)
+        }
+
+        suspend fun simulateServerAction(action: A) {
+            incomingChannel.send(action)
+        }
+    }
+
+    /**
+     * Mock connection that always throws from [connect].
+     */
+    private class FailingMockConnection<A : Action>(private val exception: Exception) : TypedClientConnection<A> {
+        private val _connectionState = MutableStateFlow(ConnectionState.DISCONNECTED)
+        override val connectionState: StateFlow<ConnectionState> = _connectionState.asStateFlow()
+
+        override val incoming: Flow<A> = Channel<A>().receiveAsFlow()
+
+        override suspend fun send(action: A): Unit = error("Not connected")
+
+        override suspend fun connect(): Unit = throw exception
+
+        override suspend fun disconnect() {
+            _connectionState.value = ConnectionState.DISCONNECTED
+        }
+    }
+}

--- a/kotlin/remote/client/src/commonTest/kotlin/io/flowdux/remote/ServerSharedActionForwarderTest.kt
+++ b/kotlin/remote/client/src/commonTest/kotlin/io/flowdux/remote/ServerSharedActionForwarderTest.kt
@@ -10,22 +10,23 @@ import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ServerSharedActionForwarderTest {
-
     @Test
     fun serverSharedAction_emitted_from_processor_is_automatically_sent_to_server() = runTest {
         val connection = MockTypedClientConnection<TestAction>()
-        val middleware = EmitServerActionTestMiddleware(
-            connection = connection,
-            scope = backgroundScope,
-        )
+        val middleware =
+            EmitServerActionTestMiddleware(
+                connection = connection,
+                scope = backgroundScope,
+            )
 
-        val store = createClientStore(
-            initialState = TestState(),
-            syncMiddleware = middleware,
-            reducer = testReducer,
-            errorProcessor = testErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createClientStore(
+                initialState = TestState(),
+                syncMiddleware = middleware,
+                reducer = testReducer,
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             assertEquals(TestState(), awaitItem()) // initial state
@@ -54,18 +55,20 @@ class ServerSharedActionForwarderTest {
     @Test
     fun non_serverSharedAction_emitted_from_processor_passes_through_normally() = runTest {
         val connection = MockTypedClientConnection<TestAction>()
-        val middleware = EmitServerActionTestMiddleware(
-            connection = connection,
-            scope = backgroundScope,
-        )
+        val middleware =
+            EmitServerActionTestMiddleware(
+                connection = connection,
+                scope = backgroundScope,
+            )
 
-        val store = createClientStore(
-            initialState = TestState(),
-            syncMiddleware = middleware,
-            reducer = testReducer,
-            errorProcessor = testErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createClientStore(
+                initialState = TestState(),
+                syncMiddleware = middleware,
+                reducer = testReducer,
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             assertEquals(TestState(), awaitItem()) // initial state
@@ -87,18 +90,20 @@ class ServerSharedActionForwarderTest {
     @Test
     fun clientSharedAction_from_server_is_not_re_dispatched_prevents_infinite_loop() = runTest {
         val connection = MockTypedClientConnection<TestAction>()
-        val middleware = TestSyncMiddleware(
-            connection = connection,
-            scope = backgroundScope,
-        )
+        val middleware =
+            TestSyncMiddleware(
+                connection = connection,
+                scope = backgroundScope,
+            )
 
-        val store = createClientStore(
-            initialState = TestState(),
-            syncMiddleware = middleware,
-            reducer = testReducer,
-            errorProcessor = testErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createClientStore(
+                initialState = TestState(),
+                syncMiddleware = middleware,
+                reducer = testReducer,
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             assertEquals(TestState(), awaitItem()) // initial state
@@ -124,27 +129,30 @@ class ServerSharedActionForwarderTest {
         val connection = MockTypedClientConnection<TestAction>()
 
         // Custom middleware that emits multiple ServerSharedActions
-        val middleware = object : SyncMiddleware<TestState, TestAction>(
-            connection = connection,
-            scope = backgroundScope,
-        ) {
-            override val processors = buildProcessors {
-                on<TestAction.Connect> { _, _ -> startConnection() }
-                on<TestAction.TriggerEmitServerAction> { _, action ->
-                    emit(TestAction.ServerAdd(action.value))
-                    emit(TestAction.ServerSetMessage("test"))
-                    emit(TestAction.Add(1)) // local
-                }
+        val middleware =
+            object : SyncMiddleware<TestState, TestAction>(
+                connection = connection,
+                scope = backgroundScope,
+            ) {
+                override val processors =
+                    buildProcessors {
+                        on<TestAction.Connect> { _, _ -> startConnection() }
+                        on<TestAction.TriggerEmitServerAction> { _, action ->
+                            emit(TestAction.ServerAdd(action.value))
+                            emit(TestAction.ServerSetMessage("test"))
+                            emit(TestAction.Add(1)) // local
+                        }
+                    }
             }
-        }
 
-        val store = createClientStore(
-            initialState = TestState(),
-            syncMiddleware = middleware,
-            reducer = testReducer,
-            errorProcessor = testErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createClientStore(
+                initialState = TestState(),
+                syncMiddleware = middleware,
+                reducer = testReducer,
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             assertEquals(TestState(), awaitItem())

--- a/kotlin/remote/client/src/commonTest/kotlin/io/flowdux/remote/SyncMiddlewareTest.kt
+++ b/kotlin/remote/client/src/commonTest/kotlin/io/flowdux/remote/SyncMiddlewareTest.kt
@@ -13,30 +13,31 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
-import kotlin.test.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class SyncMiddlewareTest {
-
     @Test
     fun `ServerSharedAction is intercepted and sent to server`() = runTest {
         val connection = MockTypedClientConnection<TestAction>()
-        val middleware = TestSyncMiddleware(
-            connection = connection,
-            scope = backgroundScope,
-        )
+        val middleware =
+            TestSyncMiddleware(
+                connection = connection,
+                scope = backgroundScope,
+            )
 
-        val store = createStore(
-            initialState = TestState(),
-            reducer = testReducer,
-            middlewares = listOf(middleware),
-            errorProcessor = testErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = TestState(),
+                reducer = testReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             assertEquals(TestState(), awaitItem()) // initial state
@@ -62,18 +63,20 @@ class SyncMiddlewareTest {
     @Test
     fun `non-ServerSharedAction passes through to local reducer`() = runTest {
         val connection = MockTypedClientConnection<TestAction>()
-        val middleware = TestSyncMiddleware(
-            connection = connection,
-            scope = backgroundScope,
-        )
+        val middleware =
+            TestSyncMiddleware(
+                connection = connection,
+                scope = backgroundScope,
+            )
 
-        val store = createStore(
-            initialState = TestState(),
-            reducer = testReducer,
-            middlewares = listOf(middleware),
-            errorProcessor = testErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = TestState(),
+                reducer = testReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             assertEquals(TestState(), awaitItem())
@@ -97,18 +100,20 @@ class SyncMiddlewareTest {
     @Test
     fun `server response actions are dispatched to local store`() = runTest {
         val connection = MockTypedClientConnection<TestAction>()
-        val middleware = TestSyncMiddleware(
-            connection = connection,
-            scope = backgroundScope,
-        )
+        val middleware =
+            TestSyncMiddleware(
+                connection = connection,
+                scope = backgroundScope,
+            )
 
-        val store = createStore(
-            initialState = TestState(),
-            reducer = testReducer,
-            middlewares = listOf(middleware),
-            errorProcessor = testErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = TestState(),
+                reducer = testReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             assertEquals(TestState(), awaitItem())
@@ -128,18 +133,20 @@ class SyncMiddlewareTest {
     @Test
     fun `non-ServerSharedAction server responses pass through without being sent to server`() = runTest {
         val connection = MockTypedClientConnection<TestAction>()
-        val middleware = TestSyncMiddleware(
-            connection = connection,
-            scope = backgroundScope,
-        )
+        val middleware =
+            TestSyncMiddleware(
+                connection = connection,
+                scope = backgroundScope,
+            )
 
-        val store = createStore(
-            initialState = TestState(),
-            reducer = testReducer,
-            middlewares = listOf(middleware),
-            errorProcessor = testErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = TestState(),
+                reducer = testReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             assertEquals(TestState(), awaitItem())
@@ -162,18 +169,20 @@ class SyncMiddlewareTest {
     @Test
     fun `multiple server response actions are all dispatched`() = runTest {
         val connection = MockTypedClientConnection<TestAction>()
-        val middleware = TestSyncMiddleware(
-            connection = connection,
-            scope = backgroundScope,
-        )
+        val middleware =
+            TestSyncMiddleware(
+                connection = connection,
+                scope = backgroundScope,
+            )
 
-        val store = createStore(
-            initialState = TestState(),
-            reducer = testReducer,
-            middlewares = listOf(middleware),
-            errorProcessor = testErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = TestState(),
+                reducer = testReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             assertEquals(TestState(), awaitItem())
@@ -205,18 +214,20 @@ class SyncMiddlewareTest {
         val cancellationSignal = CompletableDeferred<Boolean>()
         val connection = CancellationTrackingMockConnection<TestAction>(cancellationSignal)
 
-        val middleware = TestSyncMiddleware(
-            connection = connection,
-            scope = backgroundScope,
-        )
+        val middleware =
+            TestSyncMiddleware(
+                connection = connection,
+                scope = backgroundScope,
+            )
 
-        val store = createStore(
-            initialState = TestState(),
-            reducer = testReducer,
-            middlewares = listOf(middleware),
-            errorProcessor = testErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = TestState(),
+                reducer = testReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             assertEquals(TestState(), awaitItem())
@@ -232,9 +243,10 @@ class SyncMiddlewareTest {
             store.dispatch(TestAction.Disconnect)
 
             // Wait for cancellation signal
-            val wasCancelled = withTimeoutOrNull(1000) {
-                cancellationSignal.await()
-            }
+            val wasCancelled =
+                withTimeoutOrNull(1000) {
+                    cancellationSignal.await()
+                }
 
             assertNotNull(wasCancelled, "Connection job should be cancelled on disconnect")
             assertTrue(wasCancelled, "Connection job coroutine should have been cancelled")
@@ -246,18 +258,20 @@ class SyncMiddlewareTest {
     @Test
     fun `reconnect works after disconnect`() = runTest {
         val connection = MockTypedClientConnection<TestAction>()
-        val middleware = TestSyncMiddleware(
-            connection = connection,
-            scope = backgroundScope,
-        )
+        val middleware =
+            TestSyncMiddleware(
+                connection = connection,
+                scope = backgroundScope,
+            )
 
-        val store = createStore(
-            initialState = TestState(),
-            reducer = testReducer,
-            middlewares = listOf(middleware),
-            errorProcessor = testErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = TestState(),
+                reducer = testReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             assertEquals(TestState(), awaitItem())
@@ -299,22 +313,25 @@ class SyncMiddlewareTest {
 
     @Test
     fun `onConnectionError callback dispatches error action when connection fails`() = runTest {
-        val connection = MockTypedClientConnection<TestAction>(
-            connectException = RuntimeException("Connection failed"),
-        )
-        val middleware = TestSyncMiddleware(
-            connection = connection,
-            scope = backgroundScope,
-            onConnectionError = { e -> TestAction.ConnectionError(e.message ?: "Unknown error") },
-        )
+        val connection =
+            MockTypedClientConnection<TestAction>(
+                connectException = RuntimeException("Connection failed"),
+            )
+        val middleware =
+            TestSyncMiddleware(
+                connection = connection,
+                scope = backgroundScope,
+                onConnectionError = { e -> TestAction.ConnectionError(e.message ?: "Unknown error") },
+            )
 
-        val store = createStore(
-            initialState = TestState(),
-            reducer = testReducer,
-            middlewares = listOf(middleware),
-            errorProcessor = testErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = TestState(),
+                reducer = testReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             assertEquals(TestState(), awaitItem()) // initial state
@@ -331,22 +348,25 @@ class SyncMiddlewareTest {
 
     @Test
     fun `connection error without callback is silently ignored`() = runTest {
-        val connection = MockTypedClientConnection<TestAction>(
-            connectException = RuntimeException("Connection failed"),
-        )
-        val middleware = TestSyncMiddleware(
-            connection = connection,
-            scope = backgroundScope,
-            // No onConnectionError callback
-        )
+        val connection =
+            MockTypedClientConnection<TestAction>(
+                connectException = RuntimeException("Connection failed"),
+            )
+        val middleware =
+            TestSyncMiddleware(
+                connection = connection,
+                scope = backgroundScope,
+                // No onConnectionError callback
+            )
 
-        val store = createStore(
-            initialState = TestState(),
-            reducer = testReducer,
-            middlewares = listOf(middleware),
-            errorProcessor = testErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = TestState(),
+                reducer = testReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             assertEquals(TestState(), awaitItem()) // initial state
@@ -364,52 +384,55 @@ class SyncMiddlewareTest {
     @Test
     fun `reconnect after connection failure works`() = runTest {
         var shouldFail = true
-        val connection = object : TypedClientConnection<TestAction> {
-            private val _connectionState = MutableStateFlow(ConnectionState.DISCONNECTED)
-            override val connectionState = _connectionState.asStateFlow()
+        val connection =
+            object : TypedClientConnection<TestAction> {
+                private val _connectionState = MutableStateFlow(ConnectionState.DISCONNECTED)
+                override val connectionState = _connectionState.asStateFlow()
 
-            private val incomingChannel = Channel<TestAction>(Channel.BUFFERED)
-            override val incoming = incomingChannel.receiveAsFlow()
+                private val incomingChannel = Channel<TestAction>(Channel.BUFFERED)
+                override val incoming = incomingChannel.receiveAsFlow()
 
-            val sentActions = mutableListOf<TestAction>()
+                val sentActions = mutableListOf<TestAction>()
 
-            override suspend fun send(action: TestAction) {
-                sentActions.add(action)
-            }
-
-            override suspend fun connect() {
-                if (shouldFail) {
-                    throw RuntimeException("Connection failed")
+                override suspend fun send(action: TestAction) {
+                    sentActions.add(action)
                 }
-                _connectionState.value = ConnectionState.CONNECTED
-            }
 
-            override suspend fun disconnect() {
-                _connectionState.value = ConnectionState.DISCONNECTED
-            }
+                override suspend fun connect() {
+                    if (shouldFail) {
+                        throw RuntimeException("Connection failed")
+                    }
+                    _connectionState.value = ConnectionState.CONNECTED
+                }
 
-            suspend fun simulateServerAction(action: TestAction) {
-                incomingChannel.send(action)
+                override suspend fun disconnect() {
+                    _connectionState.value = ConnectionState.DISCONNECTED
+                }
+
+                suspend fun simulateServerAction(action: TestAction) {
+                    incomingChannel.send(action)
+                }
             }
-        }
 
         val errorActions = mutableListOf<String>()
-        val middleware = TestSyncMiddleware(
-            connection = connection,
-            scope = backgroundScope,
-            onConnectionError = { e ->
-                errorActions.add(e.message ?: "Unknown")
-                TestAction.ConnectionError(e.message ?: "Unknown error")
-            },
-        )
+        val middleware =
+            TestSyncMiddleware(
+                connection = connection,
+                scope = backgroundScope,
+                onConnectionError = { e ->
+                    errorActions.add(e.message ?: "Unknown")
+                    TestAction.ConnectionError(e.message ?: "Unknown error")
+                },
+            )
 
-        val store = createStore(
-            initialState = TestState(),
-            reducer = testReducer,
-            middlewares = listOf(middleware),
-            errorProcessor = testErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = TestState(),
+                reducer = testReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             assertEquals(TestState(), awaitItem())
@@ -442,46 +465,49 @@ class SyncMiddlewareTest {
         val errorCallbackInvoked = CompletableDeferred<Boolean>()
         val cancellationSignal = CompletableDeferred<Boolean>()
 
-        val connection = object : TypedClientConnection<TestAction> {
-            private val _connectionState = MutableStateFlow(ConnectionState.DISCONNECTED)
-            override val connectionState = _connectionState.asStateFlow()
+        val connection =
+            object : TypedClientConnection<TestAction> {
+                private val _connectionState = MutableStateFlow(ConnectionState.DISCONNECTED)
+                override val connectionState = _connectionState.asStateFlow()
 
-            private val incomingChannel = Channel<TestAction>(Channel.BUFFERED)
-            override val incoming = incomingChannel.receiveAsFlow()
+                private val incomingChannel = Channel<TestAction>(Channel.BUFFERED)
+                override val incoming = incomingChannel.receiveAsFlow()
 
-            override suspend fun send(action: TestAction) {}
+                override suspend fun send(action: TestAction) {}
 
-            override suspend fun connect() {
-                _connectionState.value = ConnectionState.CONNECTED
-                try {
-                    awaitCancellation()
-                } catch (e: CancellationException) {
-                    cancellationSignal.complete(true)
-                    throw e
+                override suspend fun connect() {
+                    _connectionState.value = ConnectionState.CONNECTED
+                    try {
+                        awaitCancellation()
+                    } catch (e: CancellationException) {
+                        cancellationSignal.complete(true)
+                        throw e
+                    }
+                }
+
+                override suspend fun disconnect() {
+                    _connectionState.value = ConnectionState.DISCONNECTED
                 }
             }
 
-            override suspend fun disconnect() {
-                _connectionState.value = ConnectionState.DISCONNECTED
-            }
-        }
+        val middleware =
+            TestSyncMiddleware(
+                connection = connection,
+                scope = backgroundScope,
+                onConnectionError = { _ ->
+                    errorCallbackInvoked.complete(true)
+                    TestAction.ConnectionError("Should not be called")
+                },
+            )
 
-        val middleware = TestSyncMiddleware(
-            connection = connection,
-            scope = backgroundScope,
-            onConnectionError = { _ ->
-                errorCallbackInvoked.complete(true)
-                TestAction.ConnectionError("Should not be called")
-            },
-        )
-
-        val store = createStore(
-            initialState = TestState(),
-            reducer = testReducer,
-            middlewares = listOf(middleware),
-            errorProcessor = testErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = TestState(),
+                reducer = testReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             assertEquals(TestState(), awaitItem())
@@ -502,7 +528,10 @@ class SyncMiddlewareTest {
             delay(200)
 
             // Error callback should NOT have been invoked for CancellationException
-            assertFalse(errorCallbackInvoked.isCompleted, "onConnectionError should not be called for CancellationException")
+            assertFalse(
+                errorCallbackInvoked.isCompleted,
+                "onConnectionError should not be called for CancellationException",
+            )
 
             // No error action should be dispatched
             expectNoEvents()
@@ -514,18 +543,20 @@ class SyncMiddlewareTest {
     @Test
     fun `rapid connect disconnect connect sequence works correctly`() = runTest {
         val connection = MockTypedClientConnection<TestAction>()
-        val middleware = TestSyncMiddleware(
-            connection = connection,
-            scope = backgroundScope,
-        )
+        val middleware =
+            TestSyncMiddleware(
+                connection = connection,
+                scope = backgroundScope,
+            )
 
-        val store = createStore(
-            initialState = TestState(),
-            reducer = testReducer,
-            middlewares = listOf(middleware),
-            errorProcessor = testErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = TestState(),
+                reducer = testReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             assertEquals(TestState(), awaitItem())
@@ -546,5 +577,4 @@ class SyncMiddlewareTest {
             cancelAndIgnoreRemainingEvents()
         }
     }
-
 }

--- a/kotlin/remote/client/src/commonTest/kotlin/io/flowdux/remote/TestFixtures.kt
+++ b/kotlin/remote/client/src/commonTest/kotlin/io/flowdux/remote/TestFixtures.kt
@@ -23,35 +23,48 @@ data class TestState(val count: Int = 0, val message: String = "") : State
 
 sealed interface TestAction : Action {
     data class Add(val value: Int) : TestAction
+
     data class SetMessage(val message: String) : TestAction
-    data class ServerAdd(val value: Int) : TestAction, ServerSharedAction
-    data class ServerSetMessage(val message: String) : TestAction, ServerSharedAction
+
+    data class ServerAdd(val value: Int) :
+        TestAction,
+        ServerSharedAction
+
+    data class ServerSetMessage(val message: String) :
+        TestAction,
+        ServerSharedAction
+
     data class ConnectionError(val message: String) : TestAction
+
     object LocalIncrement : TestAction
+
     object Connect : TestAction
+
     object Disconnect : TestAction
 
     /** Triggers emit(ServerSharedAction) to test auto-dispatch */
     data class TriggerEmitServerAction(val value: Int) : TestAction
 }
 
-val testReducer = Reducer<TestState, TestAction> { state, action ->
-    when (action) {
-        is TestAction.Add -> state.copy(count = state.count + action.value)
-        is TestAction.SetMessage -> state.copy(message = action.message)
-        is TestAction.ServerAdd -> state.copy(count = state.count + action.value)
-        is TestAction.ServerSetMessage -> state.copy(message = action.message)
-        is TestAction.ConnectionError -> state.copy(message = action.message)
-        is TestAction.LocalIncrement -> state.copy(count = state.count + 1)
-        is TestAction.Connect -> state
-        is TestAction.Disconnect -> state
-        is TestAction.TriggerEmitServerAction -> state // handled by processor, not reducer
+val testReducer =
+    Reducer<TestState, TestAction> { state, action ->
+        when (action) {
+            is TestAction.Add -> state.copy(count = state.count + action.value)
+            is TestAction.SetMessage -> state.copy(message = action.message)
+            is TestAction.ServerAdd -> state.copy(count = state.count + action.value)
+            is TestAction.ServerSetMessage -> state.copy(message = action.message)
+            is TestAction.ConnectionError -> state.copy(message = action.message)
+            is TestAction.LocalIncrement -> state.copy(count = state.count + 1)
+            is TestAction.Connect -> state
+            is TestAction.Disconnect -> state
+            is TestAction.TriggerEmitServerAction -> state // handled by processor, not reducer
+        }
     }
-}
 
-val testErrorProcessor = object : ErrorProcessor<TestAction> {
-    override fun process(throwable: Throwable): Flow<TestAction> = emptyFlow()
-}
+val testErrorProcessor =
+    object : ErrorProcessor<TestAction> {
+        override fun process(throwable: Throwable): Flow<TestAction> = emptyFlow()
+    }
 
 // -- Test SyncMiddleware subclass --
 
@@ -64,14 +77,15 @@ class TestSyncMiddleware(
     scope = scope,
     onConnectionError = onConnectionError,
 ) {
-    override val processors: ActionProcessorMap<TestState, TestAction> = buildProcessors {
-        on<TestAction.Connect> { _, _ ->
-            startConnection()
+    override val processors: ActionProcessorMap<TestState, TestAction> =
+        buildProcessors {
+            on<TestAction.Connect> { _, _ ->
+                startConnection()
+            }
+            on<TestAction.Disconnect> { _, _ ->
+                stopConnection()
+            }
         }
-        on<TestAction.Disconnect> { _, _ ->
-            stopConnection()
-        }
-    }
 }
 
 /**
@@ -79,27 +93,26 @@ class TestSyncMiddleware(
  * With [ServerSharedActionForwarder] (via createClientStore), the emitted action
  * is auto re-dispatched through the middleware pipeline and sent to the server.
  */
-class EmitServerActionTestMiddleware(
-    connection: TypedClientConnection<TestAction>,
-    scope: CoroutineScope? = null,
-) : SyncMiddleware<TestState, TestAction>(
-    connection = connection,
-    scope = scope,
-) {
-    override val processors: ActionProcessorMap<TestState, TestAction> = buildProcessors {
-        on<TestAction.Connect> { _, _ ->
-            startConnection()
+class EmitServerActionTestMiddleware(connection: TypedClientConnection<TestAction>, scope: CoroutineScope? = null) :
+    SyncMiddleware<TestState, TestAction>(
+        connection = connection,
+        scope = scope,
+    ) {
+    override val processors: ActionProcessorMap<TestState, TestAction> =
+        buildProcessors {
+            on<TestAction.Connect> { _, _ ->
+                startConnection()
+            }
+            on<TestAction.Disconnect> { _, _ ->
+                stopConnection()
+            }
+            on<TestAction.TriggerEmitServerAction> { _, action ->
+                // ServerSharedActionForwarder will auto re-dispatch this to the server
+                emit(TestAction.ServerAdd(action.value))
+                // Also emit a local action to verify processor runs
+                emit(TestAction.Add(1))
+            }
         }
-        on<TestAction.Disconnect> { _, _ ->
-            stopConnection()
-        }
-        on<TestAction.TriggerEmitServerAction> { _, action ->
-            // ServerSharedActionForwarder will auto re-dispatch this to the server
-            emit(TestAction.ServerAdd(action.value))
-            // Also emit a local action to verify processor runs
-            emit(TestAction.Add(1))
-        }
-    }
 }
 
 // -- Mock TypedClientConnection --

--- a/kotlin/remote/core/build.gradle.kts
+++ b/kotlin/remote/core/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
+    alias(libs.plugins.kotlinSerialization)
     id("flowdux.publish-conventions")
 }
 
@@ -45,6 +46,7 @@ kotlin {
             implementation(kotlin("test"))
             implementation(libs.kotlinx.coroutines.test)
             implementation(libs.turbine)
+            implementation(libs.kotlinx.serialization.json)
         }
     }
 

--- a/kotlin/remote/core/build.gradle.kts
+++ b/kotlin/remote/core/build.gradle.kts
@@ -13,7 +13,7 @@ mavenPublishing {
 }
 
 // JitPack only publishes JVM artifacts to avoid variant resolution issues for JVM/Android consumers
-val isJitPack = System.getenv("JITPACK") == "true"
+val isJitPack = providers.environmentVariable("JITPACK").map { it == "true" }.getOrElse(false)
 
 kotlin {
     jvm()

--- a/kotlin/remote/core/src/commonTest/kotlin/io/flowdux/remote/SharedActionTest.kt
+++ b/kotlin/remote/core/src/commonTest/kotlin/io/flowdux/remote/SharedActionTest.kt
@@ -2,8 +2,8 @@ package io.flowdux.remote
 
 import io.flowdux.Action
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -11,7 +11,6 @@ import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 class SharedActionTest {
-
     // -- Test domain actions --
 
     interface ChatAction : Action
@@ -19,16 +18,24 @@ class SharedActionTest {
     @Serializable
     sealed interface SharedChatAction : ChatAction {
         @Serializable
-        data class SendMessage(val text: String) : SharedChatAction, ServerSharedAction
+        data class SendMessage(val text: String) :
+            SharedChatAction,
+            ServerSharedAction
 
         @Serializable
-        data class JoinRoom(val user: String) : SharedChatAction, ServerSharedAction
+        data class JoinRoom(val user: String) :
+            SharedChatAction,
+            ServerSharedAction
 
         @Serializable
-        data class SyncState(val messages: List<String>) : SharedChatAction, ClientSharedAction
+        data class SyncState(val messages: List<String>) :
+            SharedChatAction,
+            ClientSharedAction
 
         @Serializable
-        data class Kicked(val reason: String) : SharedChatAction, ClientSharedAction
+        data class Kicked(val reason: String) :
+            SharedChatAction,
+            ClientSharedAction
     }
 
     data class LocalAction(val value: Int) : ChatAction
@@ -63,12 +70,13 @@ class SharedActionTest {
 
     @Test
     fun filterServerSharedActionsFromMixedList() {
-        val actions: List<Action> = listOf(
-            SharedChatAction.SendMessage("hello"),
-            LocalAction(1),
-            SharedChatAction.SyncState(listOf("msg")),
-            SharedChatAction.JoinRoom("alice"),
-        )
+        val actions: List<Action> =
+            listOf(
+                SharedChatAction.SendMessage("hello"),
+                LocalAction(1),
+                SharedChatAction.SyncState(listOf("msg")),
+                SharedChatAction.JoinRoom("alice"),
+            )
 
         val serverActions = actions.filterIsInstance<ServerSharedAction>()
         assertEquals(2, serverActions.size)
@@ -78,12 +86,13 @@ class SharedActionTest {
 
     @Test
     fun filterClientSharedActionsFromMixedList() {
-        val actions: List<Action> = listOf(
-            SharedChatAction.SendMessage("hello"),
-            SharedChatAction.SyncState(listOf("msg")),
-            LocalAction(1),
-            SharedChatAction.Kicked("spam"),
-        )
+        val actions: List<Action> =
+            listOf(
+                SharedChatAction.SendMessage("hello"),
+                SharedChatAction.SyncState(listOf("msg")),
+                LocalAction(1),
+                SharedChatAction.Kicked("spam"),
+            )
 
         val clientActions = actions.filterIsInstance<ClientSharedAction>()
         assertEquals(2, clientActions.size)
@@ -93,12 +102,13 @@ class SharedActionTest {
 
     @Test
     fun filterSharedActionsExcludesLocalActions() {
-        val actions: List<Action> = listOf(
-            SharedChatAction.SendMessage("hello"),
-            LocalAction(1),
-            LocalAction(2),
-            SharedChatAction.SyncState(listOf("msg")),
-        )
+        val actions: List<Action> =
+            listOf(
+                SharedChatAction.SendMessage("hello"),
+                LocalAction(1),
+                LocalAction(2),
+                SharedChatAction.SyncState(listOf("msg")),
+            )
 
         val sharedActions = actions.filterIsInstance<SharedAction>()
         assertEquals(2, sharedActions.size)
@@ -132,12 +142,13 @@ class SharedActionTest {
 
     @Test
     fun polymorphicSerializationPreservesDirectionMarkers() {
-        val actions = listOf<SharedChatAction>(
-            SharedChatAction.SendMessage("hello"),
-            SharedChatAction.JoinRoom("alice"),
-            SharedChatAction.SyncState(listOf("msg")),
-            SharedChatAction.Kicked("spam"),
-        )
+        val actions =
+            listOf<SharedChatAction>(
+                SharedChatAction.SendMessage("hello"),
+                SharedChatAction.JoinRoom("alice"),
+                SharedChatAction.SyncState(listOf("msg")),
+                SharedChatAction.Kicked("spam"),
+            )
 
         for (action in actions) {
             val encoded = json.encodeToString<SharedChatAction>(action)

--- a/kotlin/remote/core/src/commonTest/kotlin/io/flowdux/remote/SharedActionTest.kt
+++ b/kotlin/remote/core/src/commonTest/kotlin/io/flowdux/remote/SharedActionTest.kt
@@ -1,0 +1,172 @@
+package io.flowdux.remote
+
+import io.flowdux.Action
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.encodeToString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class SharedActionTest {
+
+    // -- Test domain actions --
+
+    interface ChatAction : Action
+
+    @Serializable
+    sealed interface SharedChatAction : ChatAction {
+        @Serializable
+        data class SendMessage(val text: String) : SharedChatAction, ServerSharedAction
+
+        @Serializable
+        data class JoinRoom(val user: String) : SharedChatAction, ServerSharedAction
+
+        @Serializable
+        data class SyncState(val messages: List<String>) : SharedChatAction, ClientSharedAction
+
+        @Serializable
+        data class Kicked(val reason: String) : SharedChatAction, ClientSharedAction
+    }
+
+    data class LocalAction(val value: Int) : ChatAction
+
+    // -- Type hierarchy tests --
+
+    @Test
+    fun serverSharedActionExtendsSharedAction() {
+        val action: Action = SharedChatAction.SendMessage("hello")
+        assertTrue(action is SharedAction)
+        assertTrue(action is ServerSharedAction)
+        assertFalse(action is ClientSharedAction)
+    }
+
+    @Test
+    fun clientSharedActionExtendsSharedAction() {
+        val action: Action = SharedChatAction.SyncState(listOf("msg"))
+        assertTrue(action is SharedAction)
+        assertTrue(action is ClientSharedAction)
+        assertFalse(action is ServerSharedAction)
+    }
+
+    @Test
+    fun localActionIsNotSharedAction() {
+        val action: Action = LocalAction(42)
+        assertFalse(action is SharedAction)
+        assertFalse(action is ServerSharedAction)
+        assertFalse(action is ClientSharedAction)
+    }
+
+    // -- Filtering tests --
+
+    @Test
+    fun filterServerSharedActionsFromMixedList() {
+        val actions: List<Action> = listOf(
+            SharedChatAction.SendMessage("hello"),
+            LocalAction(1),
+            SharedChatAction.SyncState(listOf("msg")),
+            SharedChatAction.JoinRoom("alice"),
+        )
+
+        val serverActions = actions.filterIsInstance<ServerSharedAction>()
+        assertEquals(2, serverActions.size)
+        assertIs<SharedChatAction.SendMessage>(serverActions[0])
+        assertIs<SharedChatAction.JoinRoom>(serverActions[1])
+    }
+
+    @Test
+    fun filterClientSharedActionsFromMixedList() {
+        val actions: List<Action> = listOf(
+            SharedChatAction.SendMessage("hello"),
+            SharedChatAction.SyncState(listOf("msg")),
+            LocalAction(1),
+            SharedChatAction.Kicked("spam"),
+        )
+
+        val clientActions = actions.filterIsInstance<ClientSharedAction>()
+        assertEquals(2, clientActions.size)
+        assertIs<SharedChatAction.SyncState>(clientActions[0])
+        assertIs<SharedChatAction.Kicked>(clientActions[1])
+    }
+
+    @Test
+    fun filterSharedActionsExcludesLocalActions() {
+        val actions: List<Action> = listOf(
+            SharedChatAction.SendMessage("hello"),
+            LocalAction(1),
+            LocalAction(2),
+            SharedChatAction.SyncState(listOf("msg")),
+        )
+
+        val sharedActions = actions.filterIsInstance<SharedAction>()
+        assertEquals(2, sharedActions.size)
+    }
+
+    // -- Serialization tests --
+
+    private val json = Json
+
+    @Test
+    fun serializeAndDeserializeServerSharedAction() {
+        val original = SharedChatAction.SendMessage("hello")
+        val encoded = json.encodeToString<SharedChatAction>(original)
+        val decoded = json.decodeFromString<SharedChatAction>(encoded)
+
+        assertEquals(original, decoded)
+        assertTrue(decoded is ServerSharedAction)
+        assertFalse(decoded is ClientSharedAction)
+    }
+
+    @Test
+    fun serializeAndDeserializeClientSharedAction() {
+        val original = SharedChatAction.SyncState(listOf("msg1", "msg2"))
+        val encoded = json.encodeToString<SharedChatAction>(original)
+        val decoded = json.decodeFromString<SharedChatAction>(encoded)
+
+        assertEquals(original, decoded)
+        assertTrue(decoded is ClientSharedAction)
+        assertFalse(decoded is ServerSharedAction)
+    }
+
+    @Test
+    fun polymorphicSerializationPreservesDirectionMarkers() {
+        val actions = listOf<SharedChatAction>(
+            SharedChatAction.SendMessage("hello"),
+            SharedChatAction.JoinRoom("alice"),
+            SharedChatAction.SyncState(listOf("msg")),
+            SharedChatAction.Kicked("spam"),
+        )
+
+        for (action in actions) {
+            val encoded = json.encodeToString<SharedChatAction>(action)
+            val decoded = json.decodeFromString<SharedChatAction>(encoded)
+
+            assertEquals(action, decoded)
+            assertEquals(action is ServerSharedAction, decoded is ServerSharedAction)
+            assertEquals(action is ClientSharedAction, decoded is ClientSharedAction)
+        }
+    }
+
+    @Test
+    fun serializedJsonContainsTypeDiscriminator() {
+        val action = SharedChatAction.SendMessage("hello")
+        val encoded = json.encodeToString<SharedChatAction>(action)
+
+        // Polymorphic serialization includes type discriminator
+        assertTrue(encoded.contains("type"), "JSON should contain type discriminator: $encoded")
+        assertTrue(encoded.contains("SendMessage"), "JSON should contain class name: $encoded")
+    }
+
+    @Test
+    fun emptyCollectionFieldSerializesCorrectly() {
+        val original = SharedChatAction.SyncState(emptyList())
+        val encoded = json.encodeToString<SharedChatAction>(original)
+        val decoded = json.decodeFromString<SharedChatAction>(encoded)
+
+        assertEquals(original, decoded)
+        assertIs<SharedChatAction.SyncState>(decoded)
+        assertEquals(emptyList(), (decoded as SharedChatAction.SyncState).messages)
+    }
+}

--- a/kotlin/remote/ktor/build.gradle.kts
+++ b/kotlin/remote/ktor/build.gradle.kts
@@ -12,7 +12,7 @@ mavenPublishing {
 }
 
 // JitPack only publishes JVM artifacts to avoid variant resolution issues for JVM/Android consumers
-val isJitPack = System.getenv("JITPACK") == "true"
+val isJitPack = providers.environmentVariable("JITPACK").map { it == "true" }.getOrElse(false)
 
 kotlin {
     jvm()

--- a/kotlin/remote/ktor/build.gradle.kts
+++ b/kotlin/remote/ktor/build.gradle.kts
@@ -37,6 +37,10 @@ kotlin {
             implementation(libs.ktor.client.core.multiplatform)
             implementation(libs.ktor.client.websockets.multiplatform)
         }
+        commonTest.dependencies {
+            implementation(kotlin("test"))
+            implementation(libs.kotlinx.coroutines.test)
+        }
         jvmMain.dependencies {
             implementation(libs.ktor.client.cio.multiplatform)
             api(project(":kotlin:flowdux-remote-server"))

--- a/kotlin/remote/ktor/build.gradle.kts
+++ b/kotlin/remote/ktor/build.gradle.kts
@@ -44,6 +44,8 @@ kotlin {
         jvmMain.dependencies {
             implementation(libs.ktor.client.cio.multiplatform)
             api(project(":kotlin:flowdux-remote-server"))
+            api(libs.ktor.server.core)
+            api(libs.ktor.server.websockets)
         }
         jvmTest.dependencies {
             implementation(kotlin("test"))

--- a/kotlin/remote/ktor/src/commonMain/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnection.kt
+++ b/kotlin/remote/ktor/src/commonMain/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnection.kt
@@ -1,9 +1,8 @@
 package io.flowdux.remote.ktor
 
-import io.flowdux.remote.ConnectionState
 import io.flowdux.remote.ClientConnection
+import io.flowdux.remote.ConnectionState
 import io.ktor.client.HttpClient
-import io.ktor.client.plugins.websocket.WebSockets
 import io.ktor.client.plugins.websocket.webSocket
 import io.ktor.websocket.Frame
 import io.ktor.websocket.WebSocketSession
@@ -62,11 +61,7 @@ import kotlin.concurrent.Volatile
  * @param httpClient Optional pre-configured HttpClient. If not provided, a dedicated HttpClient
  *   is created and closed on [disconnect]. If provided, the caller manages its lifecycle.
  */
-class KtorWebSocketClientConnection(
-    private val url: String,
-    httpClient: HttpClient? = null,
-) : ClientConnection {
-
+class KtorWebSocketClientConnection(private val url: String, httpClient: HttpClient? = null) : ClientConnection {
     private val httpClient: HttpClient
     private val isClientOwned: Boolean
 

--- a/kotlin/remote/ktor/src/commonMain/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnection.kt
+++ b/kotlin/remote/ktor/src/commonMain/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnection.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlin.concurrent.Volatile
 
 /**
  * Ktor-based WebSocket client implementation of [ClientConnection].
@@ -69,6 +70,7 @@ class KtorWebSocketClientConnection(
 
     private val outgoingChannel = Channel<String>(Channel.BUFFERED)
 
+    @Volatile
     private var session: WebSocketSession? = null
     private val connectMutex = Mutex()
 

--- a/kotlin/remote/ktor/src/commonMain/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnection.kt
+++ b/kotlin/remote/ktor/src/commonMain/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnection.kt
@@ -98,10 +98,17 @@ class KtorWebSocketClientConnection(
                 try {
                     coroutineScope {
                         launch {
-                            for (frame in incoming) {
-                                if (frame is Frame.Text) {
-                                    incomingChannel.send(frame.readText())
+                            try {
+                                for (frame in incoming) {
+                                    if (frame is Frame.Text) {
+                                        incomingChannel.send(frame.readText())
+                                    }
                                 }
+                            } finally {
+                                // Close outgoingChannel so the outgoing loop terminates
+                                // and any blocked senders fail fast. This is consistent
+                                // with disconnect() which also closes channels.
+                                outgoingChannel.close()
                             }
                         }
                         launch {

--- a/kotlin/remote/ktor/src/commonMain/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnection.kt
+++ b/kotlin/remote/ktor/src/commonMain/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnection.kt
@@ -101,7 +101,13 @@ class KtorWebSocketClientConnection(
                             try {
                                 for (frame in incoming) {
                                     if (frame is Frame.Text) {
-                                        incomingChannel.send(frame.readText())
+                                        try {
+                                            incomingChannel.send(frame.readText())
+                                        } catch (_: ClosedSendChannelException) {
+                                            // disconnect() closed incomingChannel concurrently.
+                                            // This is expected — break and let connect() terminate.
+                                            break
+                                        }
                                     }
                                 }
                             } finally {

--- a/kotlin/remote/ktor/src/commonMain/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnection.kt
+++ b/kotlin/remote/ktor/src/commonMain/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnection.kt
@@ -31,6 +31,23 @@ import kotlin.concurrent.Volatile
  * [connect] suspends until the connection is closed — the caller is responsible
  * for launching it in an appropriate coroutine scope.
  *
+ * ## Single-use lifecycle
+ *
+ * Each instance supports a single connection lifecycle. Once the connection terminates —
+ * whether by calling [disconnect], a server-initiated close, or a connection failure —
+ * the internal channels are closed and cannot be reopened. Calling [connect] again on the
+ * same instance throws [IllegalStateException]. Create a new instance to reconnect:
+ *
+ * ```kotlin
+ * val conn1 = KtorWebSocketClientConnection(url)
+ * conn1.connect()   // suspends until disconnected
+ * conn1.disconnect()
+ *
+ * // Create a new instance for reconnection
+ * val conn2 = KtorWebSocketClientConnection(url)
+ * conn2.connect()
+ * ```
+ *
  * ## Backpressure
  *
  * Both incoming and outgoing channels use [Channel.BUFFERED] (64 elements, SUSPEND overflow):
@@ -42,7 +59,8 @@ import kotlin.concurrent.Volatile
  *   to the caller until the WebSocket can transmit buffered messages.
  *
  * @param url WebSocket URL to connect to (e.g., "ws://localhost:8080/path" or "wss://example.com/path")
- * @param httpClient Optional pre-configured HttpClient. If not provided, uses platform-default engine.
+ * @param httpClient Optional pre-configured HttpClient. If not provided, a dedicated HttpClient
+ *   is created and closed on [disconnect]. If provided, the caller manages its lifecycle.
  */
 class KtorWebSocketClientConnection(
     private val url: String,
@@ -72,6 +90,9 @@ class KtorWebSocketClientConnection(
 
     @Volatile
     private var session: WebSocketSession? = null
+
+    @Volatile
+    private var terminated = false
     private val connectMutex = Mutex()
 
     override suspend fun send(message: String) {
@@ -88,6 +109,12 @@ class KtorWebSocketClientConnection(
     override suspend fun connect() {
         connectMutex.withLock {
             if (_connectionState.value != ConnectionState.DISCONNECTED) return
+            if (terminated) {
+                throw IllegalStateException(
+                    "Cannot reconnect: this instance has already been used. " +
+                        "Create a new KtorWebSocketClientConnection instance to reconnect.",
+                )
+            }
             _connectionState.value = ConnectionState.CONNECTING
         }
 
@@ -128,11 +155,13 @@ class KtorWebSocketClientConnection(
                 }
             }
         } finally {
+            terminated = true
             _connectionState.value = ConnectionState.DISCONNECTED
         }
     }
 
     override suspend fun disconnect() {
+        terminated = true
         _connectionState.value = ConnectionState.DISCONNECTED
         session?.close()
         session = null

--- a/kotlin/remote/ktor/src/commonMain/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnection.kt
+++ b/kotlin/remote/ktor/src/commonMain/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnection.kt
@@ -54,10 +54,10 @@ class KtorWebSocketClientConnection(
     private val _connectionState = MutableStateFlow(ConnectionState.DISCONNECTED)
     override val connectionState: StateFlow<ConnectionState> = _connectionState
 
-    private val incomingChannel = Channel<String>(Channel.UNLIMITED)
+    private val incomingChannel = Channel<String>(Channel.BUFFERED)
     override val incoming: Flow<String> = incomingChannel.receiveAsFlow()
 
-    private val outgoingChannel = Channel<String>(Channel.UNLIMITED)
+    private val outgoingChannel = Channel<String>(Channel.BUFFERED)
 
     private var session: WebSocketSession? = null
     private val connectMutex = Mutex()

--- a/kotlin/remote/ktor/src/commonMain/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnection.kt
+++ b/kotlin/remote/ktor/src/commonMain/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnection.kt
@@ -30,6 +30,16 @@ import kotlinx.coroutines.sync.withLock
  * [connect] suspends until the connection is closed — the caller is responsible
  * for launching it in an appropriate coroutine scope.
  *
+ * ## Backpressure
+ *
+ * Both incoming and outgoing channels use [Channel.BUFFERED] (64 elements, SUSPEND overflow):
+ *
+ * - **Incoming**: When the buffer fills up, the WebSocket receive loop suspends until the
+ *   consumer collects messages from [incoming]. Consumers should collect promptly to avoid
+ *   blocking WebSocket frame processing, which applies backpressure to the server.
+ * - **Outgoing**: [send] suspends when the outgoing buffer is full, applying backpressure
+ *   to the caller until the WebSocket can transmit buffered messages.
+ *
  * @param url WebSocket URL to connect to (e.g., "ws://localhost:8080/path" or "wss://example.com/path")
  * @param httpClient Optional pre-configured HttpClient. If not provided, uses platform-default engine.
  */

--- a/kotlin/remote/ktor/src/commonTest/kotlin/io/flowdux/remote/ktor/KtorClientConnectionCommonTest.kt
+++ b/kotlin/remote/ktor/src/commonTest/kotlin/io/flowdux/remote/ktor/KtorClientConnectionCommonTest.kt
@@ -1,0 +1,72 @@
+package io.flowdux.remote.ktor
+
+import io.flowdux.remote.ConnectionState
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class KtorClientConnectionCommonTest {
+
+    @Test
+    fun initialStateIsDisconnected() = runTest {
+        val connection = KtorWebSocketClientConnection("ws://localhost:8080/test")
+        try {
+            assertEquals(ConnectionState.DISCONNECTED, connection.connectionState.value)
+        } finally {
+            connection.disconnect()
+        }
+    }
+
+    @Test
+    fun factoryCreateWithCustomParamsInitializesConnection() = runTest {
+        val connection = KtorWebSocketClientConnection.create(
+            host = "example.com",
+            port = 9090,
+            path = "/ws",
+            secure = false,
+        )
+        try {
+            assertEquals(ConnectionState.DISCONNECTED, connection.connectionState.value)
+        } finally {
+            connection.disconnect()
+        }
+    }
+
+    @Test
+    fun factoryCreateWithSecureParamInitializesConnection() = runTest {
+        val connection = KtorWebSocketClientConnection.create(
+            host = "example.com",
+            port = 443,
+            path = "/ws",
+            secure = true,
+        )
+        try {
+            assertEquals(ConnectionState.DISCONNECTED, connection.connectionState.value)
+        } finally {
+            connection.disconnect()
+        }
+    }
+
+    @Test
+    fun factoryCreateWithDefaultsInitializesConnection() = runTest {
+        val connection = KtorWebSocketClientConnection.create()
+        try {
+            assertEquals(ConnectionState.DISCONNECTED, connection.connectionState.value)
+        } finally {
+            connection.disconnect()
+        }
+    }
+
+    @Test
+    fun sendBeforeConnectThrowsIllegalState() = runTest {
+        val connection = KtorWebSocketClientConnection("ws://localhost:8080/test")
+        try {
+            assertFailsWith<IllegalStateException> {
+                connection.send("hello")
+            }
+        } finally {
+            connection.disconnect()
+        }
+    }
+}

--- a/kotlin/remote/ktor/src/commonTest/kotlin/io/flowdux/remote/ktor/KtorClientConnectionCommonTest.kt
+++ b/kotlin/remote/ktor/src/commonTest/kotlin/io/flowdux/remote/ktor/KtorClientConnectionCommonTest.kt
@@ -7,7 +7,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 class KtorClientConnectionCommonTest {
-
     @Test
     fun initialStateIsDisconnected() = runTest {
         val connection = KtorWebSocketClientConnection("ws://localhost:8080/test")
@@ -20,12 +19,13 @@ class KtorClientConnectionCommonTest {
 
     @Test
     fun factoryCreateWithCustomParamsInitializesConnection() = runTest {
-        val connection = KtorWebSocketClientConnection.create(
-            host = "example.com",
-            port = 9090,
-            path = "/ws",
-            secure = false,
-        )
+        val connection =
+            KtorWebSocketClientConnection.create(
+                host = "example.com",
+                port = 9090,
+                path = "/ws",
+                secure = false,
+            )
         try {
             assertEquals(ConnectionState.DISCONNECTED, connection.connectionState.value)
         } finally {
@@ -35,12 +35,13 @@ class KtorClientConnectionCommonTest {
 
     @Test
     fun factoryCreateWithSecureParamInitializesConnection() = runTest {
-        val connection = KtorWebSocketClientConnection.create(
-            host = "example.com",
-            port = 443,
-            path = "/ws",
-            secure = true,
-        )
+        val connection =
+            KtorWebSocketClientConnection.create(
+                host = "example.com",
+                port = 443,
+                path = "/ws",
+                secure = true,
+            )
         try {
             assertEquals(ConnectionState.DISCONNECTED, connection.connectionState.value)
         } finally {

--- a/kotlin/remote/ktor/src/commonTest/kotlin/io/flowdux/remote/ktor/KtorClientConnectionCommonTest.kt
+++ b/kotlin/remote/ktor/src/commonTest/kotlin/io/flowdux/remote/ktor/KtorClientConnectionCommonTest.kt
@@ -59,6 +59,15 @@ class KtorClientConnectionCommonTest {
     }
 
     @Test
+    fun connectAfterDisconnectThrowsIllegalState() = runTest {
+        val connection = KtorWebSocketClientConnection("ws://localhost:8080/test")
+        connection.disconnect()
+        assertFailsWith<IllegalStateException> {
+            connection.connect()
+        }
+    }
+
+    @Test
     fun sendBeforeConnectThrowsIllegalState() = runTest {
         val connection = KtorWebSocketClientConnection("ws://localhost:8080/test")
         try {

--- a/kotlin/remote/ktor/src/jvmMain/kotlin/io/flowdux/remote/ktor/KtorWebSocketServerConnection.kt
+++ b/kotlin/remote/ktor/src/jvmMain/kotlin/io/flowdux/remote/ktor/KtorWebSocketServerConnection.kt
@@ -6,11 +6,11 @@ import io.ktor.websocket.WebSocketSession
 import io.ktor.websocket.readText
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.ClosedSendChannelException
-import kotlinx.coroutines.isActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.isActive
 
 /**
  * Ktor-based WebSocket server implementation of [ServerConnection].
@@ -20,15 +20,14 @@ import kotlinx.coroutines.flow.receiveAsFlow
  *
  * @param session Ktor WebSocket session (typically a server session from a `webSocket` route)
  */
-class KtorWebSocketServerConnection(
-    private val session: WebSocketSession,
-) : ServerConnection {
-
+class KtorWebSocketServerConnection(private val session: WebSocketSession) : ServerConnection {
     override val isActive: Boolean get() = session.isActive
 
-    override val incoming: Flow<String> = session.incoming.receiveAsFlow()
-        .filterIsInstance<Frame.Text>()
-        .map { it.readText() }
+    override val incoming: Flow<String> =
+        session.incoming
+            .receiveAsFlow()
+            .filterIsInstance<Frame.Text>()
+            .map { it.readText() }
 
     @OptIn(kotlinx.coroutines.DelicateCoroutinesApi::class)
     override suspend fun send(message: String) {

--- a/kotlin/remote/ktor/src/jvmMain/kotlin/io/flowdux/remote/ktor/OriginCheck.kt
+++ b/kotlin/remote/ktor/src/jvmMain/kotlin/io/flowdux/remote/ktor/OriginCheck.kt
@@ -1,0 +1,60 @@
+package io.flowdux.remote.ktor
+
+import io.ktor.server.routing.Route
+import io.ktor.server.websocket.DefaultWebSocketServerSession
+import io.ktor.server.websocket.webSocket
+import io.ktor.websocket.CloseReason
+import io.ktor.websocket.close
+
+/**
+ * Check the `Origin` header of the current WebSocket session against the given [policy].
+ *
+ * If the origin is not allowed, the session is closed with
+ * [CloseReason.Codes.VIOLATED_POLICY] and this function returns `false`.
+ *
+ * Usage inside a `webSocket` handler:
+ * ```kotlin
+ * webSocket("/ws") {
+ *     if (!checkOrigin(policy)) return@webSocket
+ *     // proceed normally
+ * }
+ * ```
+ *
+ * @param policy the [OriginPolicy] to evaluate.
+ * @return `true` if the origin is allowed; `false` if the session was closed.
+ */
+suspend fun DefaultWebSocketServerSession.checkOrigin(policy: OriginPolicy): Boolean {
+    val origin = call.request.headers["Origin"]
+    if (policy.isAllowed(origin)) return true
+    close(CloseReason(CloseReason.Codes.VIOLATED_POLICY, "Origin not allowed"))
+    return false
+}
+
+/**
+ * Install a WebSocket route with automatic origin validation.
+ *
+ * Equivalent to calling [webSocket] and invoking [checkOrigin] at the start:
+ * ```kotlin
+ * webSocketWithOriginCheck("/ws", policy) {
+ *     val conn = KtorWebSocketServerConnection(this)
+ *     // handle connection ...
+ * }
+ * ```
+ *
+ * If the client's `Origin` header is rejected, the session is closed with
+ * [CloseReason.Codes.VIOLATED_POLICY] before [handler] is invoked.
+ *
+ * @param path the WebSocket endpoint path.
+ * @param originPolicy the [OriginPolicy] to enforce.
+ * @param handler the WebSocket session handler, invoked only when the origin is allowed.
+ */
+fun Route.webSocketWithOriginCheck(
+    path: String,
+    originPolicy: OriginPolicy,
+    handler: suspend DefaultWebSocketServerSession.() -> Unit,
+) {
+    webSocket(path) {
+        if (!checkOrigin(originPolicy)) return@webSocket
+        handler()
+    }
+}

--- a/kotlin/remote/ktor/src/jvmMain/kotlin/io/flowdux/remote/ktor/OriginPolicy.kt
+++ b/kotlin/remote/ktor/src/jvmMain/kotlin/io/flowdux/remote/ktor/OriginPolicy.kt
@@ -1,0 +1,64 @@
+package io.flowdux.remote.ktor
+
+import java.util.Locale
+
+/**
+ * Policy for validating WebSocket `Origin` headers to prevent
+ * Cross-Site WebSocket Hijacking (CSWSH) attacks.
+ *
+ * Usage:
+ * ```kotlin
+ * val policy = OriginPolicy.AllowList(
+ *     origins = setOf("https://example.com", "https://app.example.com"),
+ * )
+ *
+ * routing {
+ *     webSocketWithOriginCheck("/ws", policy) {
+ *         val conn = KtorWebSocketServerConnection(this)
+ *         // ...
+ *     }
+ * }
+ * ```
+ *
+ * @see webSocketWithOriginCheck
+ */
+sealed interface OriginPolicy {
+
+    /**
+     * Check whether the given [origin] is allowed by this policy.
+     *
+     * @param origin the value of the `Origin` header, or `null` if absent.
+     * @return `true` if the connection should be accepted.
+     */
+    fun isAllowed(origin: String?): Boolean
+
+    /**
+     * Permits all origins, including absent `Origin` headers.
+     * Useful for development or when origin validation is handled elsewhere.
+     */
+    data object AllowAll : OriginPolicy {
+        override fun isAllowed(origin: String?): Boolean = true
+    }
+
+    /**
+     * Permits only the specified [origins].
+     *
+     * Origins are compared case-insensitively after trimming trailing slashes.
+     * Example allowed values: `"https://example.com"`, `"http://localhost:3000"`.
+     *
+     * @param origins set of allowed origin strings (scheme + host + optional port).
+     * @param allowNullOrigin whether to allow requests with no `Origin` header
+     *   (e.g. same-origin requests from some clients, or non-browser clients).
+     *   Defaults to `false` for maximum security.
+     */
+    data class AllowList(val origins: Set<String>, val allowNullOrigin: Boolean = false) : OriginPolicy {
+
+        private val normalized: Set<String> =
+            origins.toSet().map { it.trimEnd('/').lowercase(Locale.ROOT) }.toSet()
+
+        override fun isAllowed(origin: String?): Boolean {
+            if (origin == null) return allowNullOrigin
+            return origin.trimEnd('/').lowercase(Locale.ROOT) in normalized
+        }
+    }
+}

--- a/kotlin/remote/ktor/src/jvmTest/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnectionTest.kt
+++ b/kotlin/remote/ktor/src/jvmTest/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnectionTest.kt
@@ -291,4 +291,35 @@ class KtorWebSocketClientConnectionTest {
             server.stop(500, 1_000)
         }
     }
+
+    @Test
+    fun `server initiated close terminates connect without explicit disconnect`() = runBlocking {
+        val server = embeddedServer(CIO, port = 0) {
+            install(WebSockets)
+            routing {
+                webSocket("/test") {
+                    delay(200)
+                    close(CloseReason(CloseReason.Codes.NORMAL, "Server closing"))
+                }
+            }
+        }.start(wait = false)
+
+        var connection: KtorWebSocketClientConnection? = null
+        try {
+            val port = server.engine.resolvedConnectors().first().port
+            connection = KtorWebSocketClientConnection("ws://localhost:$port/test")
+
+            val connectJob = launch(Dispatchers.Default) { connection.connect() }
+            withTimeout(5_000) {
+                connection.connectionState.first { it == ConnectionState.CONNECTED }
+            }
+
+            // connect() should return on its own after the server closes
+            withTimeout(5_000) { connectJob.join() }
+            assertEquals(ConnectionState.DISCONNECTED, connection.connectionState.value)
+        } finally {
+            connection?.disconnect()
+            server.stop(500, 1_000)
+        }
+    }
 }

--- a/kotlin/remote/ktor/src/jvmTest/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnectionTest.kt
+++ b/kotlin/remote/ktor/src/jvmTest/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnectionTest.kt
@@ -322,4 +322,42 @@ class KtorWebSocketClientConnectionTest {
             server.stop(500, 1_000)
         }
     }
+
+    @Test
+    fun `disconnect during active message reception completes cleanly`() = runBlocking {
+        val server = embeddedServer(CIO, port = 0) {
+            install(WebSockets)
+            routing {
+                webSocket("/test") {
+                    // Stream messages continuously to keep the receive loop busy
+                    var i = 0
+                    while (true) {
+                        send(Frame.Text("msg-${i++}"))
+                        delay(10)
+                    }
+                }
+            }
+        }.start(wait = false)
+
+        try {
+            val port = server.engine.resolvedConnectors().first().port
+            val connection = KtorWebSocketClientConnection("ws://localhost:$port/test")
+
+            val connectJob = launch(Dispatchers.Default) { connection.connect() }
+            withTimeout(5_000) {
+                connection.connectionState.first { it == ConnectionState.CONNECTED }
+            }
+
+            // Wait for some messages to flow through
+            withTimeout(5_000) { connection.incoming.first() }
+
+            // Disconnect while the receive loop is actively processing frames.
+            // This exercises the ClosedSendChannelException race condition path.
+            connection.disconnect()
+            withTimeout(5_000) { connectJob.join() }
+            assertEquals(ConnectionState.DISCONNECTED, connection.connectionState.value)
+        } finally {
+            server.stop(500, 1_000)
+        }
+    }
 }

--- a/kotlin/remote/ktor/src/jvmTest/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnectionTest.kt
+++ b/kotlin/remote/ktor/src/jvmTest/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnectionTest.kt
@@ -9,7 +9,10 @@ import io.ktor.server.websocket.*
 import io.ktor.websocket.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
@@ -356,6 +359,159 @@ class KtorWebSocketClientConnectionTest {
             connection.disconnect()
             withTimeout(5_000) { connectJob.join() }
             assertEquals(ConnectionState.DISCONNECTED, connection.connectionState.value)
+        } finally {
+            server.stop(500, 1_000)
+        }
+    }
+
+    @Test
+    fun `incoming burst beyond buffer size delivers all messages without loss`() = runBlocking {
+        val messageCount = 100
+        val server = embeddedServer(CIO, port = 0) {
+            install(WebSockets)
+            routing {
+                webSocket("/test") {
+                    // Send messages as fast as possible to overflow the buffer (64)
+                    for (i in 0 until messageCount) {
+                        send(Frame.Text("msg-$i"))
+                    }
+                    // Keep connection alive until client disconnects
+                    for (frame in incoming) { /* keep alive */ }
+                }
+            }
+        }.start(wait = false)
+
+        try {
+            val port = server.engine.resolvedConnectors().first().port
+            val connection = KtorWebSocketClientConnection("ws://localhost:$port/test")
+
+            val connectJob = launch(Dispatchers.Default) { connection.connect() }
+            withTimeout(5_000) {
+                connection.connectionState.first { it == ConnectionState.CONNECTED }
+            }
+
+            // Collect all messages at once. The server sends 100 messages which exceeds
+            // the buffer capacity (64). SUSPEND overflow policy ensures no messages are
+            // dropped — the server's send() suspends until buffer space is available.
+            val received = withTimeout(10_000) {
+                connection.incoming.take(messageCount).toList()
+            }
+
+            assertEquals(messageCount, received.size)
+            for (i in 0 until messageCount) {
+                assertEquals("msg-$i", received[i], "Message $i out of order or missing")
+            }
+
+            connection.disconnect()
+            withTimeout(5_000) { connectJob.join() }
+        } finally {
+            server.stop(500, 1_000)
+        }
+    }
+
+    @Test
+    fun `outgoing messages beyond buffer size are all delivered to slow server`() = runBlocking {
+        val messageCount = 100
+        val serverReceivedMessages = java.util.concurrent.CopyOnWriteArrayList<String>()
+
+        val server = embeddedServer(CIO, port = 0) {
+            install(WebSockets)
+            routing {
+                webSocket("/test") {
+                    for (frame in incoming) {
+                        if (frame is Frame.Text) {
+                            serverReceivedMessages.add(frame.readText())
+                            // Slow server: delays reading to encourage the outgoing buffer to fill up.
+                            delay(10)
+                        }
+                    }
+                }
+            }
+        }.start(wait = false)
+
+        try {
+            val port = server.engine.resolvedConnectors().first().port
+            val connection = KtorWebSocketClientConnection("ws://localhost:$port/test")
+
+            val connectJob = launch(Dispatchers.Default) { connection.connect() }
+            withTimeout(5_000) {
+                connection.connectionState.first { it == ConnectionState.CONNECTED }
+            }
+
+            // Send more messages than the buffer can hold (64).
+            // With the slow server, the outgoing buffer is likely to fill up, causing
+            // send() to suspend until messages are drained. No messages should be dropped.
+            withTimeout(30_000) {
+                for (i in 0 until messageCount) {
+                    connection.send("msg-$i")
+                }
+            }
+
+            // Wait for server to finish processing all messages
+            withTimeout(10_000) {
+                while (serverReceivedMessages.size < messageCount) {
+                    delay(50)
+                }
+            }
+
+            assertEquals(messageCount, serverReceivedMessages.size)
+            for (i in 0 until messageCount) {
+                assertEquals("msg-$i", serverReceivedMessages[i], "Message $i out of order or missing")
+            }
+
+            connection.disconnect()
+            withTimeout(5_000) { connectJob.join() }
+        } finally {
+            server.stop(500, 1_000)
+        }
+    }
+
+    @Test
+    fun `slow consumer receives messages in order under sustained backpressure`() = runBlocking {
+        val messageCount = 200 // Well above buffer size of 64
+        val server = embeddedServer(CIO, port = 0) {
+            install(WebSockets)
+            routing {
+                webSocket("/test") {
+                    for (i in 0 until messageCount) {
+                        send(Frame.Text("msg-$i"))
+                    }
+                    // Keep alive until client disconnects
+                    for (frame in incoming) { /* keep alive */ }
+                }
+            }
+        }.start(wait = false)
+
+        var connection: KtorWebSocketClientConnection? = null
+        try {
+            val port = server.engine.resolvedConnectors().first().port
+            connection = KtorWebSocketClientConnection("ws://localhost:$port/test")
+
+            val connectJob = launch(Dispatchers.Default) { connection.connect() }
+            withTimeout(5_000) {
+                connection.connectionState.first { it == ConnectionState.CONNECTED }
+            }
+
+            try {
+                // Collect slowly with periodic delays to exercise buffer fill/drain cycles.
+                // With BUFFERED (64, SUSPEND), the receive loop suspends when the buffer fills,
+                // then resumes as the consumer drains it. No messages should be dropped.
+                val consumed = mutableListOf<String>()
+                withTimeout(30_000) {
+                    connection.incoming.take(messageCount).collect { msg ->
+                        consumed.add(msg)
+                        if (consumed.size % 10 == 0) delay(50)
+                    }
+                }
+
+                assertEquals(messageCount, consumed.size)
+                for (i in 0 until messageCount) {
+                    assertEquals("msg-$i", consumed[i], "Message $i out of order or missing")
+                }
+            } finally {
+                connection.disconnect()
+                withTimeout(5_000) { connectJob.join() }
+            }
         } finally {
             server.stop(500, 1_000)
         }

--- a/kotlin/remote/ktor/src/jvmTest/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnectionTest.kt
+++ b/kotlin/remote/ktor/src/jvmTest/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnectionTest.kt
@@ -194,4 +194,101 @@ class KtorWebSocketClientConnectionTest {
             server.stop(500, 1_000)
         }
     }
+
+    @Test
+    fun `connect to unreachable server returns to DISCONNECTED`() = runBlocking {
+        // Use localhost with a closed port for fast, deterministic failure
+        val connection = KtorWebSocketClientConnection("ws://127.0.0.1:1/test")
+        assertEquals(ConnectionState.DISCONNECTED, connection.connectionState.value)
+
+        // connect() should throw or return, but state must return to DISCONNECTED
+        try {
+            withTimeout(3_000) { connection.connect() }
+        } catch (_: Exception) {
+            // Expected: connection failure
+        } finally {
+            connection.disconnect()
+        }
+
+        assertEquals(ConnectionState.DISCONNECTED, connection.connectionState.value)
+    }
+
+    @Test
+    fun `reconnect after disconnect succeeds`() = runBlocking {
+        val server = embeddedServer(CIO, port = 0) {
+            install(WebSockets)
+            routing {
+                webSocket("/test") {
+                    for (frame in incoming) { /* keep alive */ }
+                }
+            }
+        }.start(wait = false)
+
+        try {
+            val port = server.engine.resolvedConnectors().first().port
+
+            // First connection
+            val connection1 = KtorWebSocketClientConnection("ws://localhost:$port/test")
+            val job1 = launch(Dispatchers.Default) { connection1.connect() }
+            withTimeout(5_000) {
+                connection1.connectionState.first { it == ConnectionState.CONNECTED }
+            }
+            connection1.disconnect()
+            withTimeout(5_000) { job1.join() }
+            assertEquals(ConnectionState.DISCONNECTED, connection1.connectionState.value)
+
+            // Second connection (new instance, same server)
+            val connection2 = KtorWebSocketClientConnection("ws://localhost:$port/test")
+            val job2 = launch(Dispatchers.Default) { connection2.connect() }
+            withTimeout(5_000) {
+                connection2.connectionState.first { it == ConnectionState.CONNECTED }
+            }
+            assertEquals(ConnectionState.CONNECTED, connection2.connectionState.value)
+
+            connection2.disconnect()
+            withTimeout(5_000) { job2.join() }
+        } finally {
+            server.stop(500, 1_000)
+        }
+    }
+
+    @Test
+    fun `server initiated close allows client to detect and disconnect`() = runBlocking {
+        val serverClosed = AtomicBoolean(false)
+
+        val server = embeddedServer(CIO, port = 0) {
+            install(WebSockets)
+            routing {
+                webSocket("/test") {
+                    delay(200)
+                    close(CloseReason(CloseReason.Codes.NORMAL, "Server closing"))
+                    serverClosed.set(true)
+                }
+            }
+        }.start(wait = false)
+
+        try {
+            val port = server.engine.resolvedConnectors().first().port
+            val connection = KtorWebSocketClientConnection("ws://localhost:$port/test")
+
+            val connectJob = launch(Dispatchers.Default) { connection.connect() }
+            withTimeout(5_000) {
+                connection.connectionState.first { it == ConnectionState.CONNECTED }
+            }
+
+            // Wait for server to close by polling the flag
+            withTimeout(5_000) {
+                while (!serverClosed.get()) {
+                    delay(10)
+                }
+            }
+
+            // Client calls disconnect to clean up
+            connection.disconnect()
+            withTimeout(5_000) { connectJob.join() }
+            assertEquals(ConnectionState.DISCONNECTED, connection.connectionState.value)
+        } finally {
+            server.stop(500, 1_000)
+        }
+    }
 }

--- a/kotlin/remote/ktor/src/jvmTest/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnectionTest.kt
+++ b/kotlin/remote/ktor/src/jvmTest/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnectionTest.kt
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class KtorWebSocketClientConnectionTest {
@@ -462,6 +463,45 @@ class KtorWebSocketClientConnectionTest {
             connection.disconnect()
             withTimeout(5_000) { connectJob.join() }
         } finally {
+            server.stop(500, 1_000)
+        }
+    }
+
+    @Test
+    fun `connect after disconnect throws IllegalStateException`() = runBlocking {
+        val server = embeddedServer(CIO, port = 0) {
+            install(WebSockets)
+            routing {
+                webSocket("/test") {
+                    for (frame in incoming) { /* keep alive */ }
+                }
+            }
+        }.start(wait = false)
+
+        var connection: KtorWebSocketClientConnection? = null
+        try {
+            val port = server.engine.resolvedConnectors().first().port
+            connection = KtorWebSocketClientConnection("ws://localhost:$port/test")
+
+            val connectJob = launch(Dispatchers.Default) { connection.connect() }
+            withTimeout(5_000) {
+                connection.connectionState.first { it == ConnectionState.CONNECTED }
+            }
+
+            connection.disconnect()
+            withTimeout(5_000) { connectJob.join() }
+            assertEquals(ConnectionState.DISCONNECTED, connection.connectionState.value)
+
+            // Attempting to connect the same instance again must fail
+            val exception = assertFailsWith<IllegalStateException> {
+                connection.connect()
+            }
+            assertTrue(
+                exception.message!!.contains("Cannot reconnect"),
+                "Expected message about reconnection, got: ${exception.message}",
+            )
+        } finally {
+            connection?.disconnect()
             server.stop(500, 1_000)
         }
     }

--- a/kotlin/remote/ktor/src/jvmTest/kotlin/io/flowdux/remote/ktor/OriginCheckTest.kt
+++ b/kotlin/remote/ktor/src/jvmTest/kotlin/io/flowdux/remote/ktor/OriginCheckTest.kt
@@ -1,0 +1,185 @@
+package io.flowdux.remote.ktor
+
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.websocket.webSocket
+import io.ktor.client.request.header
+import io.ktor.server.application.install
+import io.ktor.server.cio.CIO
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.routing.routing
+import io.ktor.server.websocket.WebSockets
+import io.ktor.server.websocket.webSocket
+import io.ktor.websocket.CloseReason
+import io.ktor.websocket.Frame
+import io.ktor.websocket.readText
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import io.ktor.client.plugins.websocket.WebSockets as ClientWebSockets
+
+class OriginCheckTest {
+
+    private val allowedOrigin = "https://example.com"
+
+    private val policy = OriginPolicy.AllowList(
+        origins = setOf(allowedOrigin),
+    )
+
+    private fun createClient() = HttpClient { install(ClientWebSockets) }
+
+    @Test
+    fun `allowed origin connects successfully`() = runBlocking {
+        val server = embeddedServer(CIO, port = 0) {
+            install(WebSockets)
+            routing {
+                webSocketWithOriginCheck("/ws", policy) {
+                    send(Frame.Text("hello"))
+                    for (frame in incoming) { /* keep alive */ }
+                }
+            }
+        }.start(wait = false)
+
+        try {
+            val port = server.engine.resolvedConnectors().first().port
+            createClient().use { client ->
+                client.webSocket(
+                    host = "localhost",
+                    port = port,
+                    path = "/ws",
+                    request = { header("Origin", allowedOrigin) },
+                ) {
+                    val frame = withTimeout(5_000) { incoming.receive() } as Frame.Text
+                    assertEquals("hello", frame.readText())
+                }
+            }
+        } finally {
+            server.stop(500, 1_000)
+        }
+    }
+
+    @Test
+    fun `rejected origin receives VIOLATED_POLICY close`() = runBlocking {
+        val server = embeddedServer(CIO, port = 0) {
+            install(WebSockets)
+            routing {
+                webSocketWithOriginCheck("/ws", policy) {
+                    send(Frame.Text("should not reach"))
+                    for (frame in incoming) { /* keep alive */ }
+                }
+            }
+        }.start(wait = false)
+
+        try {
+            val port = server.engine.resolvedConnectors().first().port
+            createClient().use { client ->
+                client.webSocket(
+                    host = "localhost",
+                    port = port,
+                    path = "/ws",
+                    request = { header("Origin", "https://evil.com") },
+                ) {
+                    val reason = withTimeout(5_000) { closeReason.await() }
+                    assertNotNull(reason)
+                    assertEquals(CloseReason.Codes.VIOLATED_POLICY.code, reason.code)
+                }
+            }
+        } finally {
+            server.stop(500, 1_000)
+        }
+    }
+
+    @Test
+    fun `null origin is rejected by AllowList with default config`() = runBlocking {
+        val server = embeddedServer(CIO, port = 0) {
+            install(WebSockets)
+            routing {
+                webSocketWithOriginCheck("/ws", policy) {
+                    send(Frame.Text("should not reach"))
+                    for (frame in incoming) { /* keep alive */ }
+                }
+            }
+        }.start(wait = false)
+
+        try {
+            val port = server.engine.resolvedConnectors().first().port
+            createClient().use { client ->
+                // No Origin header sent
+                client.webSocket(
+                    host = "localhost",
+                    port = port,
+                    path = "/ws",
+                ) {
+                    val reason = withTimeout(5_000) { closeReason.await() }
+                    assertNotNull(reason)
+                    assertEquals(CloseReason.Codes.VIOLATED_POLICY.code, reason.code)
+                }
+            }
+        } finally {
+            server.stop(500, 1_000)
+        }
+    }
+
+    @Test
+    fun `AllowAll policy permits any origin`() = runBlocking {
+        val server = embeddedServer(CIO, port = 0) {
+            install(WebSockets)
+            routing {
+                webSocketWithOriginCheck("/ws", OriginPolicy.AllowAll) {
+                    send(Frame.Text("welcome"))
+                    for (frame in incoming) { /* keep alive */ }
+                }
+            }
+        }.start(wait = false)
+
+        try {
+            val port = server.engine.resolvedConnectors().first().port
+            createClient().use { client ->
+                client.webSocket(
+                    host = "localhost",
+                    port = port,
+                    path = "/ws",
+                    request = { header("Origin", "https://any-site.com") },
+                ) {
+                    val frame = withTimeout(5_000) { incoming.receive() } as Frame.Text
+                    assertEquals("welcome", frame.readText())
+                }
+            }
+        } finally {
+            server.stop(500, 1_000)
+        }
+    }
+
+    @Test
+    fun `checkOrigin can be used standalone inside webSocket handler`() = runBlocking {
+        val server = embeddedServer(CIO, port = 0) {
+            install(WebSockets)
+            routing {
+                webSocket("/ws") {
+                    if (!checkOrigin(policy)) return@webSocket
+                    send(Frame.Text("passed"))
+                    for (frame in incoming) { /* keep alive */ }
+                }
+            }
+        }.start(wait = false)
+
+        try {
+            val port = server.engine.resolvedConnectors().first().port
+            createClient().use { client ->
+                // Allowed origin
+                client.webSocket(
+                    host = "localhost",
+                    port = port,
+                    path = "/ws",
+                    request = { header("Origin", allowedOrigin) },
+                ) {
+                    val frame = withTimeout(5_000) { incoming.receive() } as Frame.Text
+                    assertEquals("passed", frame.readText())
+                }
+            }
+        } finally {
+            server.stop(500, 1_000)
+        }
+    }
+}

--- a/kotlin/remote/ktor/src/jvmTest/kotlin/io/flowdux/remote/ktor/OriginPolicyTest.kt
+++ b/kotlin/remote/ktor/src/jvmTest/kotlin/io/flowdux/remote/ktor/OriginPolicyTest.kt
@@ -1,0 +1,88 @@
+package io.flowdux.remote.ktor
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class OriginPolicyTest {
+
+    // ── AllowAll ────────────────────────────────────────────────
+
+    @Test
+    fun `AllowAll permits any origin`() {
+        val policy = OriginPolicy.AllowAll
+        assertTrue(policy.isAllowed("https://example.com"))
+        assertTrue(policy.isAllowed("http://evil.com"))
+    }
+
+    @Test
+    fun `AllowAll permits null origin`() {
+        assertTrue(OriginPolicy.AllowAll.isAllowed(null))
+    }
+
+    // ── AllowList — basic matching ──────────────────────────────
+
+    @Test
+    fun `AllowList permits listed origin`() {
+        val policy = OriginPolicy.AllowList(origins = setOf("https://example.com"))
+        assertTrue(policy.isAllowed("https://example.com"))
+    }
+
+    @Test
+    fun `AllowList rejects unlisted origin`() {
+        val policy = OriginPolicy.AllowList(origins = setOf("https://example.com"))
+        assertFalse(policy.isAllowed("https://evil.com"))
+    }
+
+    @Test
+    fun `AllowList rejects null origin by default`() {
+        val policy = OriginPolicy.AllowList(origins = setOf("https://example.com"))
+        assertFalse(policy.isAllowed(null))
+    }
+
+    @Test
+    fun `AllowList permits null origin when allowNullOrigin is true`() {
+        val policy = OriginPolicy.AllowList(
+            origins = setOf("https://example.com"),
+            allowNullOrigin = true,
+        )
+        assertTrue(policy.isAllowed(null))
+    }
+
+    // ── AllowList — normalization ───────────────────────────────
+
+    @Test
+    fun `AllowList matching is case insensitive`() {
+        val policy = OriginPolicy.AllowList(origins = setOf("https://Example.COM"))
+        assertTrue(policy.isAllowed("https://example.com"))
+        assertTrue(policy.isAllowed("HTTPS://EXAMPLE.COM"))
+    }
+
+    @Test
+    fun `AllowList ignores trailing slash`() {
+        val policy = OriginPolicy.AllowList(origins = setOf("https://example.com/"))
+        assertTrue(policy.isAllowed("https://example.com"))
+        assertTrue(policy.isAllowed("https://example.com/"))
+    }
+
+    // ── AllowList — multiple origins ────────────────────────────
+
+    @Test
+    fun `AllowList permits any of multiple origins`() {
+        val policy = OriginPolicy.AllowList(
+            origins = setOf("https://app.example.com", "http://localhost:3000"),
+        )
+        assertTrue(policy.isAllowed("https://app.example.com"))
+        assertTrue(policy.isAllowed("http://localhost:3000"))
+        assertFalse(policy.isAllowed("https://other.com"))
+    }
+
+    // ── AllowList — empty set ───────────────────────────────────
+
+    @Test
+    fun `AllowList with empty set rejects everything`() {
+        val policy = OriginPolicy.AllowList(origins = emptySet())
+        assertFalse(policy.isAllowed("https://example.com"))
+        assertFalse(policy.isAllowed(null))
+    }
+}

--- a/kotlin/remote/multiplexer/build.gradle.kts
+++ b/kotlin/remote/multiplexer/build.gradle.kts
@@ -13,7 +13,7 @@ mavenPublishing {
 }
 
 // JitPack only publishes JVM artifacts to avoid variant resolution issues for JVM/Android consumers
-val isJitPack = System.getenv("JITPACK") == "true"
+val isJitPack = providers.environmentVariable("JITPACK").map { it == "true" }.getOrElse(false)
 
 kotlin {
     jvm()

--- a/kotlin/remote/multiplexer/src/commonMain/kotlin/io/flowdux/remote/multiplexer/ClientConnectionMultiplexer.kt
+++ b/kotlin/remote/multiplexer/src/commonMain/kotlin/io/flowdux/remote/multiplexer/ClientConnectionMultiplexer.kt
@@ -83,28 +83,29 @@ class ClientConnectionMultiplexer<A : Action>(
         // Start routing first so we're ready to receive messages
         startRouting()
         // Launch connection in background (connect() suspends until closed)
-        connectJob = scope.launch {
-            var connectFailed = false
-            try {
-                physicalConnection.connect()
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                connectFailed = true
-                if (onEvent != null) {
-                    safeOnEvent(MultiplexerEvent.ConnectionFailed(e))
-                } else {
+        connectJob =
+            scope.launch {
+                var connectFailed = false
+                try {
+                    physicalConnection.connect()
+                } catch (e: CancellationException) {
                     throw e
-                }
-            } finally {
-                connecting.store(false)
-                if (connectFailed) {
-                    // Clean up routing job to prevent zombie collectors
-                    routingJob?.cancel()
-                    routingJob = null
+                } catch (e: Exception) {
+                    connectFailed = true
+                    if (onEvent != null) {
+                        safeOnEvent(MultiplexerEvent.ConnectionFailed(e))
+                    } else {
+                        throw e
+                    }
+                } finally {
+                    connecting.store(false)
+                    if (connectFailed) {
+                        // Clean up routing job to prevent zombie collectors
+                        routingJob?.cancel()
+                        routingJob = null
+                    }
                 }
             }
-        }
     }
 
     /**
@@ -133,41 +134,42 @@ class ClientConnectionMultiplexer<A : Action>(
     }
 
     private fun startRouting() {
-        routingJob = scope.launch {
-            var transportError: Exception? = null
-            try {
-                physicalConnection.incoming.collect { routedAction ->
-                    val roomId = routedAction.roomId
-                    val virtualConnection = mutex.withLock { rooms[roomId] }
-                    if (virtualConnection != null) {
-                        val result = virtualConnection.channel.trySend(routedAction.action)
-                        if (result.isFailure) {
-                            safeOnEvent(MultiplexerEvent.MessageDropped(roomId))
+        routingJob =
+            scope.launch {
+                var transportError: Exception? = null
+                try {
+                    physicalConnection.incoming.collect { routedAction ->
+                        val roomId = routedAction.roomId
+                        val virtualConnection = mutex.withLock { rooms[roomId] }
+                        if (virtualConnection != null) {
+                            val result = virtualConnection.channel.trySend(routedAction.action)
+                            if (result.isFailure) {
+                                safeOnEvent(MultiplexerEvent.MessageDropped(roomId))
+                            }
                         }
+                        // Unknown rooms: silent drop (as per design decision)
                     }
-                    // Unknown rooms: silent drop (as per design decision)
-                }
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                transportError = e
-                if (onEvent != null) {
-                    safeOnEvent(MultiplexerEvent.RoutingStopped(e))
-                } else {
+                } catch (e: CancellationException) {
                     throw e
+                } catch (e: Exception) {
+                    transportError = e
+                    if (onEvent != null) {
+                        safeOnEvent(MultiplexerEvent.RoutingStopped(e))
+                    } else {
+                        throw e
+                    }
+                } finally {
+                    // Transport error: clean up physical connection to avoid zombie state
+                    // (routing dead but connection alive). Skipped on normal cancellation
+                    // since disconnect()/close() already handle cleanup.
+                    // Must disconnect before resetting connecting flag to prevent a
+                    // concurrent connect() from starting a new connection that we then kill.
+                    if (transportError != null) {
+                        physicalConnection.disconnect()
+                    }
+                    connecting.store(false)
                 }
-            } finally {
-                // Transport error: clean up physical connection to avoid zombie state
-                // (routing dead but connection alive). Skipped on normal cancellation
-                // since disconnect()/close() already handle cleanup.
-                // Must disconnect before resetting connecting flag to prevent a
-                // concurrent connect() from starting a new connection that we then kill.
-                if (transportError != null) {
-                    physicalConnection.disconnect()
-                }
-                connecting.store(false)
             }
-        }
     }
 
     /**
@@ -187,9 +189,10 @@ class ClientConnectionMultiplexer<A : Action>(
      * @param roomId The room identifier to remove
      */
     suspend fun removeRoom(roomId: String) {
-        val virtualConnection = mutex.withLock {
-            rooms.remove(roomId)
-        }
+        val virtualConnection =
+            mutex.withLock {
+                rooms.remove(roomId)
+            }
         virtualConnection?.channel?.close()
     }
 
@@ -219,11 +222,12 @@ class ClientConnectionMultiplexer<A : Action>(
      */
     suspend fun close() {
         closed.store(true)
-        val virtualConnections = mutex.withLock {
-            val connections = rooms.values.toList()
-            rooms.clear()
-            connections
-        }
+        val virtualConnections =
+            mutex.withLock {
+                val connections = rooms.values.toList()
+                rooms.clear()
+                connections
+            }
         virtualConnections.forEach { it.channel.close() }
         connecting.store(false)
         val routingSnapshot = routingJob
@@ -253,9 +257,7 @@ class ClientConnectionMultiplexer<A : Action>(
         }
     }
 
-    private inner class VirtualClientConnection(
-        private val roomId: String,
-    ) : TypedClientConnection<A> {
+    private inner class VirtualClientConnection(private val roomId: String) : TypedClientConnection<A> {
         val channel = Channel<A>(Channel.BUFFERED)
 
         override val connectionState: StateFlow<ConnectionState> =

--- a/kotlin/remote/multiplexer/src/commonMain/kotlin/io/flowdux/remote/multiplexer/RoutedAction.kt
+++ b/kotlin/remote/multiplexer/src/commonMain/kotlin/io/flowdux/remote/multiplexer/RoutedAction.kt
@@ -19,7 +19,4 @@ import kotlinx.serialization.Serializable
  * @property action The actual action being transmitted
  */
 @Serializable
-data class RoutedAction<A : Action>(
-    val roomId: String,
-    val action: A,
-) : Action
+data class RoutedAction<A : Action>(val roomId: String, val action: A) : Action

--- a/kotlin/remote/multiplexer/src/commonMain/kotlin/io/flowdux/remote/multiplexer/ServerConnectionMultiplexer.kt
+++ b/kotlin/remote/multiplexer/src/commonMain/kotlin/io/flowdux/remote/multiplexer/ServerConnectionMultiplexer.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlin.concurrent.Volatile
 
 /**
  * Server-side connection multiplexer that routes actions to/from multiple rooms

--- a/kotlin/remote/multiplexer/src/commonMain/kotlin/io/flowdux/remote/multiplexer/ServerConnectionMultiplexer.kt
+++ b/kotlin/remote/multiplexer/src/commonMain/kotlin/io/flowdux/remote/multiplexer/ServerConnectionMultiplexer.kt
@@ -12,7 +12,8 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlin.concurrent.Volatile
+import kotlin.concurrent.atomics.AtomicBoolean
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
 
 /**
  * Server-side connection multiplexer that routes actions to/from multiple rooms
@@ -52,6 +53,7 @@ import kotlin.concurrent.Volatile
  *        When provided, transport exceptions are reported via [MultiplexerEvent.RoutingStopped].
  *        When absent, transport exceptions propagate to [scope] via structured concurrency.
  */
+@OptIn(ExperimentalAtomicApi::class)
 class ServerConnectionMultiplexer<A : Action>(
     private val physicalConnection: TypedServerConnection<RoutedAction<A>>,
     private val scope: CoroutineScope,
@@ -61,8 +63,7 @@ class ServerConnectionMultiplexer<A : Action>(
     private val mutex = Mutex()
     private val rooms = mutableMapOf<String, VirtualServerConnection>()
     private var routingJob: Job? = null
-    @Volatile
-    private var closed = false
+    private val closed = AtomicBoolean(false)
 
     init {
         startRouting()
@@ -118,7 +119,7 @@ class ServerConnectionMultiplexer<A : Action>(
      * @return A [TypedServerConnection] scoped to the specified room
      */
     suspend fun getOrCreateRoom(roomId: String): TypedServerConnection<A> = mutex.withLock {
-        check(!closed) { "Multiplexer is closed" }
+        check(!closed.load()) { "Multiplexer is closed" }
         rooms.getOrPut(roomId) { VirtualServerConnection(roomId) }
     }
 
@@ -158,21 +159,23 @@ class ServerConnectionMultiplexer<A : Action>(
      * and clears the room registry. After closing, no new rooms can be created.
      */
     suspend fun close() {
+        if (!closed.compareAndSet(expectedValue = false, newValue = true)) return
         val virtualConnections = mutex.withLock {
-            closed = true
             val connections = rooms.values.toList()
             rooms.clear()
             connections
         }
         virtualConnections.forEach { it.channel.close() }
-        routingJob?.cancel()
+        val routingSnapshot = routingJob
+        routingJob = null
+
+        routingSnapshot?.cancel()
         // Guard against self-join: skip join() if called from within the routing
         // coroutine (e.g., from onUnknownRoom callback) to avoid deadlock.
         val callerJob = currentCoroutineContext()[Job]
-        if (routingJob != null && callerJob != routingJob) {
-            routingJob?.join()
+        if (routingSnapshot != null && callerJob != routingSnapshot) {
+            routingSnapshot.join()
         }
-        routingJob = null
     }
 
     private inner class VirtualServerConnection(
@@ -180,7 +183,7 @@ class ServerConnectionMultiplexer<A : Action>(
     ) : TypedServerConnection<A> {
         val channel = Channel<A>(Channel.BUFFERED)
 
-        override val isActive: Boolean get() = physicalConnection.isActive && !closed
+        override val isActive: Boolean get() = physicalConnection.isActive && !closed.load()
         override val incoming: Flow<A> = channel.receiveAsFlow()
 
         override suspend fun send(action: A) {

--- a/kotlin/remote/multiplexer/src/commonMain/kotlin/io/flowdux/remote/multiplexer/ServerConnectionMultiplexer.kt
+++ b/kotlin/remote/multiplexer/src/commonMain/kotlin/io/flowdux/remote/multiplexer/ServerConnectionMultiplexer.kt
@@ -70,38 +70,39 @@ class ServerConnectionMultiplexer<A : Action>(
     }
 
     private fun startRouting() {
-        routingJob = scope.launch {
-            try {
-                physicalConnection.incoming.collect { routedAction ->
-                    val roomId = routedAction.roomId
-                    val virtualConnection = mutex.withLock { rooms[roomId] }
-                    if (virtualConnection != null) {
-                        val result = virtualConnection.channel.trySend(routedAction.action)
-                        if (result.isFailure) {
-                            safeOnEvent(MultiplexerEvent.MessageDropped(roomId))
+        routingJob =
+            scope.launch {
+                try {
+                    physicalConnection.incoming.collect { routedAction ->
+                        val roomId = routedAction.roomId
+                        val virtualConnection = mutex.withLock { rooms[roomId] }
+                        if (virtualConnection != null) {
+                            val result = virtualConnection.channel.trySend(routedAction.action)
+                            if (result.isFailure) {
+                                safeOnEvent(MultiplexerEvent.MessageDropped(roomId))
+                            }
+                        } else if (onUnknownRoom != null) {
+                            try {
+                                onUnknownRoom.invoke(roomId, routedAction.action)
+                            } catch (e: CancellationException) {
+                                throw e
+                            } catch (e: Exception) {
+                                safeOnEvent(MultiplexerEvent.CallbackFailed(roomId, e))
+                            }
                         }
-                    } else if (onUnknownRoom != null) {
-                        try {
-                            onUnknownRoom.invoke(roomId, routedAction.action)
-                        } catch (e: CancellationException) {
-                            throw e
-                        } catch (e: Exception) {
-                            safeOnEvent(MultiplexerEvent.CallbackFailed(roomId, e))
-                        }
+                        // If no callback and unknown room: silent drop
                     }
-                    // If no callback and unknown room: silent drop
-                }
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                // Physical connection closed or transport error — routing stops.
-                if (onEvent != null) {
-                    safeOnEvent(MultiplexerEvent.RoutingStopped(e))
-                } else {
+                } catch (e: CancellationException) {
                     throw e
+                } catch (e: Exception) {
+                    // Physical connection closed or transport error — routing stops.
+                    if (onEvent != null) {
+                        safeOnEvent(MultiplexerEvent.RoutingStopped(e))
+                    } else {
+                        throw e
+                    }
                 }
             }
-        }
     }
 
     private fun safeOnEvent(event: MultiplexerEvent) {
@@ -129,9 +130,10 @@ class ServerConnectionMultiplexer<A : Action>(
      * @param roomId The room identifier to remove
      */
     suspend fun removeRoom(roomId: String) {
-        val virtualConnection = mutex.withLock {
-            rooms.remove(roomId)
-        }
+        val virtualConnection =
+            mutex.withLock {
+                rooms.remove(roomId)
+            }
         virtualConnection?.channel?.close()
     }
 
@@ -160,11 +162,12 @@ class ServerConnectionMultiplexer<A : Action>(
      */
     suspend fun close() {
         if (!closed.compareAndSet(expectedValue = false, newValue = true)) return
-        val virtualConnections = mutex.withLock {
-            val connections = rooms.values.toList()
-            rooms.clear()
-            connections
-        }
+        val virtualConnections =
+            mutex.withLock {
+                val connections = rooms.values.toList()
+                rooms.clear()
+                connections
+            }
         virtualConnections.forEach { it.channel.close() }
         val routingSnapshot = routingJob
         routingJob = null
@@ -178,9 +181,7 @@ class ServerConnectionMultiplexer<A : Action>(
         }
     }
 
-    private inner class VirtualServerConnection(
-        private val roomId: String,
-    ) : TypedServerConnection<A> {
+    private inner class VirtualServerConnection(private val roomId: String) : TypedServerConnection<A> {
         val channel = Channel<A>(Channel.BUFFERED)
 
         override val isActive: Boolean get() = physicalConnection.isActive && !closed.load()

--- a/kotlin/remote/multiplexer/src/commonTest/kotlin/io/flowdux/remote/multiplexer/ClientConnectionMultiplexerTest.kt
+++ b/kotlin/remote/multiplexer/src/commonTest/kotlin/io/flowdux/remote/multiplexer/ClientConnectionMultiplexerTest.kt
@@ -18,20 +18,19 @@ import kotlinx.coroutines.yield
 import kotlinx.serialization.Serializable
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class ClientConnectionMultiplexerTest {
-
     @Serializable
     sealed interface TestAction : Action {
         @Serializable data class Message(val text: String) : TestAction
+
         @Serializable data class Ping(val id: Int) : TestAction
     }
 
-    private fun routed(roomId: String, action: TestAction): RoutedAction<TestAction> =
-        RoutedAction(roomId, action)
+    private fun routed(roomId: String, action: TestAction): RoutedAction<TestAction> = RoutedAction(roomId, action)
 
     private class FakeTypedClientConnection<A : Action> : TypedClientConnection<RoutedAction<A>> {
         private val _connectionState = MutableStateFlow(ConnectionState.DISCONNECTED)
@@ -142,12 +141,14 @@ class ClientConnectionMultiplexerTest {
         val room1Actions = mutableListOf<TestAction>()
         val room2Actions = mutableListOf<TestAction>()
 
-        val job1 = launch {
-            room1.incoming.take(2).toList(room1Actions)
-        }
-        val job2 = launch {
-            room2.incoming.take(1).toList(room2Actions)
-        }
+        val job1 =
+            launch {
+                room1.incoming.take(2).toList(room1Actions)
+            }
+        val job2 =
+            launch {
+                room2.incoming.take(1).toList(room2Actions)
+            }
 
         // Allow collectors to start
         yield()
@@ -161,15 +162,17 @@ class ClientConnectionMultiplexerTest {
             job2.join()
         }
 
-        val expectedRoom1: List<TestAction> = listOf(
-            TestAction.Message("hello from room 1"),
-            TestAction.Ping(42),
-        )
+        val expectedRoom1: List<TestAction> =
+            listOf(
+                TestAction.Message("hello from room 1"),
+                TestAction.Ping(42),
+            )
         assertEquals(expectedRoom1, room1Actions)
 
-        val expectedRoom2: List<TestAction> = listOf(
-            TestAction.Message("hello from room 2"),
-        )
+        val expectedRoom2: List<TestAction> =
+            listOf(
+                TestAction.Message("hello from room 2"),
+            )
         assertEquals(expectedRoom2, room2Actions)
 
         mux.close()
@@ -205,9 +208,10 @@ class ClientConnectionMultiplexerTest {
         val room1 = mux.getOrCreateRoom("room-1")
         val room1Actions = mutableListOf<TestAction>()
 
-        val job = launch {
-            room1.incoming.take(1).toList(room1Actions)
-        }
+        val job =
+            launch {
+                room1.incoming.take(1).toList(room1Actions)
+            }
 
         // Allow collector to start
         yield()
@@ -282,9 +286,11 @@ class ClientConnectionMultiplexerTest {
         val mux = ClientConnectionMultiplexer(physical, this)
         mux.connect()
 
-        val results = (1..10).map {
-            async { mux.getOrCreateRoom("shared-room") }
-        }.awaitAll()
+        val results =
+            (1..10)
+                .map {
+                    async { mux.getOrCreateRoom("shared-room") }
+                }.awaitAll()
 
         // All should be the same instance
         val first = results.first()
@@ -303,9 +309,10 @@ class ClientConnectionMultiplexerTest {
         mux.getOrCreateRoom("room-1")
 
         // Multiple concurrent removes should not throw
-        val jobs = (1..5).map {
-            async { mux.removeRoom("room-1") }
-        }
+        val jobs =
+            (1..5).map {
+                async { mux.removeRoom("room-1") }
+            }
         jobs.awaitAll()
 
         assertFalse(mux.hasRoom("room-1"))
@@ -347,9 +354,10 @@ class ClientConnectionMultiplexerTest {
         val room1 = mux.getOrCreateRoom("room-1")
         val room1Actions = mutableListOf<TestAction>()
 
-        val job = launch {
-            room1.incoming.take(1).toList(room1Actions)
-        }
+        val job =
+            launch {
+                room1.incoming.take(1).toList(room1Actions)
+            }
         yield()
 
         physical.simulateIncoming(routed("room-1", TestAction.Message("hello")))

--- a/kotlin/remote/multiplexer/src/commonTest/kotlin/io/flowdux/remote/multiplexer/RoutedActionSerializationTest.kt
+++ b/kotlin/remote/multiplexer/src/commonTest/kotlin/io/flowdux/remote/multiplexer/RoutedActionSerializationTest.kt
@@ -2,26 +2,26 @@ package io.flowdux.remote.multiplexer
 
 import io.flowdux.Action
 import io.flowdux.remote.serialization.actionCodecOf
-import kotlinx.serialization.SerializationException
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class RoutedActionSerializationTest {
-
     @Serializable
     sealed interface TestAction : Action {
         @Serializable data object Increment : TestAction
+
         @Serializable data class Add(val value: Int) : TestAction
+
         @Serializable data class SetName(val name: String) : TestAction
     }
 
     private val routedCodec = actionCodecOf<RoutedAction<TestAction>>()
 
-    private fun routed(roomId: String, action: TestAction): RoutedAction<TestAction> =
-        RoutedAction(roomId, action)
+    private fun routed(roomId: String, action: TestAction): RoutedAction<TestAction> = RoutedAction(roomId, action)
 
     @Test
     fun encodeDecodeRoutedAction() {
@@ -50,14 +50,15 @@ class RoutedActionSerializationTest {
     @Test
     fun roundTripAllVariants() {
         val rooms = listOf("room-1", "room-2", "test-room", "")
-        val actions: List<TestAction> = listOf(
-            TestAction.Increment,
-            TestAction.Add(0),
-            TestAction.Add(-1),
-            TestAction.Add(Int.MAX_VALUE),
-            TestAction.SetName(""),
-            TestAction.SetName("hello"),
-        )
+        val actions: List<TestAction> =
+            listOf(
+                TestAction.Increment,
+                TestAction.Add(0),
+                TestAction.Add(-1),
+                TestAction.Add(Int.MAX_VALUE),
+                TestAction.SetName(""),
+                TestAction.SetName("hello"),
+            )
         for (roomId in rooms) {
             for (action in actions) {
                 val original = routed(roomId, action)

--- a/kotlin/remote/multiplexer/src/commonTest/kotlin/io/flowdux/remote/multiplexer/ServerConnectionMultiplexerTest.kt
+++ b/kotlin/remote/multiplexer/src/commonTest/kotlin/io/flowdux/remote/multiplexer/ServerConnectionMultiplexerTest.kt
@@ -15,20 +15,19 @@ import kotlinx.coroutines.yield
 import kotlinx.serialization.Serializable
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class ServerConnectionMultiplexerTest {
-
     @Serializable
     sealed interface TestAction : Action {
         @Serializable data class Message(val text: String) : TestAction
+
         @Serializable data class Ping(val id: Int) : TestAction
     }
 
-    private fun routed(roomId: String, action: TestAction): RoutedAction<TestAction> =
-        RoutedAction(roomId, action)
+    private fun routed(roomId: String, action: TestAction): RoutedAction<TestAction> = RoutedAction(roomId, action)
 
     private class FakeTypedServerConnection<A : Action> : TypedServerConnection<RoutedAction<A>> {
         override val isActive: Boolean = true
@@ -110,12 +109,14 @@ class ServerConnectionMultiplexerTest {
         val room1Actions = mutableListOf<TestAction>()
         val room2Actions = mutableListOf<TestAction>()
 
-        val job1 = launch {
-            room1.incoming.take(2).toList(room1Actions)
-        }
-        val job2 = launch {
-            room2.incoming.take(1).toList(room2Actions)
-        }
+        val job1 =
+            launch {
+                room1.incoming.take(2).toList(room1Actions)
+            }
+        val job2 =
+            launch {
+                room2.incoming.take(1).toList(room2Actions)
+            }
 
         // Allow collectors to start
         yield()
@@ -129,15 +130,17 @@ class ServerConnectionMultiplexerTest {
             job2.join()
         }
 
-        val expectedRoom1: List<TestAction> = listOf(
-            TestAction.Message("hello from room 1"),
-            TestAction.Ping(42),
-        )
+        val expectedRoom1: List<TestAction> =
+            listOf(
+                TestAction.Message("hello from room 1"),
+                TestAction.Ping(42),
+            )
         assertEquals(expectedRoom1, room1Actions)
 
-        val expectedRoom2: List<TestAction> = listOf(
-            TestAction.Message("hello from room 2"),
-        )
+        val expectedRoom2: List<TestAction> =
+            listOf(
+                TestAction.Message("hello from room 2"),
+            )
         assertEquals(expectedRoom2, room2Actions)
 
         mux.close()
@@ -171,9 +174,10 @@ class ServerConnectionMultiplexerTest {
         val room1 = mux.getOrCreateRoom("room-1")
         val room1Actions = mutableListOf<TestAction>()
 
-        val job = launch {
-            room1.incoming.take(1).toList(room1Actions)
-        }
+        val job =
+            launch {
+                room1.incoming.take(1).toList(room1Actions)
+            }
 
         // Allow collector to start
         yield()
@@ -226,9 +230,11 @@ class ServerConnectionMultiplexerTest {
         val physical = FakeTypedServerConnection<TestAction>()
         val mux = ServerConnectionMultiplexer(physical, this)
 
-        val results = (1..10).map {
-            async { mux.getOrCreateRoom("shared-room") }
-        }.awaitAll()
+        val results =
+            (1..10)
+                .map {
+                    async { mux.getOrCreateRoom("shared-room") }
+                }.awaitAll()
 
         // All should be the same instance
         val first = results.first()
@@ -246,9 +252,10 @@ class ServerConnectionMultiplexerTest {
         mux.getOrCreateRoom("room-1")
 
         // Multiple concurrent removes should not throw
-        val jobs = (1..5).map {
-            async { mux.removeRoom("room-1") }
-        }
+        val jobs =
+            (1..5).map {
+                async { mux.removeRoom("room-1") }
+            }
         jobs.awaitAll()
 
         assertFalse(mux.hasRoom("room-1"))
@@ -278,11 +285,12 @@ class ServerConnectionMultiplexerTest {
         val physical = FakeTypedServerConnection<TestAction>()
         val receivedCalls = mutableListOf<Pair<String, TestAction>>()
 
-        val mux = ServerConnectionMultiplexer(
-            physicalConnection = physical,
-            scope = this,
-            onUnknownRoom = { roomId, action -> receivedCalls.add(roomId to action) },
-        )
+        val mux =
+            ServerConnectionMultiplexer(
+                physicalConnection = physical,
+                scope = this,
+                onUnknownRoom = { roomId, action -> receivedCalls.add(roomId to action) },
+            )
 
         yield()
 
@@ -302,22 +310,24 @@ class ServerConnectionMultiplexerTest {
         val physical = FakeTypedServerConnection<TestAction>()
         var callCount = 0
 
-        val mux = ServerConnectionMultiplexer(
-            physicalConnection = physical,
-            scope = this,
-            onUnknownRoom = { _, _ ->
-                callCount++
-                if (callCount == 1) throw RuntimeException("callback error")
-            },
-        )
+        val mux =
+            ServerConnectionMultiplexer(
+                physicalConnection = physical,
+                scope = this,
+                onUnknownRoom = { _, _ ->
+                    callCount++
+                    if (callCount == 1) throw RuntimeException("callback error")
+                },
+            )
 
         // Also create a known room to verify routing continues
         val room1 = mux.getOrCreateRoom("room-1")
         val room1Actions = mutableListOf<TestAction>()
 
-        val job = launch {
-            room1.incoming.take(1).toList(room1Actions)
-        }
+        val job =
+            launch {
+                room1.incoming.take(1).toList(room1Actions)
+            }
         yield()
 
         // First unknown room triggers exception in callback
@@ -347,22 +357,24 @@ class ServerConnectionMultiplexerTest {
 
         // Race: coroutines create rooms while another closes the multiplexer.
         // getOrCreateRoom should either succeed or throw ISE — never corrupt state.
-        val createJobs = (1..10).map { i ->
-            async {
-                // Yield to allow interleaving with the close coroutine
-                yield()
-                try {
-                    mux.getOrCreateRoom("room-$i")
-                    true
-                } catch (_: IllegalStateException) {
-                    false // Expected: "Multiplexer is closed"
+        val createJobs =
+            (1..10).map { i ->
+                async {
+                    // Yield to allow interleaving with the close coroutine
+                    yield()
+                    try {
+                        mux.getOrCreateRoom("room-$i")
+                        true
+                    } catch (_: IllegalStateException) {
+                        false // Expected: "Multiplexer is closed"
+                    }
                 }
             }
-        }
-        val closeJob = async {
-            yield()
-            mux.close()
-        }
+        val closeJob =
+            async {
+                yield()
+                mux.close()
+            }
 
         // Advance all coroutines to ensure interleaving
         createJobs.awaitAll()
@@ -383,9 +395,10 @@ class ServerConnectionMultiplexerTest {
         mux.getOrCreateRoom("room-2")
 
         // Multiple concurrent close calls should not throw
-        val jobs = (1..5).map {
-            async { mux.close() }
-        }
+        val jobs =
+            (1..5).map {
+                async { mux.close() }
+            }
         jobs.awaitAll()
 
         assertEquals(emptySet(), mux.roomIds())
@@ -404,9 +417,10 @@ class ServerConnectionMultiplexerTest {
 
         // Start collecting from room-1
         val room1Actions = mutableListOf<TestAction>()
-        val collectJob = launch {
-            room1.incoming.collect { room1Actions.add(it) }
-        }
+        val collectJob =
+            launch {
+                room1.incoming.collect { room1Actions.add(it) }
+            }
         yield()
 
         // Route a message, then concurrently remove the room while routing continues
@@ -414,9 +428,10 @@ class ServerConnectionMultiplexerTest {
         yield()
 
         // Concurrent: remove room while routing job may still reference it
-        val removeJob = async {
-            mux.removeRoom("room-1")
-        }
+        val removeJob =
+            async {
+                mux.removeRoom("room-1")
+            }
         physical.simulateIncoming(routed("room-1", TestAction.Message("during-remove")))
         yield()
 
@@ -430,9 +445,10 @@ class ServerConnectionMultiplexerTest {
         // room-2 should still work normally after room-1 removal
         val room2 = mux.getOrCreateRoom("room-2")
         val room2Actions = mutableListOf<TestAction>()
-        val job = launch {
-            room2.incoming.take(1).toList(room2Actions)
-        }
+        val job =
+            launch {
+                room2.incoming.take(1).toList(room2Actions)
+            }
         yield()
 
         physical.simulateIncoming(routed("room-2", TestAction.Message("still works")))

--- a/kotlin/remote/multiplexer/src/commonTest/kotlin/io/flowdux/remote/multiplexer/ServerConnectionMultiplexerTest.kt
+++ b/kotlin/remote/multiplexer/src/commonTest/kotlin/io/flowdux/remote/multiplexer/ServerConnectionMultiplexerTest.kt
@@ -341,6 +341,111 @@ class ServerConnectionMultiplexerTest {
     }
 
     @Test
+    fun concurrentGetOrCreateRoomAndCloseDoesNotCorruptState() = runTest {
+        val physical = FakeTypedServerConnection<TestAction>()
+        val mux = ServerConnectionMultiplexer(physical, this)
+
+        // Race: coroutines create rooms while another closes the multiplexer.
+        // getOrCreateRoom should either succeed or throw ISE — never corrupt state.
+        val createJobs = (1..10).map { i ->
+            async {
+                // Yield to allow interleaving with the close coroutine
+                yield()
+                try {
+                    mux.getOrCreateRoom("room-$i")
+                    true
+                } catch (_: IllegalStateException) {
+                    false // Expected: "Multiplexer is closed"
+                }
+            }
+        }
+        val closeJob = async {
+            yield()
+            mux.close()
+        }
+
+        // Advance all coroutines to ensure interleaving
+        createJobs.awaitAll()
+        closeJob.await()
+
+        // After close, new rooms must be rejected
+        assertFailsWith<IllegalStateException> {
+            mux.getOrCreateRoom("room-after-close")
+        }
+    }
+
+    @Test
+    fun concurrentCloseIsSafe() = runTest {
+        val physical = FakeTypedServerConnection<TestAction>()
+        val mux = ServerConnectionMultiplexer(physical, this)
+
+        mux.getOrCreateRoom("room-1")
+        mux.getOrCreateRoom("room-2")
+
+        // Multiple concurrent close calls should not throw
+        val jobs = (1..5).map {
+            async { mux.close() }
+        }
+        jobs.awaitAll()
+
+        assertEquals(emptySet(), mux.roomIds())
+        assertFailsWith<IllegalStateException> {
+            mux.getOrCreateRoom("room-3")
+        }
+    }
+
+    @Test
+    fun removeRoomWhileRoutingMessagesIsSafe() = runTest {
+        val physical = FakeTypedServerConnection<TestAction>()
+        val mux = ServerConnectionMultiplexer(physical, this)
+
+        val room1 = mux.getOrCreateRoom("room-1")
+        mux.getOrCreateRoom("room-2")
+
+        // Start collecting from room-1
+        val room1Actions = mutableListOf<TestAction>()
+        val collectJob = launch {
+            room1.incoming.collect { room1Actions.add(it) }
+        }
+        yield()
+
+        // Route a message, then concurrently remove the room while routing continues
+        physical.simulateIncoming(routed("room-1", TestAction.Message("msg-1")))
+        yield()
+
+        // Concurrent: remove room while routing job may still reference it
+        val removeJob = async {
+            mux.removeRoom("room-1")
+        }
+        physical.simulateIncoming(routed("room-1", TestAction.Message("during-remove")))
+        yield()
+
+        removeJob.await()
+        assertFalse(mux.hasRoom("room-1"))
+
+        // Messages to removed room should be silently dropped (no crash)
+        physical.simulateIncoming(routed("room-1", TestAction.Message("after-remove")))
+        yield()
+
+        // room-2 should still work normally after room-1 removal
+        val room2 = mux.getOrCreateRoom("room-2")
+        val room2Actions = mutableListOf<TestAction>()
+        val job = launch {
+            room2.incoming.take(1).toList(room2Actions)
+        }
+        yield()
+
+        physical.simulateIncoming(routed("room-2", TestAction.Message("still works")))
+        withTimeout(1000) { job.join() }
+
+        val expected: List<TestAction> = listOf(TestAction.Message("still works"))
+        assertEquals(expected, room2Actions)
+
+        collectJob.cancel()
+        mux.close()
+    }
+
+    @Test
     fun removeRoomForNonexistentRoomIsSafe() = runTest {
         val physical = FakeTypedServerConnection<TestAction>()
         val mux = ServerConnectionMultiplexer(physical, this)

--- a/kotlin/remote/node-mediator/build.gradle.kts
+++ b/kotlin/remote/node-mediator/build.gradle.kts
@@ -49,6 +49,7 @@ kotlin {
         commonTest.dependencies {
             implementation(kotlin("test"))
             implementation(libs.kotlinx.coroutines.test)
+            implementation(libs.turbine)
         }
     }
 

--- a/kotlin/remote/node-mediator/build.gradle.kts
+++ b/kotlin/remote/node-mediator/build.gradle.kts
@@ -5,7 +5,11 @@ plugins {
 }
 
 mavenPublishing {
-    coordinates("io.github.chibimoons", "flowdux-remote-node-mediator", providers.gradleProperty("flowdux.version").get())
+    coordinates(
+        "io.github.chibimoons",
+        "flowdux-remote-node-mediator",
+        providers.gradleProperty("flowdux.version").get(),
+    )
     pom {
         name.set("Flowdux Remote Node Mediator")
         description.set("Node mediator for horizontal scaling across multiple server nodes")

--- a/kotlin/remote/node-mediator/build.gradle.kts
+++ b/kotlin/remote/node-mediator/build.gradle.kts
@@ -13,7 +13,7 @@ mavenPublishing {
 }
 
 // JitPack only publishes JVM artifacts to avoid variant resolution issues for JVM/Android consumers
-val isJitPack = System.getenv("JITPACK") == "true"
+val isJitPack = providers.environmentVariable("JITPACK").map { it == "true" }.getOrElse(false)
 
 kotlin {
     jvm()

--- a/kotlin/remote/node-mediator/src/commonMain/kotlin/io/flowdux/remote/nodemediator/CentralNodeManager.kt
+++ b/kotlin/remote/node-mediator/src/commonMain/kotlin/io/flowdux/remote/nodemediator/CentralNodeManager.kt
@@ -63,10 +63,7 @@ class CentralNodeManager<A : Action>(
     private val nodes = mutableMapOf<String, NodeEntry>()
     private var closed = false
 
-    private inner class NodeEntry(
-        val connection: TypedServerConnection<NodeAction<A>>,
-        val job: Job,
-    )
+    private inner class NodeEntry(val connection: TypedServerConnection<NodeAction<A>>, val job: Job)
 
     /**
      * Handles a node connection.
@@ -79,10 +76,7 @@ class CentralNodeManager<A : Action>(
      * @param nodeId Unique identifier for the connecting node
      * @param connection The typed connection from the node
      */
-    suspend fun handleNode(
-        nodeId: String,
-        connection: TypedServerConnection<NodeAction<A>>,
-    ) {
+    suspend fun handleNode(nodeId: String, connection: TypedServerConnection<NodeAction<A>>) {
         check(!closed) { "CentralNodeManager is closed" }
 
         val callerJob = currentCoroutineContext()[Job]!!
@@ -237,12 +231,13 @@ class CentralNodeManager<A : Action>(
      * After closing, no new nodes can connect.
      */
     suspend fun close() {
-        val entries = mutex.withLock {
-            closed = true
-            val current = nodes.values.toList()
-            nodes.clear()
-            current
-        }
+        val entries =
+            mutex.withLock {
+                closed = true
+                val current = nodes.values.toList()
+                nodes.clear()
+                current
+            }
         for (entry in entries) {
             entry.job.cancel()
         }

--- a/kotlin/remote/node-mediator/src/commonMain/kotlin/io/flowdux/remote/nodemediator/CentralNodeManager.kt
+++ b/kotlin/remote/node-mediator/src/commonMain/kotlin/io/flowdux/remote/nodemediator/CentralNodeManager.kt
@@ -18,6 +18,14 @@ import kotlinx.coroutines.withContext
  * Runs alongside the Central Store and routes actions to/from connected nodes.
  * Each node connects via a single [TypedServerConnection] carrying [NodeAction] messages.
  *
+ * ## Reconnection and split-brain prevention
+ *
+ * When a node reconnects with the same `nodeId` while its previous connection is still
+ * registered, the new connection replaces the old one. Room assignments in the [RoomRegistry]
+ * are preserved across reconnection — the old connection's cleanup does **not** unassign
+ * rooms that now belong to the replacement. A [NodeMediatorEvent.NodeReconnected] event
+ * is emitted to distinguish reconnections from fresh connections.
+ *
  * Usage:
  * ```kotlin
  * val roomRegistry = InMemoryRoomRegistry()
@@ -82,10 +90,16 @@ class CentralNodeManager<A : Action>(
         var cause: Exception? = null
 
         try {
-            safeOnEvent(NodeMediatorEvent.NodeConnected(nodeId))
-
-            mutex.withLock {
+            val isReconnect = mutex.withLock {
+                val previous = nodes[nodeId]
                 nodes[nodeId] = entry
+                previous != null
+            }
+
+            if (isReconnect) {
+                safeOnEvent(NodeMediatorEvent.NodeReconnected(nodeId))
+            } else {
+                safeOnEvent(NodeMediatorEvent.NodeConnected(nodeId))
             }
 
             connection.incoming.collect { nodeAction ->
@@ -103,16 +117,30 @@ class CentralNodeManager<A : Action>(
             cause = e
         } finally {
             withContext(NonCancellable) {
-                mutex.withLock {
+                val shouldCleanupRooms = mutex.withLock {
                     // Only remove if this entry is still the current one (not replaced by a newer connection)
                     if (nodes[nodeId] === entry) {
                         nodes.remove(nodeId)
+                        true
+                    } else {
+                        false
                     }
                 }
-                // Remove room assignments for disconnected node
-                val rooms = roomRegistry.getRoomsForNode(nodeId)
-                for (roomId in rooms) {
-                    roomRegistry.unassignRoom(roomId)
+                // Only unassign rooms if this connection was NOT replaced by a newer one.
+                // When a node reconnects, the new connection takes over room ownership,
+                // and the old connection's cleanup must not revoke those assignments.
+                if (shouldCleanupRooms) {
+                    // Re-check that no new connection registered with this nodeId
+                    // between our removal and room cleanup. This prevents a race where
+                    // a new handleNode() registers the same nodeId after we released the
+                    // mutex but before room cleanup starts.
+                    val replacedSinceRemoval = mutex.withLock { nodes.containsKey(nodeId) }
+                    if (!replacedSinceRemoval) {
+                        val rooms = roomRegistry.getRoomsForNode(nodeId)
+                        for (roomId in rooms) {
+                            roomRegistry.unassignRoom(roomId)
+                        }
+                    }
                 }
             }
             safeOnEvent(NodeMediatorEvent.NodeDisconnected(nodeId, cause))

--- a/kotlin/remote/node-mediator/src/commonMain/kotlin/io/flowdux/remote/nodemediator/NodeAction.kt
+++ b/kotlin/remote/node-mediator/src/commonMain/kotlin/io/flowdux/remote/nodemediator/NodeAction.kt
@@ -19,7 +19,4 @@ import kotlinx.serialization.Serializable
  * @property action The actual action being transmitted
  */
 @Serializable
-data class NodeAction<A : Action>(
-    val roomId: String,
-    val action: A,
-) : Action
+data class NodeAction<A : Action>(val roomId: String, val action: A) : Action

--- a/kotlin/remote/node-mediator/src/commonMain/kotlin/io/flowdux/remote/nodemediator/NodeMediator.kt
+++ b/kotlin/remote/node-mediator/src/commonMain/kotlin/io/flowdux/remote/nodemediator/NodeMediator.kt
@@ -83,27 +83,28 @@ class NodeMediator<A : Action>(
         }
 
         startRouting()
-        connectJob = scope.launch {
-            var connectFailed = false
-            try {
-                transport.connect()
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                connectFailed = true
-                if (onEvent != null) {
-                    safeOnEvent(NodeMediatorEvent.ConnectionFailed(e))
-                } else {
+        connectJob =
+            scope.launch {
+                var connectFailed = false
+                try {
+                    transport.connect()
+                } catch (e: CancellationException) {
                     throw e
-                }
-            } finally {
-                connecting.store(false)
-                if (connectFailed) {
-                    routingJob?.cancel()
-                    routingJob = null
+                } catch (e: Exception) {
+                    connectFailed = true
+                    if (onEvent != null) {
+                        safeOnEvent(NodeMediatorEvent.ConnectionFailed(e))
+                    } else {
+                        throw e
+                    }
+                } finally {
+                    connecting.store(false)
+                    if (connectFailed) {
+                        routingJob?.cancel()
+                        routingJob = null
+                    }
                 }
             }
-        }
     }
 
     /**
@@ -132,48 +133,49 @@ class NodeMediator<A : Action>(
     }
 
     private fun startRouting() {
-        routingJob = scope.launch {
-            var transportError: Exception? = null
-            try {
-                transport.incoming.collect { nodeAction ->
-                    val roomId = nodeAction.roomId
-                    val handler = mutex.withLock { rooms[roomId] }
-                    if (handler != null) {
-                        try {
-                            handler.invoke(nodeAction.action)
-                        } catch (e: CancellationException) {
-                            throw e
-                        } catch (e: Exception) {
-                            safeOnEvent(NodeMediatorEvent.CallbackFailed(roomId, e))
+        routingJob =
+            scope.launch {
+                var transportError: Exception? = null
+                try {
+                    transport.incoming.collect { nodeAction ->
+                        val roomId = nodeAction.roomId
+                        val handler = mutex.withLock { rooms[roomId] }
+                        if (handler != null) {
+                            try {
+                                handler.invoke(nodeAction.action)
+                            } catch (e: CancellationException) {
+                                throw e
+                            } catch (e: Exception) {
+                                safeOnEvent(NodeMediatorEvent.CallbackFailed(roomId, e))
+                            }
+                        } else if (onUnknownRoom != null) {
+                            try {
+                                onUnknownRoom.invoke(roomId, nodeAction.action)
+                            } catch (e: CancellationException) {
+                                throw e
+                            } catch (e: Exception) {
+                                safeOnEvent(NodeMediatorEvent.CallbackFailed(roomId, e))
+                            }
+                        } else {
+                            safeOnEvent(NodeMediatorEvent.MessageDropped(roomId))
                         }
-                    } else if (onUnknownRoom != null) {
-                        try {
-                            onUnknownRoom.invoke(roomId, nodeAction.action)
-                        } catch (e: CancellationException) {
-                            throw e
-                        } catch (e: Exception) {
-                            safeOnEvent(NodeMediatorEvent.CallbackFailed(roomId, e))
-                        }
-                    } else {
-                        safeOnEvent(NodeMediatorEvent.MessageDropped(roomId))
                     }
-                }
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                transportError = e
-                if (onEvent != null) {
-                    safeOnEvent(NodeMediatorEvent.RoutingStopped(e))
-                } else {
+                } catch (e: CancellationException) {
                     throw e
+                } catch (e: Exception) {
+                    transportError = e
+                    if (onEvent != null) {
+                        safeOnEvent(NodeMediatorEvent.RoutingStopped(e))
+                    } else {
+                        throw e
+                    }
+                } finally {
+                    if (transportError != null) {
+                        transport.disconnect()
+                    }
+                    connecting.store(false)
                 }
-            } finally {
-                if (transportError != null) {
-                    transport.disconnect()
-                }
-                connecting.store(false)
             }
-        }
     }
 
     /**

--- a/kotlin/remote/node-mediator/src/commonMain/kotlin/io/flowdux/remote/nodemediator/NodeMediatorEvent.kt
+++ b/kotlin/remote/node-mediator/src/commonMain/kotlin/io/flowdux/remote/nodemediator/NodeMediatorEvent.kt
@@ -18,6 +18,7 @@ package io.flowdux.remote.nodemediator
  *             is NodeMediatorEvent.ConnectionFailed -> logger.error("Connection failed", event.cause)
  *             is NodeMediatorEvent.NodeDisconnected -> logger.info("Node ${event.nodeId} disconnected")
  *             is NodeMediatorEvent.NodeConnected -> logger.info("Node ${event.nodeId} connected")
+ *             is NodeMediatorEvent.NodeReconnected -> logger.info("Node ${event.nodeId} reconnected")
  *             is NodeMediatorEvent.CallbackFailed -> logger.error("Callback failed", event.cause)
  *         }
  *     },
@@ -54,6 +55,13 @@ sealed interface NodeMediatorEvent {
      * Emitted by [CentralNodeManager] when a node establishes a connection.
      */
     data class NodeConnected(val nodeId: String) : NodeMediatorEvent
+
+    /**
+     * A node reconnected to the Central server while its previous connection was still registered.
+     * Emitted by [CentralNodeManager] when a node connects with a nodeId that is already present.
+     * Room assignments are preserved across reconnection.
+     */
+    data class NodeReconnected(val nodeId: String) : NodeMediatorEvent
 
     /**
      * An [NodeMediator.onUnknownRoom] or [CentralNodeManager.onUpstreamAction] callback

--- a/kotlin/remote/node-mediator/src/commonMain/kotlin/io/flowdux/remote/nodemediator/NodeMediatorExt.kt
+++ b/kotlin/remote/node-mediator/src/commonMain/kotlin/io/flowdux/remote/nodemediator/NodeMediatorExt.kt
@@ -30,9 +30,7 @@ import kotlinx.serialization.json.Json
  */
 inline fun <reified A : Action> ClientConnection.typedNodeActionJson(
     json: Json = SerializableActionCodec.DefaultJson,
-): TypedClientConnection<NodeAction<A>> {
-    return typed(actionCodecOf<NodeAction<A>>(json), JsonMessageCodec())
-}
+): TypedClientConnection<NodeAction<A>> = typed(actionCodecOf<NodeAction<A>>(json), JsonMessageCodec())
 
 /**
  * Creates a [TypedServerConnection] for [NodeAction] using JSON serialization.
@@ -52,9 +50,7 @@ inline fun <reified A : Action> ClientConnection.typedNodeActionJson(
  */
 inline fun <reified A : Action> ServerConnection.typedNodeActionJson(
     json: Json = SerializableActionCodec.DefaultJson,
-): TypedServerConnection<NodeAction<A>> {
-    return typed(actionCodecOf<NodeAction<A>>(json), JsonMessageCodec())
-}
+): TypedServerConnection<NodeAction<A>> = typed(actionCodecOf<NodeAction<A>>(json), JsonMessageCodec())
 
 /**
  * Creates a [WebSocketNodeTransport] for [NodeAction] using JSON serialization.
@@ -72,6 +68,4 @@ inline fun <reified A : Action> ServerConnection.typedNodeActionJson(
  */
 inline fun <reified A : Action> ClientConnection.webSocketNodeTransport(
     json: Json = SerializableActionCodec.DefaultJson,
-): NodeTransport<A> {
-    return WebSocketNodeTransport(typedNodeActionJson<A>(json))
-}
+): NodeTransport<A> = WebSocketNodeTransport(typedNodeActionJson<A>(json))

--- a/kotlin/remote/node-mediator/src/commonMain/kotlin/io/flowdux/remote/nodemediator/NodeRoomServer.kt
+++ b/kotlin/remote/node-mediator/src/commonMain/kotlin/io/flowdux/remote/nodemediator/NodeRoomServer.kt
@@ -77,20 +77,21 @@ class NodeRoomServer<S : State, A : Action>(
     val mediator: NodeMediator<A>
 
     init {
-        mediator = NodeMediator(
-            nodeId = nodeId,
-            transport = transport,
-            scope = scope,
-            onUnknownRoom = { roomId, action ->
-                // Central relayed to a room this node doesn't know about yet — auto-create it
-                val room = roomServer.getOrCreateRoom(roomId)
-                mediator.registerRoom(roomId) { centralAction ->
-                    room.store.dispatch(centralAction)
-                }
-                room.store.dispatch(action)
-            },
-            onEvent = onEvent,
-        )
+        mediator =
+            NodeMediator(
+                nodeId = nodeId,
+                transport = transport,
+                scope = scope,
+                onUnknownRoom = { roomId, action ->
+                    // Central relayed to a room this node doesn't know about yet — auto-create it
+                    val room = roomServer.getOrCreateRoom(roomId)
+                    mediator.registerRoom(roomId) { centralAction ->
+                        room.store.dispatch(centralAction)
+                    }
+                    room.store.dispatch(action)
+                },
+                onEvent = onEvent,
+            )
     }
 
     /**
@@ -122,11 +123,7 @@ class NodeRoomServer<S : State, A : Action>(
      * @param sessionId Unique identifier for this client session
      * @param connection Typed connection for sending/receiving actions
      */
-    suspend fun handleClient(
-        roomId: String,
-        sessionId: String,
-        connection: TypedServerConnection<A>,
-    ) {
+    suspend fun handleClient(roomId: String, sessionId: String, connection: TypedServerConnection<A>) {
         val room = roomServer.getOrCreateRoom(roomId)
         if (!mediator.hasRoom(roomId)) {
             mediator.registerRoom(roomId) { centralAction ->
@@ -219,18 +216,18 @@ private class ForwardingConnection<A : Action>(
     private val mediator: NodeMediator<A>,
     private val roomId: String,
 ) : TypedServerConnection<A> {
-
     override val isActive: Boolean get() = delegate.isActive
 
-    override val incoming: Flow<A> = delegate.incoming.onEach { action ->
-        try {
-            mediator.forwardToCentral(roomId, action)
-        } catch (e: CancellationException) {
-            throw e
-        } catch (_: Exception) {
-            // Forwarding failure should not disconnect the client
+    override val incoming: Flow<A> =
+        delegate.incoming.onEach { action ->
+            try {
+                mediator.forwardToCentral(roomId, action)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                // Forwarding failure should not disconnect the client
+            }
         }
-    }
 
     override suspend fun send(action: A) = delegate.send(action)
 }

--- a/kotlin/remote/node-mediator/src/commonMain/kotlin/io/flowdux/remote/nodemediator/registry/InMemoryRoomRegistry.kt
+++ b/kotlin/remote/node-mediator/src/commonMain/kotlin/io/flowdux/remote/nodemediator/registry/InMemoryRoomRegistry.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.sync.withLock
  * implement [RoomRegistry] with an external store like Redis.
  */
 class InMemoryRoomRegistry : RoomRegistry {
-
     private val assignments = mutableMapOf<String, String>()
     private val mutex = Mutex()
 

--- a/kotlin/remote/node-mediator/src/commonMain/kotlin/io/flowdux/remote/nodemediator/transport/WebSocketNodeTransport.kt
+++ b/kotlin/remote/node-mediator/src/commonMain/kotlin/io/flowdux/remote/nodemediator/transport/WebSocketNodeTransport.kt
@@ -14,13 +14,17 @@ import kotlinx.coroutines.flow.Flow
  * @param A The type of actions being transported
  * @param connection The typed client connection to the Central server
  */
-class WebSocketNodeTransport<A : Action>(
-    private val connection: TypedClientConnection<NodeAction<A>>,
-) : NodeTransport<A> {
+class WebSocketNodeTransport<A : Action>(private val connection: TypedClientConnection<NodeAction<A>>) :
+    NodeTransport<A> {
     override val incoming: Flow<NodeAction<A>> = connection.incoming
+
     override suspend fun send(action: NodeAction<A>) = connection.send(action)
+
     override suspend fun subscribeRoom(roomId: String) { /* no-op: Central handles routing */ }
+
     override suspend fun unsubscribeRoom(roomId: String) { /* no-op */ }
+
     override suspend fun connect() = connection.connect()
+
     override suspend fun disconnect() = connection.disconnect()
 }

--- a/kotlin/remote/node-mediator/src/commonTest/kotlin/io/flowdux/remote/nodemediator/CentralNodeManagerTest.kt
+++ b/kotlin/remote/node-mediator/src/commonTest/kotlin/io/flowdux/remote/nodemediator/CentralNodeManagerTest.kt
@@ -426,6 +426,119 @@ class CentralNodeManagerTest {
     }
 
     @Test
+    fun reconnectingNodePreservesRoomAssignments() = runTest {
+        val registry = InMemoryRoomRegistry()
+        val events = mutableListOf<NodeMediatorEvent>()
+        val manager = CentralNodeManager<TestAction>(
+            roomRegistry = registry,
+            onUpstreamAction = { _, _, _ -> },
+            onEvent = { events.add(it) },
+        )
+
+        val conn1 = FakeTypedServerConnection()
+        val handleJob1 = launch { manager.handleNode("node-1", conn1) }
+        yield()
+
+        // Assign rooms to node-1
+        registry.assignRoom("room-1", "node-1")
+        registry.assignRoom("room-2", "node-1")
+
+        // Node reconnects with the same ID (simulates partition recovery)
+        val conn2 = FakeTypedServerConnection()
+        val handleJob2 = launch { manager.handleNode("node-1", conn2) }
+        yield()
+
+        // Old connection finishes — its cleanup must NOT unassign rooms
+        handleJob1.cancel()
+        handleJob1.join()
+
+        // Room assignments must still exist
+        assertEquals("node-1", registry.getNodeForRoom("room-1"))
+        assertEquals("node-1", registry.getNodeForRoom("room-2"))
+
+        // NodeReconnected event should have been emitted
+        assertTrue(
+            events.any { it is NodeMediatorEvent.NodeReconnected && it.nodeId == "node-1" },
+            "Expected NodeReconnected event",
+        )
+
+        // New connection should still be able to receive actions
+        manager.sendToRoom("room-1", TestAction.Message("after-reconnect"))
+        assertEquals(1, conn2.sentActions.size)
+        assertEquals(
+            NodeAction<TestAction>("room-1", TestAction.Message("after-reconnect")),
+            conn2.sentActions[0],
+        )
+
+        handleJob2.cancel()
+        handleJob2.join()
+        manager.close()
+    }
+
+    @Test
+    fun normalDisconnectStillCleansUpRooms() = runTest {
+        val registry = InMemoryRoomRegistry()
+        val manager = CentralNodeManager<TestAction>(
+            roomRegistry = registry,
+            onUpstreamAction = { _, _, _ -> },
+        )
+
+        val conn = FakeTypedServerConnection()
+        val handleJob = launch { manager.handleNode("node-1", conn) }
+        yield()
+
+        registry.assignRoom("room-1", "node-1")
+        registry.assignRoom("room-2", "node-1")
+
+        // Normal disconnect (no replacement) — rooms should be cleaned up
+        handleJob.cancel()
+        handleJob.join()
+
+        assertEquals(null, registry.getNodeForRoom("room-1"))
+        assertEquals(null, registry.getNodeForRoom("room-2"))
+
+        manager.close()
+    }
+
+    @Test
+    fun reconnectEmitsReconnectedNotConnected() = runTest {
+        val events = mutableListOf<NodeMediatorEvent>()
+        val manager = CentralNodeManager<TestAction>(
+            onUpstreamAction = { _, _, _ -> },
+            onEvent = { events.add(it) },
+        )
+
+        val conn1 = FakeTypedServerConnection()
+        val handleJob1 = launch { manager.handleNode("node-1", conn1) }
+        yield()
+
+        // First connection should emit NodeConnected
+        assertTrue(events.any { it is NodeMediatorEvent.NodeConnected && it.nodeId == "node-1" })
+        events.clear()
+
+        // Reconnect with same nodeId
+        val conn2 = FakeTypedServerConnection()
+        val handleJob2 = launch { manager.handleNode("node-1", conn2) }
+        yield()
+
+        // Should emit NodeReconnected, NOT NodeConnected
+        assertTrue(
+            events.any { it is NodeMediatorEvent.NodeReconnected && it.nodeId == "node-1" },
+            "Expected NodeReconnected event",
+        )
+        assertFalse(
+            events.any { it is NodeMediatorEvent.NodeConnected },
+            "Should not emit NodeConnected on reconnect",
+        )
+
+        handleJob1.cancel()
+        handleJob2.cancel()
+        handleJob1.join()
+        handleJob2.join()
+        manager.close()
+    }
+
+    @Test
     fun duplicateNodeIdReplacesConnection() = runTest {
         val manager = CentralNodeManager<TestAction>(
 

--- a/kotlin/remote/node-mediator/src/commonTest/kotlin/io/flowdux/remote/nodemediator/CentralNodeManagerTest.kt
+++ b/kotlin/remote/node-mediator/src/commonTest/kotlin/io/flowdux/remote/nodemediator/CentralNodeManagerTest.kt
@@ -20,6 +20,7 @@ class CentralNodeManagerTest {
     @Serializable
     sealed interface TestAction : Action {
         @Serializable data class Message(val text: String) : TestAction
+
         @Serializable data class Ping(val id: Int) : TestAction
     }
 
@@ -333,9 +334,7 @@ class CentralNodeManagerTest {
             override val isActive: Boolean = true
             val incomingFlow = MutableSharedFlow<NodeAction<TestAction>>(extraBufferCapacity = 64)
             override val incoming: Flow<NodeAction<TestAction>> = incomingFlow
-            override suspend fun send(action: NodeAction<TestAction>) {
-                throw RuntimeException("send failed")
-            }
+            override suspend fun send(action: NodeAction<TestAction>): Unit = throw RuntimeException("send failed")
         }
 
         val healthyConn = FakeTypedServerConnection()
@@ -383,8 +382,10 @@ class CentralNodeManagerTest {
 
         // node-1 should receive room-A and room-B
         assertEquals(2, conn1.sentActions.size)
-        assertTrue(conn1.sentActions.contains(NodeAction<TestAction>("room-A", TestAction.Message("announcement"))))
-        assertTrue(conn1.sentActions.contains(NodeAction<TestAction>("room-B", TestAction.Message("announcement"))))
+        val expectedA = NodeAction<TestAction>("room-A", TestAction.Message("announcement"))
+        val expectedB = NodeAction<TestAction>("room-B", TestAction.Message("announcement"))
+        assertTrue(conn1.sentActions.contains(expectedA))
+        assertTrue(conn1.sentActions.contains(expectedB))
 
         // node-2 should receive room-C
         assertEquals(1, conn2.sentActions.size)

--- a/kotlin/remote/node-mediator/src/commonTest/kotlin/io/flowdux/remote/nodemediator/InMemoryRoomRegistryTest.kt
+++ b/kotlin/remote/node-mediator/src/commonTest/kotlin/io/flowdux/remote/nodemediator/InMemoryRoomRegistryTest.kt
@@ -7,10 +7,8 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 class InMemoryRoomRegistryTest {
-
     @Test
     fun assignAndGetNodeForRoom() = runTest {
         val registry = InMemoryRoomRegistry()
@@ -114,11 +112,12 @@ class InMemoryRoomRegistryTest {
     @Test
     fun concurrentAssignments() = runTest {
         val registry = InMemoryRoomRegistry()
-        val deferreds = (1..100).map { i ->
-            async {
-                registry.assignRoom("room-$i", "node-${i % 3}")
+        val deferreds =
+            (1..100).map { i ->
+                async {
+                    registry.assignRoom("room-$i", "node-${i % 3}")
+                }
             }
-        }
         deferreds.awaitAll()
 
         val all = registry.getAllAssignments()
@@ -130,9 +129,10 @@ class InMemoryRoomRegistryTest {
         val registry = InMemoryRoomRegistry()
 
         // Assign 50 rooms
-        (1..50).map { i ->
-            async { registry.assignRoom("room-$i", "node-A") }
-        }.awaitAll()
+        (1..50)
+            .map { i ->
+                async { registry.assignRoom("room-$i", "node-A") }
+            }.awaitAll()
 
         // Concurrently unassign odd rooms and reassign even rooms
         val ops = mutableListOf<kotlinx.coroutines.Deferred<Unit>>()

--- a/kotlin/remote/node-mediator/src/commonTest/kotlin/io/flowdux/remote/nodemediator/IntegrationTest.kt
+++ b/kotlin/remote/node-mediator/src/commonTest/kotlin/io/flowdux/remote/nodemediator/IntegrationTest.kt
@@ -2,9 +2,9 @@ package io.flowdux.remote.nodemediator
 
 import io.flowdux.Action
 import io.flowdux.remote.ConnectionState
+import io.flowdux.remote.TypedClientConnection
 import io.flowdux.remote.nodemediator.registry.InMemoryRoomRegistry
 import io.flowdux.remote.nodemediator.transport.WebSocketNodeTransport
-import io.flowdux.remote.TypedClientConnection
 import io.flowdux.remote.server.connection.TypedServerConnection
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -26,10 +26,10 @@ import kotlin.test.assertTrue
  * via linked fake connections.
  */
 class IntegrationTest {
-
     @Serializable
     sealed interface TestAction : Action {
         @Serializable data class Message(val text: String) : TestAction
+
         @Serializable data class Broadcast(val text: String) : TestAction
     }
 
@@ -46,32 +46,34 @@ class IntegrationTest {
         // server → client channel
         private val serverToClient = MutableSharedFlow<NodeAction<TestAction>>(extraBufferCapacity = 64)
 
-        val clientSide = object : TypedClientConnection<NodeAction<TestAction>> {
-            private val _connectionState = MutableStateFlow(ConnectionState.DISCONNECTED)
-            override val connectionState: StateFlow<ConnectionState> = _connectionState
-            override val incoming: Flow<NodeAction<TestAction>> = serverToClient
+        val clientSide =
+            object : TypedClientConnection<NodeAction<TestAction>> {
+                private val _connectionState = MutableStateFlow(ConnectionState.DISCONNECTED)
+                override val connectionState: StateFlow<ConnectionState> = _connectionState
+                override val incoming: Flow<NodeAction<TestAction>> = serverToClient
 
-            override suspend fun send(action: NodeAction<TestAction>) {
-                clientToServer.emit(action)
+                override suspend fun send(action: NodeAction<TestAction>) {
+                    clientToServer.emit(action)
+                }
+
+                override suspend fun connect() {
+                    _connectionState.value = ConnectionState.CONNECTED
+                }
+
+                override suspend fun disconnect() {
+                    _connectionState.value = ConnectionState.DISCONNECTED
+                }
             }
 
-            override suspend fun connect() {
-                _connectionState.value = ConnectionState.CONNECTED
-            }
+        val serverSide =
+            object : TypedServerConnection<NodeAction<TestAction>> {
+                override val isActive: Boolean = true
+                override val incoming: Flow<NodeAction<TestAction>> = clientToServer
 
-            override suspend fun disconnect() {
-                _connectionState.value = ConnectionState.DISCONNECTED
+                override suspend fun send(action: NodeAction<TestAction>) {
+                    serverToClient.emit(action)
+                }
             }
-        }
-
-        val serverSide = object : TypedServerConnection<NodeAction<TestAction>> {
-            override val isActive: Boolean = true
-            override val incoming: Flow<NodeAction<TestAction>> = clientToServer
-
-            override suspend fun send(action: NodeAction<TestAction>) {
-                serverToClient.emit(action)
-            }
-        }
     }
 
     @Test
@@ -80,16 +82,18 @@ class IntegrationTest {
         val link = LinkedConnection()
         val receivedActions = mutableListOf<TestAction>()
 
-        val manager = CentralNodeManager<TestAction>(
-            roomRegistry = registry,
-            onUpstreamAction = { _, _, _ -> },
-        )
+        val manager =
+            CentralNodeManager<TestAction>(
+                roomRegistry = registry,
+                onUpstreamAction = { _, _, _ -> },
+            )
 
-        val mediator = NodeMediator<TestAction>(
-            nodeId = "node-1",
-            transport = WebSocketNodeTransport(link.clientSide),
-            scope = this,
-        )
+        val mediator =
+            NodeMediator<TestAction>(
+                nodeId = "node-1",
+                transport = WebSocketNodeTransport(link.clientSide),
+                scope = this,
+            )
 
         // Start node handling on central
         val handleJob = launch { manager.handleNode("node-1", link.serverSide) }
@@ -122,17 +126,19 @@ class IntegrationTest {
         val link = LinkedConnection()
         val upstreamReceived = mutableListOf<Triple<String, String, TestAction>>()
 
-        val manager = CentralNodeManager<TestAction>(
-            onUpstreamAction = { nodeId, roomId, action ->
-                upstreamReceived.add(Triple(nodeId, roomId, action))
-            },
-        )
+        val manager =
+            CentralNodeManager<TestAction>(
+                onUpstreamAction = { nodeId, roomId, action ->
+                    upstreamReceived.add(Triple(nodeId, roomId, action))
+                },
+            )
 
-        val mediator = NodeMediator<TestAction>(
-            nodeId = "node-1",
-            transport = WebSocketNodeTransport(link.clientSide),
-            scope = this,
-        )
+        val mediator =
+            NodeMediator<TestAction>(
+                nodeId = "node-1",
+                transport = WebSocketNodeTransport(link.clientSide),
+                scope = this,
+            )
 
         val handleJob = launch { manager.handleNode("node-1", link.serverSide) }
         yield()
@@ -167,24 +173,27 @@ class IntegrationTest {
         val nodeBActions = mutableListOf<TestAction>()
 
         lateinit var manager: CentralNodeManager<TestAction>
-        manager = CentralNodeManager<TestAction>(
-            roomRegistry = registry,
-            onUpstreamAction = { _, roomId, action ->
-                // Central relays upstream action to the target room's node
-                manager.sendToRoom(roomId, action)
-            },
-        )
+        manager =
+            CentralNodeManager<TestAction>(
+                roomRegistry = registry,
+                onUpstreamAction = { _, roomId, action ->
+                    // Central relays upstream action to the target room's node
+                    manager.sendToRoom(roomId, action)
+                },
+            )
 
-        val mediatorA = NodeMediator<TestAction>(
-            nodeId = "node-A",
-            transport = WebSocketNodeTransport(linkA.clientSide),
-            scope = this,
-        )
-        val mediatorB = NodeMediator<TestAction>(
-            nodeId = "node-B",
-            transport = WebSocketNodeTransport(linkB.clientSide),
-            scope = this,
-        )
+        val mediatorA =
+            NodeMediator<TestAction>(
+                nodeId = "node-A",
+                transport = WebSocketNodeTransport(linkA.clientSide),
+                scope = this,
+            )
+        val mediatorB =
+            NodeMediator<TestAction>(
+                nodeId = "node-B",
+                transport = WebSocketNodeTransport(linkB.clientSide),
+                scope = this,
+            )
 
         val handleJobA = launch { manager.handleNode("node-A", linkA.serverSide) }
         val handleJobB = launch { manager.handleNode("node-B", linkB.serverSide) }
@@ -222,11 +231,12 @@ class IntegrationTest {
         val registry = InMemoryRoomRegistry()
         val events = mutableListOf<NodeMediatorEvent>()
 
-        val manager = CentralNodeManager<TestAction>(
-            roomRegistry = registry,
-            onUpstreamAction = { _, _, _ -> },
-            onEvent = { events.add(it) },
-        )
+        val manager =
+            CentralNodeManager<TestAction>(
+                roomRegistry = registry,
+                onUpstreamAction = { _, _, _ -> },
+                onEvent = { events.add(it) },
+            )
 
         // First connection
         val link1 = LinkedConnection()
@@ -248,11 +258,12 @@ class IntegrationTest {
         val link2 = LinkedConnection()
         val receivedActions = mutableListOf<TestAction>()
 
-        val mediator = NodeMediator<TestAction>(
-            nodeId = "node-1",
-            transport = WebSocketNodeTransport(link2.clientSide),
-            scope = this,
-        )
+        val mediator =
+            NodeMediator<TestAction>(
+                nodeId = "node-1",
+                transport = WebSocketNodeTransport(link2.clientSide),
+                scope = this,
+            )
 
         val handleJob2 = launch { manager.handleNode("node-1", link2.serverSide) }
         yield()
@@ -289,21 +300,24 @@ class IntegrationTest {
         val nodeARoom2 = mutableListOf<TestAction>()
         val nodeBRoom3 = mutableListOf<TestAction>()
 
-        val manager = CentralNodeManager<TestAction>(
-            roomRegistry = registry,
-            onUpstreamAction = { _, _, _ -> },
-        )
+        val manager =
+            CentralNodeManager<TestAction>(
+                roomRegistry = registry,
+                onUpstreamAction = { _, _, _ -> },
+            )
 
-        val mediatorA = NodeMediator<TestAction>(
-            nodeId = "node-A",
-            transport = WebSocketNodeTransport(linkA.clientSide),
-            scope = this,
-        )
-        val mediatorB = NodeMediator<TestAction>(
-            nodeId = "node-B",
-            transport = WebSocketNodeTransport(linkB.clientSide),
-            scope = this,
-        )
+        val mediatorA =
+            NodeMediator<TestAction>(
+                nodeId = "node-A",
+                transport = WebSocketNodeTransport(linkA.clientSide),
+                scope = this,
+            )
+        val mediatorB =
+            NodeMediator<TestAction>(
+                nodeId = "node-B",
+                transport = WebSocketNodeTransport(linkB.clientSide),
+                scope = this,
+            )
 
         val handleJobA = launch { manager.handleNode("node-A", linkA.serverSide) }
         val handleJobB = launch { manager.handleNode("node-B", linkB.serverSide) }
@@ -351,18 +365,20 @@ class IntegrationTest {
         val nodeReceived = mutableListOf<TestAction>()
         val centralReceived = mutableListOf<Triple<String, String, TestAction>>()
 
-        val manager = CentralNodeManager<TestAction>(
-            roomRegistry = registry,
-            onUpstreamAction = { nodeId, roomId, action ->
-                centralReceived.add(Triple(nodeId, roomId, action))
-            },
-        )
+        val manager =
+            CentralNodeManager<TestAction>(
+                roomRegistry = registry,
+                onUpstreamAction = { nodeId, roomId, action ->
+                    centralReceived.add(Triple(nodeId, roomId, action))
+                },
+            )
 
-        val mediator = NodeMediator<TestAction>(
-            nodeId = "node-1",
-            transport = WebSocketNodeTransport(link.clientSide),
-            scope = this,
-        )
+        val mediator =
+            NodeMediator<TestAction>(
+                nodeId = "node-1",
+                transport = WebSocketNodeTransport(link.clientSide),
+                scope = this,
+            )
 
         val handleJob = launch { manager.handleNode("node-1", link.serverSide) }
         yield()
@@ -374,16 +390,18 @@ class IntegrationTest {
         registry.assignRoom("room-1", "node-1")
 
         // Simultaneously send 10 messages each way
-        val centralSending = async {
-            repeat(10) { i ->
-                manager.sendToRoom("room-1", TestAction.Message("central-$i"))
+        val centralSending =
+            async {
+                repeat(10) { i ->
+                    manager.sendToRoom("room-1", TestAction.Message("central-$i"))
+                }
             }
-        }
-        val nodeSending = async {
-            repeat(10) { i ->
-                mediator.forwardToCentral("room-1", TestAction.Message("node-$i"))
+        val nodeSending =
+            async {
+                repeat(10) { i ->
+                    mediator.forwardToCentral("room-1", TestAction.Message("node-$i"))
+                }
             }
-        }
         awaitAll(centralSending, nodeSending)
         yield()
         testScheduler.advanceUntilIdle()
@@ -395,9 +413,10 @@ class IntegrationTest {
 
         // All 10 node→central messages should arrive
         assertEquals(10, centralReceived.size)
-        val expectedCentralMessages = (0 until 10).map {
-            Triple("node-1", "room-1", TestAction.Message("node-$it") as TestAction)
-        }
+        val expectedCentralMessages =
+            (0 until 10).map {
+                Triple("node-1", "room-1", TestAction.Message("node-$it") as TestAction)
+            }
         assertEquals(expectedCentralMessages, centralReceived)
 
         mediator.close()

--- a/kotlin/remote/node-mediator/src/commonTest/kotlin/io/flowdux/remote/nodemediator/NodeActionCodecTest.kt
+++ b/kotlin/remote/node-mediator/src/commonTest/kotlin/io/flowdux/remote/nodemediator/NodeActionCodecTest.kt
@@ -2,26 +2,26 @@ package io.flowdux.remote.nodemediator
 
 import io.flowdux.Action
 import io.flowdux.remote.serialization.actionCodecOf
-import kotlinx.serialization.SerializationException
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class NodeActionCodecTest {
-
     @Serializable
     sealed interface TestAction : Action {
         @Serializable data object Increment : TestAction
+
         @Serializable data class Add(val value: Int) : TestAction
+
         @Serializable data class SetName(val name: String) : TestAction
     }
 
     private val codec = actionCodecOf<NodeAction<TestAction>>()
 
-    private fun nodeAction(roomId: String, action: TestAction): NodeAction<TestAction> =
-        NodeAction(roomId, action)
+    private fun nodeAction(roomId: String, action: TestAction): NodeAction<TestAction> = NodeAction(roomId, action)
 
     @Test
     fun encodeDecodeNodeAction() {
@@ -50,14 +50,15 @@ class NodeActionCodecTest {
     @Test
     fun roundTripAllVariants() {
         val rooms = listOf("room-1", "room-2", "test-room", "")
-        val actions: List<TestAction> = listOf(
-            TestAction.Increment,
-            TestAction.Add(0),
-            TestAction.Add(-1),
-            TestAction.Add(Int.MAX_VALUE),
-            TestAction.SetName(""),
-            TestAction.SetName("hello"),
-        )
+        val actions: List<TestAction> =
+            listOf(
+                TestAction.Increment,
+                TestAction.Add(0),
+                TestAction.Add(-1),
+                TestAction.Add(Int.MAX_VALUE),
+                TestAction.SetName(""),
+                TestAction.SetName("hello"),
+            )
         for (roomId in rooms) {
             for (action in actions) {
                 val original = nodeAction(roomId, action)

--- a/kotlin/remote/node-mediator/src/commonTest/kotlin/io/flowdux/remote/nodemediator/NodeMediatorTest.kt
+++ b/kotlin/remote/node-mediator/src/commonTest/kotlin/io/flowdux/remote/nodemediator/NodeMediatorTest.kt
@@ -18,10 +18,10 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class NodeMediatorTest {
-
     @Serializable
     sealed interface TestAction : Action {
         @Serializable data class Message(val text: String) : TestAction
+
         @Serializable data class Ping(val id: Int) : TestAction
     }
 
@@ -36,11 +36,25 @@ class NodeMediatorTest {
         var connected = false
             private set
 
-        override suspend fun send(action: NodeAction<TestAction>) { sentActions.add(action) }
-        override suspend fun subscribeRoom(roomId: String) { subscribedRooms.add(roomId) }
-        override suspend fun unsubscribeRoom(roomId: String) { unsubscribedRooms.add(roomId) }
-        override suspend fun connect() { connected = true }
-        override suspend fun disconnect() { connected = false }
+        override suspend fun send(action: NodeAction<TestAction>) {
+            sentActions.add(action)
+        }
+
+        override suspend fun subscribeRoom(roomId: String) {
+            subscribedRooms.add(roomId)
+        }
+
+        override suspend fun unsubscribeRoom(roomId: String) {
+            unsubscribedRooms.add(roomId)
+        }
+
+        override suspend fun connect() {
+            connected = true
+        }
+
+        override suspend fun disconnect() {
+            connected = false
+        }
 
         fun simulateIncoming(action: NodeAction<TestAction>) {
             incomingFlow.tryEmit(action)
@@ -50,11 +64,12 @@ class NodeMediatorTest {
     @Test
     fun registerAndUnregisterRoom() = runTest {
         val connection = FakeNodeTransport()
-        val mediator = NodeMediator<TestAction>(
-            nodeId = "node-1",
-            transport = connection,
-            scope = this,
-        )
+        val mediator =
+            NodeMediator<TestAction>(
+                nodeId = "node-1",
+                transport = connection,
+                scope = this,
+            )
         mediator.connect()
         testScheduler.advanceUntilIdle()
 
@@ -72,11 +87,12 @@ class NodeMediatorTest {
     @Test
     fun multipleRooms() = runTest {
         val connection = FakeNodeTransport()
-        val mediator = NodeMediator<TestAction>(
-            nodeId = "node-1",
-            transport = connection,
-            scope = this,
-        )
+        val mediator =
+            NodeMediator<TestAction>(
+                nodeId = "node-1",
+                transport = connection,
+                scope = this,
+            )
         mediator.connect()
         testScheduler.advanceUntilIdle()
 
@@ -95,11 +111,12 @@ class NodeMediatorTest {
         val room1Actions = mutableListOf<TestAction>()
         val room2Actions = mutableListOf<TestAction>()
 
-        val mediator = NodeMediator<TestAction>(
-            nodeId = "node-1",
-            transport = connection,
-            scope = this,
-        )
+        val mediator =
+            NodeMediator<TestAction>(
+                nodeId = "node-1",
+                transport = connection,
+                scope = this,
+            )
         mediator.connect()
         testScheduler.advanceUntilIdle()
 
@@ -111,10 +128,11 @@ class NodeMediatorTest {
         connection.simulateIncoming(NodeAction("room-1", TestAction.Message("world")))
         yield()
 
-        val expectedRoom1: List<TestAction> = listOf(
-            TestAction.Message("hello"),
-            TestAction.Message("world"),
-        )
+        val expectedRoom1: List<TestAction> =
+            listOf(
+                TestAction.Message("hello"),
+                TestAction.Message("world"),
+            )
         assertEquals(expectedRoom1, room1Actions)
         val expectedRoom2: List<TestAction> = listOf(TestAction.Ping(42))
         assertEquals(expectedRoom2, room2Actions)
@@ -125,11 +143,12 @@ class NodeMediatorTest {
     @Test
     fun upstreamForwardToCentral() = runTest {
         val connection = FakeNodeTransport()
-        val mediator = NodeMediator<TestAction>(
-            nodeId = "node-1",
-            transport = connection,
-            scope = this,
-        )
+        val mediator =
+            NodeMediator<TestAction>(
+                nodeId = "node-1",
+                transport = connection,
+                scope = this,
+            )
         mediator.connect()
         testScheduler.advanceUntilIdle()
 
@@ -150,11 +169,12 @@ class NodeMediatorTest {
         val connection = FakeNodeTransport()
         val room1Actions = mutableListOf<TestAction>()
 
-        val mediator = NodeMediator<TestAction>(
-            nodeId = "node-1",
-            transport = connection,
-            scope = this,
-        )
+        val mediator =
+            NodeMediator<TestAction>(
+                nodeId = "node-1",
+                transport = connection,
+                scope = this,
+            )
         mediator.connect()
         testScheduler.advanceUntilIdle()
 
@@ -176,12 +196,13 @@ class NodeMediatorTest {
         val connection = FakeNodeTransport()
         val unknownActions = mutableListOf<Pair<String, TestAction>>()
 
-        val mediator = NodeMediator<TestAction>(
-            nodeId = "node-1",
-            transport = connection,
-            scope = this,
-            onUnknownRoom = { roomId, action -> unknownActions.add(roomId to action) },
-        )
+        val mediator =
+            NodeMediator<TestAction>(
+                nodeId = "node-1",
+                transport = connection,
+                scope = this,
+                onUnknownRoom = { roomId, action -> unknownActions.add(roomId to action) },
+            )
         mediator.connect()
         testScheduler.advanceUntilIdle()
 
@@ -197,11 +218,12 @@ class NodeMediatorTest {
     @Test
     fun connectDisconnectLifecycle() = runTest {
         val connection = FakeNodeTransport()
-        val mediator = NodeMediator<TestAction>(
-            nodeId = "node-1",
-            transport = connection,
-            scope = this,
-        )
+        val mediator =
+            NodeMediator<TestAction>(
+                nodeId = "node-1",
+                transport = connection,
+                scope = this,
+            )
 
         assertFalse(connection.connected)
 
@@ -228,11 +250,12 @@ class NodeMediatorTest {
     @Test
     fun closeThrowsOnSubsequentUse() = runTest {
         val connection = FakeNodeTransport()
-        val mediator = NodeMediator<TestAction>(
-            nodeId = "node-1",
-            transport = connection,
-            scope = this,
-        )
+        val mediator =
+            NodeMediator<TestAction>(
+                nodeId = "node-1",
+                transport = connection,
+                scope = this,
+            )
         mediator.connect()
         testScheduler.advanceUntilIdle()
 
@@ -252,11 +275,12 @@ class NodeMediatorTest {
     @Test
     fun closeClearsRooms() = runTest {
         val connection = FakeNodeTransport()
-        val mediator = NodeMediator<TestAction>(
-            nodeId = "node-1",
-            transport = connection,
-            scope = this,
-        )
+        val mediator =
+            NodeMediator<TestAction>(
+                nodeId = "node-1",
+                transport = connection,
+                scope = this,
+            )
         mediator.connect()
         testScheduler.advanceUntilIdle()
 
@@ -271,19 +295,21 @@ class NodeMediatorTest {
     @Test
     fun concurrentRegisterRooms() = runTest {
         val connection = FakeNodeTransport()
-        val mediator = NodeMediator<TestAction>(
-            nodeId = "node-1",
-            transport = connection,
-            scope = this,
-        )
+        val mediator =
+            NodeMediator<TestAction>(
+                nodeId = "node-1",
+                transport = connection,
+                scope = this,
+            )
         mediator.connect()
         testScheduler.advanceUntilIdle()
 
-        val deferreds = (1..50).map { i ->
-            async {
-                mediator.registerRoom("room-$i") { }
+        val deferreds =
+            (1..50).map { i ->
+                async {
+                    mediator.registerRoom("room-$i") { }
+                }
             }
-        }
         deferreds.awaitAll()
 
         assertEquals(50, mediator.roomIds().size)
@@ -295,11 +321,12 @@ class NodeMediatorTest {
     fun rapidRegisterUnregisterRegister() = runTest {
         val connection = FakeNodeTransport()
         val actions = mutableListOf<TestAction>()
-        val mediator = NodeMediator<TestAction>(
-            nodeId = "node-1",
-            transport = connection,
-            scope = this,
-        )
+        val mediator =
+            NodeMediator<TestAction>(
+                nodeId = "node-1",
+                transport = connection,
+                scope = this,
+            )
         mediator.connect()
         testScheduler.advanceUntilIdle()
 
@@ -319,11 +346,12 @@ class NodeMediatorTest {
     @Test
     fun connectIsIdempotent() = runTest {
         val connection = FakeNodeTransport()
-        val mediator = NodeMediator<TestAction>(
-            nodeId = "node-1",
-            transport = connection,
-            scope = this,
-        )
+        val mediator =
+            NodeMediator<TestAction>(
+                nodeId = "node-1",
+                transport = connection,
+                scope = this,
+            )
 
         mediator.connect()
         mediator.connect() // Should not throw or create duplicate jobs
@@ -340,12 +368,13 @@ class NodeMediatorTest {
         val events = mutableListOf<NodeMediatorEvent>()
         val room2Actions = mutableListOf<TestAction>()
 
-        val mediator = NodeMediator<TestAction>(
-            nodeId = "node-1",
-            transport = connection,
-            scope = this,
-            onEvent = { events.add(it) },
-        )
+        val mediator =
+            NodeMediator<TestAction>(
+                nodeId = "node-1",
+                transport = connection,
+                scope = this,
+                onEvent = { events.add(it) },
+            )
         mediator.connect()
         testScheduler.advanceUntilIdle()
 
@@ -371,13 +400,14 @@ class NodeMediatorTest {
         val events = mutableListOf<NodeMediatorEvent>()
         val room1Actions = mutableListOf<TestAction>()
 
-        val mediator = NodeMediator<TestAction>(
-            nodeId = "node-1",
-            transport = connection,
-            scope = this,
-            onUnknownRoom = { _, _ -> throw RuntimeException("unknown room callback error") },
-            onEvent = { events.add(it) },
-        )
+        val mediator =
+            NodeMediator<TestAction>(
+                nodeId = "node-1",
+                transport = connection,
+                scope = this,
+                onUnknownRoom = { _, _ -> throw RuntimeException("unknown room callback error") },
+                onEvent = { events.add(it) },
+            )
         mediator.connect()
         testScheduler.advanceUntilIdle()
 
@@ -402,12 +432,13 @@ class NodeMediatorTest {
         val connection = FakeNodeTransport()
         val room1Actions = mutableListOf<TestAction>()
 
-        val mediator = NodeMediator<TestAction>(
-            nodeId = "node-1",
-            transport = connection,
-            scope = this,
-            onEvent = { throw RuntimeException("event callback error") },
-        )
+        val mediator =
+            NodeMediator<TestAction>(
+                nodeId = "node-1",
+                transport = connection,
+                scope = this,
+                onEvent = { throw RuntimeException("event callback error") },
+            )
         mediator.connect()
         testScheduler.advanceUntilIdle()
 
@@ -431,26 +462,33 @@ class NodeMediatorTest {
     fun transportErrorTriggersRoutingStoppedEvent() = runTest {
         val errorSignal = CompletableDeferred<Unit>()
 
-        val errorTransport = object : NodeTransport<TestAction> {
-            override val incoming: Flow<NodeAction<TestAction>> = flow {
-                errorSignal.await()
-                throw RuntimeException("transport error")
+        val errorTransport =
+            object : NodeTransport<TestAction> {
+                override val incoming: Flow<NodeAction<TestAction>> =
+                    flow {
+                        errorSignal.await()
+                        throw RuntimeException("transport error")
+                    }
+
+                override suspend fun send(action: NodeAction<TestAction>) {}
+
+                override suspend fun subscribeRoom(roomId: String) {}
+
+                override suspend fun unsubscribeRoom(roomId: String) {}
+
+                override suspend fun connect() {}
+
+                override suspend fun disconnect() {}
             }
 
-            override suspend fun send(action: NodeAction<TestAction>) {}
-            override suspend fun subscribeRoom(roomId: String) {}
-            override suspend fun unsubscribeRoom(roomId: String) {}
-            override suspend fun connect() {}
-            override suspend fun disconnect() {}
-        }
-
         val events = mutableListOf<NodeMediatorEvent>()
-        val mediator = NodeMediator<TestAction>(
-            nodeId = "node-1",
-            transport = errorTransport,
-            scope = this,
-            onEvent = { events.add(it) },
-        )
+        val mediator =
+            NodeMediator<TestAction>(
+                nodeId = "node-1",
+                transport = errorTransport,
+                scope = this,
+                onEvent = { events.add(it) },
+            )
         mediator.connect()
         testScheduler.advanceUntilIdle()
 
@@ -468,11 +506,12 @@ class NodeMediatorTest {
         val connection = FakeNodeTransport()
         val room1Actions = mutableListOf<TestAction>()
 
-        val mediator = NodeMediator<TestAction>(
-            nodeId = "node-1",
-            transport = connection,
-            scope = this,
-        )
+        val mediator =
+            NodeMediator<TestAction>(
+                nodeId = "node-1",
+                transport = connection,
+                scope = this,
+            )
         mediator.connect()
         testScheduler.advanceUntilIdle()
 
@@ -500,11 +539,12 @@ class NodeMediatorTest {
     @Test
     fun unregisterNonexistentRoomDoesNothing() = runTest {
         val connection = FakeNodeTransport()
-        val mediator = NodeMediator<TestAction>(
-            nodeId = "node-1",
-            transport = connection,
-            scope = this,
-        )
+        val mediator =
+            NodeMediator<TestAction>(
+                nodeId = "node-1",
+                transport = connection,
+                scope = this,
+            )
         mediator.connect()
         testScheduler.advanceUntilIdle()
 
@@ -518,11 +558,12 @@ class NodeMediatorTest {
     @Test
     fun registerRoomCallsTransportSubscribe() = runTest {
         val connection = FakeNodeTransport()
-        val mediator = NodeMediator<TestAction>(
-            nodeId = "node-1",
-            transport = connection,
-            scope = this,
-        )
+        val mediator =
+            NodeMediator<TestAction>(
+                nodeId = "node-1",
+                transport = connection,
+                scope = this,
+            )
         mediator.connect()
         testScheduler.advanceUntilIdle()
 
@@ -537,11 +578,12 @@ class NodeMediatorTest {
     @Test
     fun unregisterRoomCallsTransportUnsubscribe() = runTest {
         val connection = FakeNodeTransport()
-        val mediator = NodeMediator<TestAction>(
-            nodeId = "node-1",
-            transport = connection,
-            scope = this,
-        )
+        val mediator =
+            NodeMediator<TestAction>(
+                nodeId = "node-1",
+                transport = connection,
+                scope = this,
+            )
         mediator.connect()
         testScheduler.advanceUntilIdle()
 

--- a/kotlin/remote/node-mediator/src/commonTest/kotlin/io/flowdux/remote/nodemediator/NodeRoomServerTest.kt
+++ b/kotlin/remote/node-mediator/src/commonTest/kotlin/io/flowdux/remote/nodemediator/NodeRoomServerTest.kt
@@ -23,21 +23,24 @@ import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class NodeRoomServerTest {
-
     @Serializable
     sealed interface TestAction : Action {
         @Serializable data class Add(val item: String) : TestAction
-        @Serializable data class Sync(val items: List<String>) : TestAction, ClientSharedAction
+
+        @Serializable data class Sync(val items: List<String>) :
+            TestAction,
+            ClientSharedAction
     }
 
     @Serializable
     data class TestState(val items: List<String> = emptyList()) : State
 
-    private val testReducer = buildReducer<TestState, TestAction> {
-        on<TestAction.Add> { state, action ->
-            state.copy(items = state.items + action.item)
+    private val testReducer =
+        buildReducer<TestState, TestAction> {
+            on<TestAction.Add> { state, action ->
+                state.copy(items = state.items + action.item)
+            }
         }
-    }
 
     private class FakeNodeTransport : NodeTransport<TestAction> {
         val incomingFlow = MutableSharedFlow<NodeAction<TestAction>>(extraBufferCapacity = 64)
@@ -50,11 +53,25 @@ class NodeRoomServerTest {
         var connected = false
             private set
 
-        override suspend fun send(action: NodeAction<TestAction>) { sentActions.add(action) }
-        override suspend fun subscribeRoom(roomId: String) { subscribedRooms.add(roomId) }
-        override suspend fun unsubscribeRoom(roomId: String) { unsubscribedRooms.add(roomId) }
-        override suspend fun connect() { connected = true }
-        override suspend fun disconnect() { connected = false }
+        override suspend fun send(action: NodeAction<TestAction>) {
+            sentActions.add(action)
+        }
+
+        override suspend fun subscribeRoom(roomId: String) {
+            subscribedRooms.add(roomId)
+        }
+
+        override suspend fun unsubscribeRoom(roomId: String) {
+            unsubscribedRooms.add(roomId)
+        }
+
+        override suspend fun connect() {
+            connected = true
+        }
+
+        override suspend fun disconnect() {
+            connected = false
+        }
 
         fun simulateIncoming(action: NodeAction<TestAction>) {
             incomingFlow.tryEmit(action)
@@ -82,14 +99,12 @@ class NodeRoomServerTest {
 
     private fun createTestRoomServer(
         scope: kotlinx.coroutines.CoroutineScope,
-    ): RoomServer<SharedStateServer<TestState, TestAction>> {
-        return createSharedStateRoomServer(
-            initialStateFactory = { TestState() },
-            reducer = testReducer,
-            stateMapper = { state -> TestAction.Sync(state.items) },
-            scope = scope,
-        )
-    }
+    ): RoomServer<SharedStateServer<TestState, TestAction>> = createSharedStateRoomServer(
+        initialStateFactory = { TestState() },
+        reducer = testReducer,
+        stateMapper = { state -> TestAction.Sync(state.items) },
+        scope = scope,
+    )
 
     @Test
     fun handleClientRegistersRoomWithMediator() = runTest {
@@ -100,9 +115,10 @@ class NodeRoomServerTest {
         testScheduler.advanceTimeBy(1)
 
         val clientConn = FakeClientConnection()
-        val job = backgroundScope.launch {
-            server.handleClient("room-1", "session-1", clientConn)
-        }
+        val job =
+            backgroundScope.launch {
+                server.handleClient("room-1", "session-1", clientConn)
+            }
         testScheduler.advanceTimeBy(1)
 
         assertTrue(server.mediator.hasRoom("room-1"))
@@ -123,9 +139,10 @@ class NodeRoomServerTest {
         testScheduler.advanceTimeBy(1)
 
         val clientConn = FakeClientConnection()
-        val job = backgroundScope.launch {
-            server.handleClient("room-1", "session-1", clientConn)
-        }
+        val job =
+            backgroundScope.launch {
+                server.handleClient("room-1", "session-1", clientConn)
+            }
         testScheduler.advanceTimeBy(1)
 
         // Client sends an action
@@ -153,9 +170,10 @@ class NodeRoomServerTest {
         testScheduler.advanceTimeBy(1)
 
         val clientConn = FakeClientConnection()
-        val job = backgroundScope.launch {
-            server.handleClient("room-1", "session-1", clientConn)
-        }
+        val job =
+            backgroundScope.launch {
+                server.handleClient("room-1", "session-1", clientConn)
+            }
         testScheduler.advanceTimeBy(1)
 
         // Central sends an action
@@ -174,17 +192,22 @@ class NodeRoomServerTest {
     @Test
     fun forwardingFailureDoesNotDisconnectClient() = runTest {
         // Use a transport that fails on send
-        val transport = object : NodeTransport<TestAction> {
-            val incomingFlow = MutableSharedFlow<NodeAction<TestAction>>(extraBufferCapacity = 64)
-            override val incoming: Flow<NodeAction<TestAction>> = incomingFlow
-            override suspend fun send(action: NodeAction<TestAction>) {
-                throw RuntimeException("Central unreachable")
+        val transport =
+            object : NodeTransport<TestAction> {
+                val incomingFlow = MutableSharedFlow<NodeAction<TestAction>>(extraBufferCapacity = 64)
+                override val incoming: Flow<NodeAction<TestAction>> = incomingFlow
+
+                override suspend fun send(action: NodeAction<TestAction>): Unit =
+                    throw RuntimeException("Central unreachable")
+
+                override suspend fun subscribeRoom(roomId: String) {}
+
+                override suspend fun unsubscribeRoom(roomId: String) {}
+
+                override suspend fun connect() {}
+
+                override suspend fun disconnect() {}
             }
-            override suspend fun subscribeRoom(roomId: String) {}
-            override suspend fun unsubscribeRoom(roomId: String) {}
-            override suspend fun connect() {}
-            override suspend fun disconnect() {}
-        }
 
         val roomServer = createTestRoomServer(backgroundScope)
         val events = mutableListOf<NodeMediatorEvent>()
@@ -193,9 +216,10 @@ class NodeRoomServerTest {
         testScheduler.advanceTimeBy(1)
 
         val clientConn = FakeClientConnection()
-        val job = backgroundScope.launch {
-            server.handleClient("room-1", "session-1", clientConn)
-        }
+        val job =
+            backgroundScope.launch {
+                server.handleClient("room-1", "session-1", clientConn)
+            }
         testScheduler.advanceTimeBy(1)
 
         // Client sends an action — forwarding will fail
@@ -223,9 +247,10 @@ class NodeRoomServerTest {
         testScheduler.advanceTimeBy(1)
 
         val clientConn = FakeClientConnection()
-        val job = backgroundScope.launch {
-            server.handleClient("room-1", "session-1", clientConn)
-        }
+        val job =
+            backgroundScope.launch {
+                server.handleClient("room-1", "session-1", clientConn)
+            }
         testScheduler.advanceTimeBy(1)
 
         assertTrue(server.mediator.hasRoom("room-1"))
@@ -317,9 +342,11 @@ class NodeRoomServerTest {
         assertTrue(room.currentState.items.contains("dispatched"))
 
         // Verify it was forwarded
-        assertTrue(transport.sentActions.any {
-            it == NodeAction<TestAction>("room-1", TestAction.Add("dispatched"))
-        })
+        assertTrue(
+            transport.sentActions.any {
+                it == NodeAction<TestAction>("room-1", TestAction.Add("dispatched"))
+            },
+        )
 
         job.cancel()
         testScheduler.advanceTimeBy(1)
@@ -387,9 +414,10 @@ class NodeRoomServerTest {
 
         // Start Turbine collection BEFORE handleClient to capture initial state sync
         clientConn.sentFlow.test {
-            val job = backgroundScope.launch {
-                server.handleClient("room-1", "session-1", clientConn)
-            }
+            val job =
+                backgroundScope.launch {
+                    server.handleClient("room-1", "session-1", clientConn)
+                }
             testScheduler.advanceTimeBy(1)
 
             // Initial SyncState on connection

--- a/kotlin/remote/node-mediator/src/commonTest/kotlin/io/flowdux/remote/nodemediator/NodeRoomServerTest.kt
+++ b/kotlin/remote/node-mediator/src/commonTest/kotlin/io/flowdux/remote/nodemediator/NodeRoomServerTest.kt
@@ -1,5 +1,6 @@
 package io.flowdux.remote.nodemediator
 
+import app.cash.turbine.test
 import io.flowdux.Action
 import io.flowdux.State
 import io.flowdux.buildReducer
@@ -9,7 +10,7 @@ import io.flowdux.remote.server.connection.TypedServerConnection
 import io.flowdux.remote.server.pattern.RoomServer
 import io.flowdux.remote.server.pattern.SharedStateServer
 import io.flowdux.remote.server.pattern.createSharedStateRoomServer
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
@@ -20,6 +21,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class NodeRoomServerTest {
 
     @Serializable
@@ -65,8 +67,13 @@ class NodeRoomServerTest {
         override val incoming: Flow<TestAction> = incomingFlow
 
         val sentActions = mutableListOf<TestAction>()
+        private val _sentFlow = MutableSharedFlow<TestAction>(extraBufferCapacity = 64)
+        val sentFlow: Flow<TestAction> = _sentFlow
 
-        override suspend fun send(action: TestAction) { sentActions.add(action) }
+        override suspend fun send(action: TestAction) {
+            sentActions.add(action)
+            _sentFlow.tryEmit(action)
+        }
 
         fun simulateIncoming(action: TestAction) {
             incomingFlow.tryEmit(action)
@@ -90,20 +97,20 @@ class NodeRoomServerTest {
         val roomServer = createTestRoomServer(backgroundScope)
         val server = NodeRoomServer("node-1", transport, roomServer, backgroundScope)
         server.connect()
-        delay(100)
+        testScheduler.advanceTimeBy(1)
 
         val clientConn = FakeClientConnection()
         val job = backgroundScope.launch {
             server.handleClient("room-1", "session-1", clientConn)
         }
-        delay(100)
+        testScheduler.advanceTimeBy(1)
 
         assertTrue(server.mediator.hasRoom("room-1"))
         assertTrue(transport.subscribedRooms.contains("room-1"))
         assertTrue(server.roomIds().contains("room-1"))
 
         job.cancel()
-        delay(100)
+        testScheduler.advanceTimeBy(1)
         server.close()
     }
 
@@ -113,17 +120,17 @@ class NodeRoomServerTest {
         val roomServer = createTestRoomServer(backgroundScope)
         val server = NodeRoomServer("node-1", transport, roomServer, backgroundScope)
         server.connect()
-        delay(100)
+        testScheduler.advanceTimeBy(1)
 
         val clientConn = FakeClientConnection()
         val job = backgroundScope.launch {
             server.handleClient("room-1", "session-1", clientConn)
         }
-        delay(100)
+        testScheduler.advanceTimeBy(1)
 
         // Client sends an action
         clientConn.simulateIncoming(TestAction.Add("hello"))
-        delay(100)
+        testScheduler.advanceTimeBy(1)
 
         // Verify it was forwarded to Central
         assertEquals(1, transport.sentActions.size)
@@ -133,7 +140,7 @@ class NodeRoomServerTest {
         )
 
         job.cancel()
-        delay(100)
+        testScheduler.advanceTimeBy(1)
         server.close()
     }
 
@@ -143,24 +150,24 @@ class NodeRoomServerTest {
         val roomServer = createTestRoomServer(backgroundScope)
         val server = NodeRoomServer("node-1", transport, roomServer, backgroundScope)
         server.connect()
-        delay(100)
+        testScheduler.advanceTimeBy(1)
 
         val clientConn = FakeClientConnection()
         val job = backgroundScope.launch {
             server.handleClient("room-1", "session-1", clientConn)
         }
-        delay(100)
+        testScheduler.advanceTimeBy(1)
 
         // Central sends an action
         transport.simulateIncoming(NodeAction<TestAction>("room-1", TestAction.Add("from-central")))
-        delay(100)
+        testScheduler.advanceTimeBy(1)
 
         // Verify it was dispatched to the room store
         val room = roomServer.getRoom("room-1")!!
         assertTrue(room.currentState.items.contains("from-central"))
 
         job.cancel()
-        delay(100)
+        testScheduler.advanceTimeBy(1)
         server.close()
     }
 
@@ -183,17 +190,17 @@ class NodeRoomServerTest {
         val events = mutableListOf<NodeMediatorEvent>()
         val server = NodeRoomServer("node-1", transport, roomServer, backgroundScope, onEvent = { events.add(it) })
         server.connect()
-        delay(100)
+        testScheduler.advanceTimeBy(1)
 
         val clientConn = FakeClientConnection()
         val job = backgroundScope.launch {
             server.handleClient("room-1", "session-1", clientConn)
         }
-        delay(100)
+        testScheduler.advanceTimeBy(1)
 
         // Client sends an action — forwarding will fail
         clientConn.simulateIncoming(TestAction.Add("hello"))
-        delay(100)
+        testScheduler.advanceTimeBy(1)
 
         // Verify the action was still dispatched to the room store despite forwarding failure
         val room = roomServer.getRoom("room-1")!!
@@ -203,7 +210,7 @@ class NodeRoomServerTest {
         assertTrue(job.isActive)
 
         job.cancel()
-        delay(100)
+        testScheduler.advanceTimeBy(1)
         server.close()
     }
 
@@ -213,19 +220,19 @@ class NodeRoomServerTest {
         val roomServer = createTestRoomServer(backgroundScope)
         val server = NodeRoomServer("node-1", transport, roomServer, backgroundScope)
         server.connect()
-        delay(100)
+        testScheduler.advanceTimeBy(1)
 
         val clientConn = FakeClientConnection()
         val job = backgroundScope.launch {
             server.handleClient("room-1", "session-1", clientConn)
         }
-        delay(100)
+        testScheduler.advanceTimeBy(1)
 
         assertTrue(server.mediator.hasRoom("room-1"))
 
         // Disconnect client
         job.cancel()
-        delay(100)
+        testScheduler.advanceTimeBy(1)
 
         // Destroy empty room
         val destroyed = server.destroyRoomIfEmpty("room-1")
@@ -242,11 +249,11 @@ class NodeRoomServerTest {
         val roomServer = createTestRoomServer(backgroundScope)
         val server = NodeRoomServer("node-1", transport, roomServer, backgroundScope)
         server.connect()
-        delay(100)
+        testScheduler.advanceTimeBy(1)
 
         // Central sends an action for a room that doesn't exist yet
         transport.simulateIncoming(NodeAction<TestAction>("auto-room", TestAction.Add("auto-created")))
-        delay(100)
+        testScheduler.advanceTimeBy(1)
 
         // Room should have been auto-created
         assertTrue(server.mediator.hasRoom("auto-room"))
@@ -262,14 +269,14 @@ class NodeRoomServerTest {
         val roomServer = createTestRoomServer(backgroundScope)
         val server = NodeRoomServer("node-1", transport, roomServer, backgroundScope)
         server.connect()
-        delay(100)
+        testScheduler.advanceTimeBy(1)
 
         val client1 = FakeClientConnection()
         val client2 = FakeClientConnection()
 
         val job1 = backgroundScope.launch { server.handleClient("room-1", "session-1", client1) }
         val job2 = backgroundScope.launch { server.handleClient("room-1", "session-2", client2) }
-        delay(100)
+        testScheduler.advanceTimeBy(1)
 
         // Both clients are in the same room
         val room = roomServer.getRoom("room-1")!!
@@ -277,14 +284,14 @@ class NodeRoomServerTest {
 
         // Client 1 sends an action — forwarded to Central
         client1.simulateIncoming(TestAction.Add("from-client-1"))
-        delay(100)
+        testScheduler.advanceTimeBy(1)
 
         assertEquals(1, transport.sentActions.size)
         assertTrue(room.currentState.items.contains("from-client-1"))
 
         job1.cancel()
         job2.cancel()
-        delay(100)
+        testScheduler.advanceTimeBy(1)
         server.close()
     }
 
@@ -294,16 +301,16 @@ class NodeRoomServerTest {
         val roomServer = createTestRoomServer(backgroundScope)
         val server = NodeRoomServer("node-1", transport, roomServer, backgroundScope)
         server.connect()
-        delay(100)
+        testScheduler.advanceTimeBy(1)
 
         // Create room first via handleClient
         val clientConn = FakeClientConnection()
         val job = backgroundScope.launch { server.handleClient("room-1", "session-1", clientConn) }
-        delay(100)
+        testScheduler.advanceTimeBy(1)
 
         // Use dispatchAndForward
         server.dispatchAndForward("room-1", TestAction.Add("dispatched"))
-        delay(100)
+        testScheduler.advanceTimeBy(1)
 
         // Verify store was updated
         val room = roomServer.getRoom("room-1")!!
@@ -315,7 +322,7 @@ class NodeRoomServerTest {
         })
 
         job.cancel()
-        delay(100)
+        testScheduler.advanceTimeBy(1)
         server.close()
     }
 
@@ -325,20 +332,20 @@ class NodeRoomServerTest {
         val roomServer = createTestRoomServer(backgroundScope)
         val server = NodeRoomServer("node-1", transport, roomServer, backgroundScope)
         server.connect()
-        delay(100)
+        testScheduler.advanceTimeBy(1)
 
         // Create two rooms
         val client1 = FakeClientConnection()
         val client2 = FakeClientConnection()
         val job1 = backgroundScope.launch { server.handleClient("room-1", "session-1", client1) }
         val job2 = backgroundScope.launch { server.handleClient("room-2", "session-2", client2) }
-        delay(100)
+        testScheduler.advanceTimeBy(1)
 
         assertEquals(2, server.roomIds().size)
 
         // Disconnect client 1 only
         job1.cancel()
-        delay(100)
+        testScheduler.advanceTimeBy(1)
 
         // Cleanup empty rooms
         val destroyed = server.cleanupEmptyRooms()
@@ -347,7 +354,7 @@ class NodeRoomServerTest {
         assertTrue(server.mediator.hasRoom("room-2"))
 
         job2.cancel()
-        delay(100)
+        testScheduler.advanceTimeBy(1)
         server.close()
     }
 
@@ -357,14 +364,50 @@ class NodeRoomServerTest {
         val roomServer = createTestRoomServer(backgroundScope)
         val server = NodeRoomServer("node-1", transport, roomServer, backgroundScope)
         server.connect()
-        delay(100)
+        testScheduler.advanceTimeBy(1)
 
         // Should not throw for nonexistent room
         server.dispatchAndForward("nonexistent", TestAction.Add("nothing"))
-        delay(100)
+        testScheduler.advanceTimeBy(1)
 
         assertEquals(0, transport.sentActions.size)
 
+        server.close()
+    }
+
+    @Test
+    fun clientReceivesSyncStateFlowViaTurbine() = runTest {
+        val transport = FakeNodeTransport()
+        val roomServer = createTestRoomServer(backgroundScope)
+        val server = NodeRoomServer("node-1", transport, roomServer, backgroundScope)
+        server.connect()
+        testScheduler.advanceTimeBy(1)
+
+        val clientConn = FakeClientConnection()
+
+        // Start Turbine collection BEFORE handleClient to capture initial state sync
+        clientConn.sentFlow.test {
+            val job = backgroundScope.launch {
+                server.handleClient("room-1", "session-1", clientConn)
+            }
+            testScheduler.advanceTimeBy(1)
+
+            // Initial SyncState on connection
+            assertEquals(TestAction.Sync(emptyList()), awaitItem())
+
+            // Central sends actions — verify client receives updated SyncState
+            transport.simulateIncoming(NodeAction("room-1", TestAction.Add("item-1")))
+            testScheduler.advanceTimeBy(1)
+            assertEquals(TestAction.Sync(listOf("item-1")), awaitItem())
+
+            transport.simulateIncoming(NodeAction("room-1", TestAction.Add("item-2")))
+            testScheduler.advanceTimeBy(1)
+            assertEquals(TestAction.Sync(listOf("item-1", "item-2")), awaitItem())
+
+            job.cancel()
+        }
+
+        testScheduler.advanceTimeBy(1)
         server.close()
     }
 }

--- a/kotlin/remote/serialization/build.gradle.kts
+++ b/kotlin/remote/serialization/build.gradle.kts
@@ -13,7 +13,7 @@ mavenPublishing {
 }
 
 // JitPack only publishes JVM artifacts to avoid variant resolution issues for JVM/Android consumers
-val isJitPack = System.getenv("JITPACK") == "true"
+val isJitPack = providers.environmentVariable("JITPACK").map { it == "true" }.getOrElse(false)
 
 kotlin {
     jvm()

--- a/kotlin/remote/serialization/build.gradle.kts
+++ b/kotlin/remote/serialization/build.gradle.kts
@@ -5,7 +5,11 @@ plugins {
 }
 
 mavenPublishing {
-    coordinates("io.github.chibimoons", "flowdux-remote-serialization", providers.gradleProperty("flowdux.version").get())
+    coordinates(
+        "io.github.chibimoons",
+        "flowdux-remote-serialization",
+        providers.gradleProperty("flowdux.version").get(),
+    )
     pom {
         name.set("Flowdux Remote Serialization")
         description.set("kotlinx.serialization-based ActionCodec for Flowdux remote state management")

--- a/kotlin/remote/serialization/src/commonMain/kotlin/io/flowdux/remote/ActionCodec.kt
+++ b/kotlin/remote/serialization/src/commonMain/kotlin/io/flowdux/remote/ActionCodec.kt
@@ -42,6 +42,7 @@ import kotlinx.coroutines.CancellationException
  */
 interface ActionCodec<A : Action> {
     fun encode(action: A): String
+
     fun decode(json: String): A
 }
 

--- a/kotlin/remote/serialization/src/commonMain/kotlin/io/flowdux/remote/ActionCodec.kt
+++ b/kotlin/remote/serialization/src/commonMain/kotlin/io/flowdux/remote/ActionCodec.kt
@@ -1,12 +1,32 @@
 package io.flowdux.remote
 
 import io.flowdux.Action
+import kotlinx.coroutines.CancellationException
 
 /**
  * Codec for serializing and deserializing actions.
  *
  * Applications must implement this interface to define how their
  * action types are converted to/from JSON strings for wire transmission.
+ *
+ * ## Version mismatch handling
+ *
+ * During rolling updates, clients and servers may temporarily run different
+ * versions of the action schema. Use [decodeOrNull] to gracefully skip
+ * unrecognized action types instead of crashing:
+ *
+ * ```kotlin
+ * val action = codec.decodeOrNull(json)
+ * if (action == null) {
+ *     logger.warn("Unknown action type, skipping: $json")
+ * } else {
+ *     // process the decoded action
+ * }
+ * ```
+ *
+ * The typed connection layer ([TypedClientConnection] / [io.flowdux.remote.server.connection.TypedServerConnection])
+ * already handles decode failures via the `onDecodeError` callback —
+ * unrecognized actions are skipped and processing continues.
  *
  * Example:
  * ```kotlin
@@ -23,4 +43,19 @@ import io.flowdux.Action
 interface ActionCodec<A : Action> {
     fun encode(action: A): String
     fun decode(json: String): A
+}
+
+/**
+ * Decodes the given JSON string, returning `null` if decoding fails.
+ *
+ * This is useful for graceful handling of action type version mismatches
+ * during rolling updates — unknown or incompatible action types return `null`
+ * instead of throwing an exception.
+ */
+fun <A : Action> ActionCodec<A>.decodeOrNull(json: String): A? = try {
+    decode(json)
+} catch (e: CancellationException) {
+    throw e
+} catch (_: Exception) {
+    null
 }

--- a/kotlin/remote/serialization/src/commonMain/kotlin/io/flowdux/remote/DefaultTypedClientConnection.kt
+++ b/kotlin/remote/serialization/src/commonMain/kotlin/io/flowdux/remote/DefaultTypedClientConnection.kt
@@ -16,32 +16,34 @@ internal class DefaultTypedClientConnection<A : Action>(
     private val messageCodec: MessageCodec,
     private val onDecodeError: ((Exception) -> Unit)? = null,
 ) : TypedClientConnection<A> {
-
     override val connectionState: StateFlow<ConnectionState>
         get() = connection.connectionState
 
     @Suppress("UNCHECKED_CAST")
-    override val incoming: Flow<A> = connection.incoming.transform { raw ->
-        val response = try {
-            messageCodec.decodeServerMessage(raw)
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            onDecodeError?.invoke(e)
-            return@transform
-        }
-        for (actionJson in response.actions) {
-            val action = try {
-                actionCodec.decode(actionJson)
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                onDecodeError?.invoke(e)
-                continue
+    override val incoming: Flow<A> =
+        connection.incoming.transform { raw ->
+            val response =
+                try {
+                    messageCodec.decodeServerMessage(raw)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    onDecodeError?.invoke(e)
+                    return@transform
+                }
+            for (actionJson in response.actions) {
+                val action =
+                    try {
+                        actionCodec.decode(actionJson)
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        onDecodeError?.invoke(e)
+                        continue
+                    }
+                emit(action)
             }
-            emit(action)
         }
-    }
 
     override suspend fun send(action: A) {
         val actionJson = actionCodec.encode(action)

--- a/kotlin/remote/serialization/src/commonMain/kotlin/io/flowdux/remote/RemoteMessage.kt
+++ b/kotlin/remote/serialization/src/commonMain/kotlin/io/flowdux/remote/RemoteMessage.kt
@@ -5,6 +5,4 @@ package io.flowdux.remote
  *
  * @property actions Serialized action JSON strings to be dispatched to the local store.
  */
-data class ServerResponse(
-    val actions: List<String>,
-)
+data class ServerResponse(val actions: List<String>)

--- a/kotlin/remote/serialization/src/commonMain/kotlin/io/flowdux/remote/serialization/JsonMessageCodec.kt
+++ b/kotlin/remote/serialization/src/commonMain/kotlin/io/flowdux/remote/serialization/JsonMessageCodec.kt
@@ -5,6 +5,7 @@ import io.flowdux.remote.ServerResponse
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonUnquotedLiteral
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
@@ -22,10 +23,9 @@ class JsonMessageCodec(
 ) : MessageCodec {
 
     override fun encodeActionMessage(actionJson: String): String {
-        val payload = json.parseToJsonElement(actionJson)
         return json.encodeToString(JsonElement.serializer(), buildJsonObject {
             put("type", "action")
-            put("payload", payload)
+            put("payload", JsonUnquotedLiteral(actionJson))
         })
     }
 
@@ -33,11 +33,11 @@ class JsonMessageCodec(
         val obj = json.parseToJsonElement(raw).jsonObject
         val payload = obj["payload"]
             ?: error("Missing \"payload\" field in client message: $raw")
-        return json.encodeToString(JsonElement.serializer(), payload)
+        return payload.toString()
     }
 
     override fun encodeServerResponse(actions: List<String>): String {
-        val elements = actions.map { json.parseToJsonElement(it) }
+        val elements = actions.map { JsonUnquotedLiteral(it) }
         return json.encodeToString(JsonElement.serializer(), buildJsonObject {
             put("type", "response")
             put("actions", JsonArray(elements))
@@ -48,9 +48,7 @@ class JsonMessageCodec(
         val obj = json.parseToJsonElement(raw).jsonObject
         val actionsElement = obj["actions"]
             ?: error("Missing \"actions\" field in server message: $raw")
-        val actions = actionsElement.jsonArray.map {
-            json.encodeToString(JsonElement.serializer(), it)
-        }
+        val actions = actionsElement.jsonArray.map { it.toString() }
         return ServerResponse(actions = actions)
     }
 }

--- a/kotlin/remote/serialization/src/commonMain/kotlin/io/flowdux/remote/serialization/JsonMessageCodec.kt
+++ b/kotlin/remote/serialization/src/commonMain/kotlin/io/flowdux/remote/serialization/JsonMessageCodec.kt
@@ -18,36 +18,39 @@ import kotlinx.serialization.json.put
  * - Client → Server: `{"type":"action","payload":{...}}`
  * - Server → Client: `{"type":"response","actions":[{...},...]}`
  */
-class JsonMessageCodec(
-    private val json: Json = Json,
-) : MessageCodec {
-
-    override fun encodeActionMessage(actionJson: String): String {
-        return json.encodeToString(JsonElement.serializer(), buildJsonObject {
+class JsonMessageCodec(private val json: Json = Json) : MessageCodec {
+    override fun encodeActionMessage(actionJson: String): String = json.encodeToString(
+        JsonElement.serializer(),
+        buildJsonObject {
             put("type", "action")
             put("payload", JsonUnquotedLiteral(actionJson))
-        })
-    }
+        },
+    )
 
     override fun decodeActionFromClient(raw: String): String {
         val obj = json.parseToJsonElement(raw).jsonObject
-        val payload = obj["payload"]
-            ?: error("Missing \"payload\" field in client message: $raw")
+        val payload =
+            obj["payload"]
+                ?: error("Missing \"payload\" field in client message: $raw")
         return payload.toString()
     }
 
     override fun encodeServerResponse(actions: List<String>): String {
         val elements = actions.map { JsonUnquotedLiteral(it) }
-        return json.encodeToString(JsonElement.serializer(), buildJsonObject {
-            put("type", "response")
-            put("actions", JsonArray(elements))
-        })
+        return json.encodeToString(
+            JsonElement.serializer(),
+            buildJsonObject {
+                put("type", "response")
+                put("actions", JsonArray(elements))
+            },
+        )
     }
 
     override fun decodeServerMessage(raw: String): ServerResponse {
         val obj = json.parseToJsonElement(raw).jsonObject
-        val actionsElement = obj["actions"]
-            ?: error("Missing \"actions\" field in server message: $raw")
+        val actionsElement =
+            obj["actions"]
+                ?: error("Missing \"actions\" field in server message: $raw")
         val actions = actionsElement.jsonArray.map { it.toString() }
         return ServerResponse(actions = actions)
     }

--- a/kotlin/remote/serialization/src/commonMain/kotlin/io/flowdux/remote/serialization/SerializableActionCodec.kt
+++ b/kotlin/remote/serialization/src/commonMain/kotlin/io/flowdux/remote/serialization/SerializableActionCodec.kt
@@ -33,16 +33,16 @@ class SerializableActionCodec<A : Action>(
     private val serializer: KSerializer<A>,
     private val json: Json = DefaultJson,
 ) : ActionCodec<A> {
-
     override fun encode(action: A): String = json.encodeToString(serializer, action)
 
     override fun decode(json: String): A = this.json.decodeFromString(serializer, json)
 
     companion object {
-        val DefaultJson: Json = Json {
-            classDiscriminator = "type"
-            ignoreUnknownKeys = true
-        }
+        val DefaultJson: Json =
+            Json {
+                classDiscriminator = "type"
+                ignoreUnknownKeys = true
+            }
     }
 }
 
@@ -55,6 +55,5 @@ class SerializableActionCodec<A : Action>(
  * val middleware = MySyncMiddleware(typedConnection)
  * ```
  */
-inline fun <reified A : Action> actionCodecOf(
-    json: Json = SerializableActionCodec.DefaultJson,
-): ActionCodec<A> = SerializableActionCodec(serializer(), json)
+inline fun <reified A : Action> actionCodecOf(json: Json = SerializableActionCodec.DefaultJson): ActionCodec<A> =
+    SerializableActionCodec(serializer(), json)

--- a/kotlin/remote/serialization/src/commonMain/kotlin/io/flowdux/remote/serialization/SerializableActionCodec.kt
+++ b/kotlin/remote/serialization/src/commonMain/kotlin/io/flowdux/remote/serialization/SerializableActionCodec.kt
@@ -16,6 +16,14 @@ import kotlinx.serialization.serializer
  * To use short names like `{"type":"SendMessage", ...}`, annotate subclasses
  * with `@SerialName("SendMessage")`.
  *
+ * ## Forward compatibility
+ *
+ * [DefaultJson] enables `ignoreUnknownKeys`, so actions serialized by a newer
+ * schema version (with additional fields) can still be decoded by an older version.
+ * Unknown type discriminators (entirely new action subclasses) will still throw
+ * [kotlinx.serialization.SerializationException] — use [io.flowdux.remote.decodeOrNull] or the
+ * `onDecodeError` callback on typed connections to handle those gracefully.
+ *
  * Usage:
  * ```kotlin
  * val codec = actionCodecOf<ChatAction>()
@@ -33,6 +41,7 @@ class SerializableActionCodec<A : Action>(
     companion object {
         val DefaultJson: Json = Json {
             classDiscriminator = "type"
+            ignoreUnknownKeys = true
         }
     }
 }

--- a/kotlin/remote/serialization/src/commonMain/kotlin/io/flowdux/remote/serialization/TypedConnectionExt.kt
+++ b/kotlin/remote/serialization/src/commonMain/kotlin/io/flowdux/remote/serialization/TypedConnectionExt.kt
@@ -124,7 +124,8 @@ inline fun <reified Wire : A, reified A : Action> ServerConnection.typedJsonAs(
  * @param Super The broader action type that [Sub] extends
  * @throws IllegalArgumentException if [send] is called with an action that is not a [Sub] instance
  */
-inline fun <reified Sub : Super, reified Super : Action> TypedClientConnection<Sub>.upcast(): TypedClientConnection<Super> =
+inline fun <reified Sub : Super, reified Super : Action> TypedClientConnection<Sub>.upcast():
+    TypedClientConnection<Super> =
     UpcastTypedClientConnection(this, Sub::class)
 
 /**
@@ -150,7 +151,8 @@ inline fun <reified Sub : Super, reified Super : Action> TypedClientConnection<S
  * @param Super The broader action type that [Sub] extends
  * @throws IllegalArgumentException if [send] is called with an action that is not a [Sub] instance
  */
-inline fun <reified Sub : Super, reified Super : Action> TypedServerConnection<Sub>.upcast(): TypedServerConnection<Super> =
+inline fun <reified Sub : Super, reified Super : Action> TypedServerConnection<Sub>.upcast():
+    TypedServerConnection<Super> =
     UpcastTypedServerConnection(this, Sub::class)
 
 /**
@@ -158,10 +160,7 @@ inline fun <reified Sub : Super, reified Super : Action> TypedServerConnection<S
  * @throws IllegalArgumentException if the action type doesn't match
  */
 @Suppress("UNCHECKED_CAST")
-internal fun <Sub : Super, Super : Action> validateAndCast(
-    action: Super,
-    subClass: kotlin.reflect.KClass<Sub>,
-): Sub {
+internal fun <Sub : Super, Super : Action> validateAndCast(action: Super, subClass: kotlin.reflect.KClass<Sub>): Sub {
     require(subClass.isInstance(action)) {
         "Cannot send ${action::class.simpleName} through connection typed for ${subClass.simpleName}"
     }

--- a/kotlin/remote/serialization/src/commonMain/kotlin/io/flowdux/remote/server/DefaultTypedServerConnection.kt
+++ b/kotlin/remote/serialization/src/commonMain/kotlin/io/flowdux/remote/server/DefaultTypedServerConnection.kt
@@ -19,20 +19,20 @@ internal class DefaultTypedServerConnection<A : Action>(
     private val messageCodec: MessageCodec,
     private val onDecodeError: ((Exception) -> Unit)? = null,
 ) : TypedServerConnection<A> {
-
     override val isActive: Boolean get() = connection.isActive
 
-    override val incoming: Flow<A> = connection.incoming.mapNotNull { raw ->
-        try {
-            val actionJson = messageCodec.decodeActionFromClient(raw)
-            actionCodec.decode(actionJson)
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            onDecodeError?.invoke(e)
-            null
+    override val incoming: Flow<A> =
+        connection.incoming.mapNotNull { raw ->
+            try {
+                val actionJson = messageCodec.decodeActionFromClient(raw)
+                actionCodec.decode(actionJson)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                onDecodeError?.invoke(e)
+                null
+            }
         }
-    }
 
     override suspend fun send(action: A) {
         val actionJson = actionCodec.encode(action)

--- a/kotlin/remote/serialization/src/commonTest/kotlin/io/flowdux/remote/serialization/DefaultTypedConnectionTest.kt
+++ b/kotlin/remote/serialization/src/commonTest/kotlin/io/flowdux/remote/serialization/DefaultTypedConnectionTest.kt
@@ -40,7 +40,9 @@ class DefaultTypedConnectionTest {
         override suspend fun connect() {}
         override suspend fun disconnect() {}
 
-        fun emit(raw: String) { _incoming.tryEmit(raw) }
+        fun emit(raw: String) {
+            _incoming.tryEmit(raw)
+        }
     }
 
     // -- Mock ServerConnection --
@@ -51,7 +53,9 @@ class DefaultTypedConnectionTest {
         override val incoming: Flow<String> = _incoming
         override suspend fun send(message: String) {}
 
-        fun emit(raw: String) { _incoming.tryEmit(raw) }
+        fun emit(raw: String) {
+            _incoming.tryEmit(raw)
+        }
     }
 
     // -- Failing codecs --
@@ -65,7 +69,8 @@ class DefaultTypedConnectionTest {
         override fun encodeActionMessage(actionJson: String) = ""
         override fun decodeActionFromClient(raw: String): String = throw RuntimeException("message decode failed")
         override fun encodeServerResponse(actions: List<String>) = ""
-        override fun decodeServerMessage(raw: String): ServerResponse = throw RuntimeException("server message decode failed")
+        override fun decodeServerMessage(raw: String): ServerResponse =
+            throw RuntimeException("server message decode failed")
     }
 
     private val goodActionCodec = actionCodecOf<TestAction>()
@@ -116,7 +121,11 @@ class DefaultTypedConnectionTest {
         yield()
 
         // Valid server response wrapping an action
-        val serverMsg = goodMessageCodec.encodeServerResponse(listOf("""{"type":"io.flowdux.remote.serialization.DefaultTypedConnectionTest.TestAction.Ping","id":1}"""))
+        val serverMsg = goodMessageCodec.encodeServerResponse(
+            listOf(
+                """{"type":"io.flowdux.remote.serialization.DefaultTypedConnectionTest.TestAction.Ping","id":1}""",
+            ),
+        )
         mockConn.emit(serverMsg)
         yield()
 
@@ -228,7 +237,9 @@ class DefaultTypedConnectionTest {
         yield()
 
         // Valid client message wrapping an action
-        val clientMsg = goodMessageCodec.encodeActionMessage("""{"type":"io.flowdux.remote.serialization.DefaultTypedConnectionTest.TestAction.Ping","id":1}""")
+        val clientMsg = goodMessageCodec.encodeActionMessage(
+            """{"type":"io.flowdux.remote.serialization.DefaultTypedConnectionTest.TestAction.Ping","id":1}""",
+        )
         mockConn.emit(clientMsg)
         yield()
 

--- a/kotlin/remote/serialization/src/commonTest/kotlin/io/flowdux/remote/serialization/JsonMessageCodecTest.kt
+++ b/kotlin/remote/serialization/src/commonTest/kotlin/io/flowdux/remote/serialization/JsonMessageCodecTest.kt
@@ -1,10 +1,9 @@
 package io.flowdux.remote.serialization
 
-import kotlin.test.assertEquals
 import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class JsonMessageCodecTest {
-
     private val codec = JsonMessageCodec()
 
     @Test
@@ -63,10 +62,11 @@ class JsonMessageCodecTest {
 
     @Test
     fun roundtripServerResponse() {
-        val actions = listOf(
-            """{"type":"Add","value":1}""",
-            """{"type":"SetMessage","message":"hello"}""",
-        )
+        val actions =
+            listOf(
+                """{"type":"Add","value":1}""",
+                """{"type":"SetMessage","message":"hello"}""",
+            )
 
         val encoded = codec.encodeServerResponse(actions)
         val decoded = codec.decodeServerMessage(encoded)

--- a/kotlin/remote/serialization/src/commonTest/kotlin/io/flowdux/remote/serialization/SerializableActionCodecTest.kt
+++ b/kotlin/remote/serialization/src/commonTest/kotlin/io/flowdux/remote/serialization/SerializableActionCodecTest.kt
@@ -1,11 +1,13 @@
 package io.flowdux.remote.serialization
 
 import io.flowdux.Action
+import io.flowdux.remote.decodeOrNull
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class SerializableActionCodecTest {
@@ -91,5 +93,50 @@ class SerializableActionCodecTest {
         assertFailsWith<SerializationException> {
             codec.decode("""{"type":"io.flowdux.remote.serialization.SerializableActionCodecTest.TestAction.Add"}""")
         }
+    }
+
+    // --- decodeOrNull ---
+
+    @Test
+    fun decodeOrNullReturnsActionForValidJson() {
+        val json = codec.encode(TestAction.Add(42))
+        val decoded = codec.decodeOrNull(json)
+        assertEquals(TestAction.Add(42), decoded)
+    }
+
+    @Test
+    fun decodeOrNullReturnsNullForUnknownType() {
+        val result = codec.decodeOrNull("""{"type":"NonExistent","value":1}""")
+        assertNull(result)
+    }
+
+    @Test
+    fun decodeOrNullReturnsNullForMalformedJson() {
+        val result = codec.decodeOrNull("not json at all")
+        assertNull(result)
+    }
+
+    @Test
+    fun decodeOrNullReturnsNullForMissingRequiredField() {
+        val result = codec.decodeOrNull(
+            """{"type":"io.flowdux.remote.serialization.SerializableActionCodecTest.TestAction.Add"}""",
+        )
+        assertNull(result)
+    }
+
+    // --- ignoreUnknownKeys (forward compatibility) ---
+
+    @Test
+    fun decodeIgnoresUnknownFields() {
+        val json = """{"type":"io.flowdux.remote.serialization.SerializableActionCodecTest.TestAction.Add","value":10,"newField":"ignored"}"""
+        val decoded = codec.decode(json)
+        assertEquals(TestAction.Add(10), decoded)
+    }
+
+    @Test
+    fun decodeIgnoresUnknownFieldsOnDataObject() {
+        val json = """{"type":"io.flowdux.remote.serialization.SerializableActionCodecTest.TestAction.Increment","extraKey":true}"""
+        val decoded = codec.decode(json)
+        assertEquals(TestAction.Increment, decoded)
     }
 }

--- a/kotlin/remote/serialization/src/commonTest/kotlin/io/flowdux/remote/serialization/SerializableActionCodecTest.kt
+++ b/kotlin/remote/serialization/src/commonTest/kotlin/io/flowdux/remote/serialization/SerializableActionCodecTest.kt
@@ -11,11 +11,12 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class SerializableActionCodecTest {
-
     @Serializable
     sealed interface TestAction : Action {
         @Serializable data object Increment : TestAction
+
         @Serializable data class Add(val value: Int) : TestAction
+
         @Serializable data class SetName(val name: String) : TestAction
     }
 
@@ -54,13 +55,14 @@ class SerializableActionCodecTest {
 
     @Test
     fun roundTripAllVariants() {
-        val actions = listOf(
-            TestAction.Increment,
-            TestAction.Add(0),
-            TestAction.Add(-1),
-            TestAction.SetName(""),
-            TestAction.SetName("test"),
-        )
+        val actions =
+            listOf(
+                TestAction.Increment,
+                TestAction.Add(0),
+                TestAction.Add(-1),
+                TestAction.SetName(""),
+                TestAction.SetName("test"),
+            )
         for (action in actions) {
             val encoded = codec.encode(action)
             val decoded = codec.decode(encoded)
@@ -126,16 +128,21 @@ class SerializableActionCodecTest {
 
     // --- ignoreUnknownKeys (forward compatibility) ---
 
+    private val typePrefix =
+        "io.flowdux.remote.serialization.SerializableActionCodecTest.TestAction"
+
     @Test
     fun decodeIgnoresUnknownFields() {
-        val json = """{"type":"io.flowdux.remote.serialization.SerializableActionCodecTest.TestAction.Add","value":10,"newField":"ignored"}"""
+        val json =
+            """{"type":"$typePrefix.Add","value":10,"newField":"ignored"}"""
         val decoded = codec.decode(json)
         assertEquals(TestAction.Add(10), decoded)
     }
 
     @Test
     fun decodeIgnoresUnknownFieldsOnDataObject() {
-        val json = """{"type":"io.flowdux.remote.serialization.SerializableActionCodecTest.TestAction.Increment","extraKey":true}"""
+        val json =
+            """{"type":"$typePrefix.Increment","extraKey":true}"""
         val decoded = codec.decode(json)
         assertEquals(TestAction.Increment, decoded)
     }

--- a/kotlin/remote/serialization/src/commonTest/kotlin/io/flowdux/remote/serialization/UpcastConnectionTest.kt
+++ b/kotlin/remote/serialization/src/commonTest/kotlin/io/flowdux/remote/serialization/UpcastConnectionTest.kt
@@ -7,7 +7,6 @@ import io.flowdux.remote.server.connection.TypedServerConnection
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
@@ -17,12 +16,13 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class UpcastConnectionTest {
-
     // -- Test Action Hierarchy --
     interface AppAction : Action
+
     sealed interface SharedAction : AppAction {
         data class Message(val text: String) : SharedAction
     }
+
     data class LocalAction(val value: Int) : AppAction
 
     // -- Mock TypedClientConnection --

--- a/kotlin/remote/server/build.gradle.kts
+++ b/kotlin/remote/server/build.gradle.kts
@@ -12,7 +12,7 @@ mavenPublishing {
 }
 
 // JitPack only publishes JVM artifacts to avoid variant resolution issues for JVM/Android consumers
-val isJitPack = System.getenv("JITPACK") == "true"
+val isJitPack = providers.environmentVariable("JITPACK").map { it == "true" }.getOrElse(false)
 
 kotlin {
     jvm()

--- a/kotlin/remote/server/src/commonMain/kotlin/io/flowdux/remote/server/CreateServerStore.kt
+++ b/kotlin/remote/server/src/commonMain/kotlin/io/flowdux/remote/server/CreateServerStore.kt
@@ -71,14 +71,15 @@ fun <S : State, A : Action> createServerStore(
     // Order: additionalMiddlewares -> syncMiddleware -> forwarder
     val allMiddlewares = additionalMiddlewares + syncMiddleware + forwarder
 
-    store = createStore(
-        initialState = initialState,
-        middlewares = allMiddlewares,
-        reducer = reducer,
-        errorProcessor = errorProcessor,
-        logger = logger,
-        scope = scope,
-        concurrency = concurrency,
-    )
+    store =
+        createStore(
+            initialState = initialState,
+            middlewares = allMiddlewares,
+            reducer = reducer,
+            errorProcessor = errorProcessor,
+            logger = logger,
+            scope = scope,
+            concurrency = concurrency,
+        )
     return store
 }

--- a/kotlin/remote/server/src/commonMain/kotlin/io/flowdux/remote/server/StoreServeExt.kt
+++ b/kotlin/remote/server/src/commonMain/kotlin/io/flowdux/remote/server/StoreServeExt.kt
@@ -16,9 +16,7 @@ import io.flowdux.remote.server.middleware.InternalStartListening
  * @param wrapState Maps the current state to an action (typically a [ClientSharedAction][io.flowdux.remote.ClientSharedAction])
  *   that the server middleware will send to the client.
  */
-suspend fun <S : State, A : Action> Store<S, A>.serveState(
-    wrapState: (S) -> A,
-) {
+suspend fun <S : State, A : Action> Store<S, A>.serveState(wrapState: (S) -> A) {
     state.collect { dispatch(wrapState(it)) }
 }
 
@@ -33,9 +31,7 @@ suspend fun <S : State, A : Action> Store<S, A>.serveState(
  * }
  * ```
  */
-suspend inline fun <S : State, A : Action> Store<S, A>.use(
-    block: suspend Store<S, A>.() -> Unit,
-) {
+suspend inline fun <S : State, A : Action> Store<S, A>.use(block: suspend Store<S, A>.() -> Unit) {
     try {
         block()
     } finally {
@@ -63,9 +59,7 @@ suspend inline fun <S : State, A : Action> Store<S, A>.use(
  *   that the server middleware will send to the client.
  */
 @Suppress("UNCHECKED_CAST")
-suspend fun <S : State, A : Action> Store<S, A>.serve(
-    wrapState: (S) -> A,
-) = use {
+suspend fun <S : State, A : Action> Store<S, A>.serve(wrapState: (S) -> A) = use {
     dispatch(InternalStartListening() as A)
     serveState(wrapState)
 }

--- a/kotlin/remote/server/src/commonMain/kotlin/io/flowdux/remote/server/middleware/ClientSharedActionForwarder.kt
+++ b/kotlin/remote/server/src/commonMain/kotlin/io/flowdux/remote/server/middleware/ClientSharedActionForwarder.kt
@@ -25,10 +25,8 @@ import kotlinx.coroutines.flow.flowOf
  *
  * @param dispatch Function to re-dispatch actions through the full Store pipeline.
  */
-internal class ClientSharedActionForwarder<S : State, A : Action>(
-    private val dispatch: (A) -> Unit,
-) : Middleware<S, A> {
-
+internal class ClientSharedActionForwarder<S : State, A : Action>(private val dispatch: (A) -> Unit) :
+    Middleware<S, A> {
     override val processors: ActionProcessorMap<S, A> = emptyMap()
 
     override fun process(getState: () -> S, action: A): Flow<A> {

--- a/kotlin/remote/server/src/commonMain/kotlin/io/flowdux/remote/server/middleware/MultiClientSyncMiddleware.kt
+++ b/kotlin/remote/server/src/commonMain/kotlin/io/flowdux/remote/server/middleware/MultiClientSyncMiddleware.kt
@@ -49,10 +49,8 @@ internal class InternalSessionListener(
  *
  * Dispatched directly from [createSharedStateServer][io.flowdux.remote.server.pattern.createSharedStateServer].
  */
-internal class InternalStateServing(
-    private val stateFlow: StateFlow<*>,
-    private val stateMapper: (Any) -> Action,
-) : FlowHolderAction {
+internal class InternalStateServing(private val stateFlow: StateFlow<*>, private val stateMapper: (Any) -> Action) :
+    FlowHolderAction {
     override val delivery: FlowActionDelivery get() = FlowActionDelivery.Dispatch
     override val strategy: ExecutionStrategy get() = sequential()
 
@@ -93,10 +91,7 @@ internal class InternalPerSessionStateServing(
 /**
  * Internal action dispatched to send an action to a specific client.
  */
-class InternalSendToClient(
-    val sessionId: String,
-    val action: Action,
-) : Action
+class InternalSendToClient(val sessionId: String, val action: Action) : Action
 
 /**
  * Internal middleware that routes actions for multiple client connections.
@@ -122,7 +117,6 @@ class MultiClientSyncMiddleware<S : State, A : Action>(
     override val processors: ActionProcessorMap<S, A> = emptyMap(),
     internal val broadcaster: SessionBroadcaster<A>,
 ) : Middleware<S, A> {
-
     @Suppress("UNCHECKED_CAST")
     override fun process(getState: () -> S, action: A): Flow<A> = flow {
         // 1. InternalSendToClient: send action to specific client

--- a/kotlin/remote/server/src/commonMain/kotlin/io/flowdux/remote/server/middleware/MultiClientSyncMiddleware.kt
+++ b/kotlin/remote/server/src/commonMain/kotlin/io/flowdux/remote/server/middleware/MultiClientSyncMiddleware.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onCompletion
 
 // -- New top-level FlowHolderActions (direct dispatch, no middleware intermediary) --
 
@@ -30,11 +31,14 @@ import kotlinx.coroutines.flow.map
  */
 internal class InternalSessionListener(
     private val connection: TypedServerConnection<*>,
+    private val onTerminate: (() -> Unit)? = null,
 ) : FlowHolderAction {
     override val delivery: FlowActionDelivery get() = FlowActionDelivery.Dispatch
     override val strategy: ExecutionStrategy get() = concurrent()
 
-    override fun toFlowAction(): Flow<Action> = connection.incoming.map { it }
+    override fun toFlowAction(): Flow<Action> = connection.incoming
+        .map { it }
+        .onCompletion { runCatching { onTerminate?.invoke() } }
 }
 
 /**

--- a/kotlin/remote/server/src/commonMain/kotlin/io/flowdux/remote/server/middleware/SingleClientSyncMiddleware.kt
+++ b/kotlin/remote/server/src/commonMain/kotlin/io/flowdux/remote/server/middleware/SingleClientSyncMiddleware.kt
@@ -49,10 +49,8 @@ internal class InternalStartListening : Action
  *
  * @param connection The [TypedServerConnection] for communicating with the client.
  */
-open class SingleClientSyncMiddleware<S : State, A : Action>(
-    private val connection: TypedServerConnection<A>,
-) : Middleware<S, A> {
-
+open class SingleClientSyncMiddleware<S : State, A : Action>(private val connection: TypedServerConnection<A>) :
+    Middleware<S, A> {
     override val processors: ActionProcessorMap<S, A> = emptyMap()
 
     @Suppress("UNCHECKED_CAST")

--- a/kotlin/remote/server/src/commonMain/kotlin/io/flowdux/remote/server/pattern/PerClientServer.kt
+++ b/kotlin/remote/server/src/commonMain/kotlin/io/flowdux/remote/server/pattern/PerClientServer.kt
@@ -61,15 +61,13 @@ class PerClientServer<S : State, A : Action> internal constructor(
      * @param sessionId Unique identifier for this client session.
      * @param connection Typed connection for sending/receiving actions.
      */
-    override suspend fun handleClient(
-        sessionId: String,
-        connection: TypedServerConnection<A>,
-    ) {
-        val store = mutex.withLock {
-            sessionFactory(sessionId, connection).also { store ->
-                sessions[sessionId] = store
+    override suspend fun handleClient(sessionId: String, connection: TypedServerConnection<A>) {
+        val store =
+            mutex.withLock {
+                sessionFactory(sessionId, connection).also { store ->
+                    sessions[sessionId] = store
+                }
             }
-        }
 
         try {
             store.serve(stateMapper)
@@ -87,28 +85,22 @@ class PerClientServer<S : State, A : Action> internal constructor(
      * @param sessionId Unique identifier for the session.
      * @return The [Store] if the session exists, null otherwise.
      */
-    suspend fun getSession(sessionId: String): Store<S, A>? {
-        return mutex.withLock {
-            sessions[sessionId]
-        }
+    suspend fun getSession(sessionId: String): Store<S, A>? = mutex.withLock {
+        sessions[sessionId]
     }
 
     /**
      * Get a snapshot of all active session IDs.
      */
-    override suspend fun sessionIds(): Set<String> {
-        return mutex.withLock {
-            sessions.keys.toSet()
-        }
+    override suspend fun sessionIds(): Set<String> = mutex.withLock {
+        sessions.keys.toSet()
     }
 
     /**
      * Get the number of active sessions.
      */
-    override suspend fun sessionCount(): Int {
-        return mutex.withLock {
-            sessions.size
-        }
+    override suspend fun sessionCount(): Int = mutex.withLock {
+        sessions.size
     }
 
     /**
@@ -153,9 +145,7 @@ fun <S : State, A : Action> createPerClientServer(
     stateMapper: (S) -> A,
     scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
     sessionFactory: (sessionId: String, connection: TypedServerConnection<A>) -> Store<S, A>,
-): PerClientServer<S, A> {
-    return PerClientServer(sessionFactory, stateMapper, scope)
-}
+): PerClientServer<S, A> = PerClientServer(sessionFactory, stateMapper, scope)
 
 /**
  * Create a [PerClientServer] with simple configuration.
@@ -194,19 +184,17 @@ fun <S : State, A : Action> createPerClientServer(
     errorProcessor: ErrorProcessor<A> = DefaultErrorProcessor(),
     logger: StoreLogger<S, A> = NoOpStoreLogger(),
     scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
-): PerClientServer<S, A> {
-    return createPerClientServer(
-        stateMapper = stateMapper,
+): PerClientServer<S, A> = createPerClientServer(
+    stateMapper = stateMapper,
+    scope = scope,
+) { sessionId, connection ->
+    createSingleClientServer(
+        initialState = initialStateFactory(sessionId),
+        reducer = reducer,
+        connection = connection,
+        processors = processors,
+        errorProcessor = errorProcessor,
+        logger = logger,
         scope = scope,
-    ) { sessionId, connection ->
-        createSingleClientServer(
-            initialState = initialStateFactory(sessionId),
-            reducer = reducer,
-            connection = connection,
-            processors = processors,
-            errorProcessor = errorProcessor,
-            logger = logger,
-            scope = scope,
-        )
-    }
+    )
 }

--- a/kotlin/remote/server/src/commonMain/kotlin/io/flowdux/remote/server/pattern/RoomServer.kt
+++ b/kotlin/remote/server/src/commonMain/kotlin/io/flowdux/remote/server/pattern/RoomServer.kt
@@ -59,11 +59,9 @@ class RoomServer<H : ClientHandler<*>> internal constructor(
      * @param roomId Unique identifier for the room.
      * @return The [ClientHandler] for the room.
      */
-    suspend fun getOrCreateRoom(roomId: String): H {
-        return mutex.withLock {
-            rooms.getOrPut(roomId) {
-                roomFactory(roomId)
-            }
+    suspend fun getOrCreateRoom(roomId: String): H = mutex.withLock {
+        rooms.getOrPut(roomId) {
+            roomFactory(roomId)
         }
     }
 
@@ -73,10 +71,8 @@ class RoomServer<H : ClientHandler<*>> internal constructor(
      * @param roomId Unique identifier for the room.
      * @return The [ClientHandler] if the room exists, null otherwise.
      */
-    suspend fun getRoom(roomId: String): H? {
-        return mutex.withLock {
-            rooms[roomId]
-        }
+    suspend fun getRoom(roomId: String): H? = mutex.withLock {
+        rooms[roomId]
     }
 
     /**
@@ -85,13 +81,11 @@ class RoomServer<H : ClientHandler<*>> internal constructor(
      * @param roomId Unique identifier for the room.
      * @return true if the room existed and was destroyed, false otherwise.
      */
-    suspend fun destroyRoom(roomId: String): Boolean {
-        return mutex.withLock {
-            rooms.remove(roomId)?.let { room ->
-                room.close()
-                true
-            } ?: false
-        }
+    suspend fun destroyRoom(roomId: String): Boolean = mutex.withLock {
+        rooms.remove(roomId)?.let { room ->
+            room.close()
+            true
+        } ?: false
     }
 
     /**
@@ -115,19 +109,15 @@ class RoomServer<H : ClientHandler<*>> internal constructor(
     /**
      * Get a snapshot of all active room IDs.
      */
-    suspend fun roomIds(): Set<String> {
-        return mutex.withLock {
-            rooms.keys.toSet()
-        }
+    suspend fun roomIds(): Set<String> = mutex.withLock {
+        rooms.keys.toSet()
     }
 
     /**
      * Get the number of active rooms.
      */
-    suspend fun roomCount(): Int {
-        return mutex.withLock {
-            rooms.size
-        }
+    suspend fun roomCount(): Int = mutex.withLock {
+        rooms.size
     }
 
     /**
@@ -138,9 +128,12 @@ class RoomServer<H : ClientHandler<*>> internal constructor(
     suspend fun cleanupEmptyRooms(): List<String> {
         val destroyedRooms = mutableListOf<String>()
         mutex.withLock {
-            val emptyRoomIds = rooms.filter { (_, room) ->
-                room.sessionCount() == 0
-            }.keys.toList()
+            val emptyRoomIds =
+                rooms
+                    .filter { (_, room) ->
+                        room.sessionCount() == 0
+                    }.keys
+                    .toList()
 
             emptyRoomIds.forEach { roomId ->
                 rooms.remove(roomId)?.let { room ->
@@ -201,9 +194,7 @@ class RoomServer<H : ClientHandler<*>> internal constructor(
 fun <H : ClientHandler<*>> createRoomServer(
     scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
     roomFactory: (roomId: String) -> H,
-): RoomServer<H> {
-    return RoomServer(roomFactory, scope)
-}
+): RoomServer<H> = RoomServer(roomFactory, scope)
 
 /**
  * Create a [RoomServer] with [SharedStateServer] rooms using simple configuration.
@@ -241,20 +232,18 @@ fun <S : State, A : Action> createSharedStateRoomServer(
     errorProcessor: ErrorProcessor<A> = DefaultErrorProcessor(),
     logger: StoreLogger<S, A> = NoOpStoreLogger(),
     scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
-): RoomServer<SharedStateServer<S, A>> {
-    return createRoomServer(scope) { roomId ->
-        createSharedStateServer(
-            initialState = initialStateFactory(roomId),
-            reducer = reducer,
-            stateMapper = stateMapper,
-            processors = processors,
-            sessionRegistry = sessionRegistryFactory(),
-            broadcastConfig = broadcastConfig,
-            errorProcessor = errorProcessor,
-            logger = logger,
-            scope = scope,
-        )
-    }
+): RoomServer<SharedStateServer<S, A>> = createRoomServer(scope) { roomId ->
+    createSharedStateServer(
+        initialState = initialStateFactory(roomId),
+        reducer = reducer,
+        stateMapper = stateMapper,
+        processors = processors,
+        sessionRegistry = sessionRegistryFactory(),
+        broadcastConfig = broadcastConfig,
+        errorProcessor = errorProcessor,
+        logger = logger,
+        scope = scope,
+    )
 }
 
 /**
@@ -297,16 +286,14 @@ fun <S : State, A : Action> createPerClientRoomServer(
     errorProcessor: ErrorProcessor<A> = DefaultErrorProcessor(),
     logger: StoreLogger<S, A> = NoOpStoreLogger(),
     scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
-): RoomServer<PerClientServer<S, A>> {
-    return createRoomServer(scope) { roomId ->
-        createPerClientServer(
-            initialStateFactory = { sessionId -> initialStateFactory(roomId, sessionId) },
-            reducer = reducer,
-            stateMapper = stateMapper,
-            processors = processors,
-            errorProcessor = errorProcessor,
-            logger = logger,
-            scope = scope,
-        )
-    }
+): RoomServer<PerClientServer<S, A>> = createRoomServer(scope) { roomId ->
+    createPerClientServer(
+        initialStateFactory = { sessionId -> initialStateFactory(roomId, sessionId) },
+        reducer = reducer,
+        stateMapper = stateMapper,
+        processors = processors,
+        errorProcessor = errorProcessor,
+        logger = logger,
+        scope = scope,
+    )
 }

--- a/kotlin/remote/server/src/commonMain/kotlin/io/flowdux/remote/server/pattern/SharedStateServer.kt
+++ b/kotlin/remote/server/src/commonMain/kotlin/io/flowdux/remote/server/pattern/SharedStateServer.kt
@@ -19,10 +19,10 @@ import io.flowdux.remote.server.session.BroadcastConfig
 import io.flowdux.remote.server.session.InMemorySessionRegistry
 import io.flowdux.remote.server.session.SessionBroadcaster
 import io.flowdux.remote.server.session.SessionRegistry
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.StateFlow
 
 /**
@@ -103,7 +103,8 @@ class SharedStateServer<S : State, A : Action> internal constructor(
      * Handle a client connection.
      *
      * Registers the session in the registry and dispatches [InternalSessionListener]
-     * to start listening for incoming messages. Suspends until cancelled, then removes
+     * to start listening for incoming messages. Suspends until the connection's incoming
+     * flow terminates (error or completion) or until cancelled, then removes
      * the session from the registry directly to ensure cleanup even if the store is closed.
      *
      * @param sessionId Unique identifier for this client session.
@@ -115,9 +116,19 @@ class SharedStateServer<S : State, A : Action> internal constructor(
         connection: TypedServerConnection<A>,
     ) {
         sessionRegistry.addSession(sessionId, connection)
-        store.dispatch(InternalSessionListener(connection) as A)
+        val listenerDone = CompletableDeferred<Unit>()
+        if (store.isClosed) {
+            listenerDone.complete(Unit)
+        } else {
+            store.dispatch(
+                InternalSessionListener(connection) { listenerDone.complete(Unit) } as A,
+            )
+            // Handle race: store may have closed between isClosed check and dispatch,
+            // causing dispatch to silently drop. Complete to avoid hanging.
+            if (store.isClosed) listenerDone.complete(Unit)
+        }
         try {
-            awaitCancellation()
+            listenerDone.await()
         } finally {
             // Direct removal ensures cleanup even if store is already closed
             sessionRegistry.removeSession(sessionId)

--- a/kotlin/remote/server/src/commonMain/kotlin/io/flowdux/remote/server/pattern/SharedStateServer.kt
+++ b/kotlin/remote/server/src/commonMain/kotlin/io/flowdux/remote/server/pattern/SharedStateServer.kt
@@ -111,10 +111,7 @@ class SharedStateServer<S : State, A : Action> internal constructor(
      * @param connection Typed connection for sending/receiving actions.
      */
     @Suppress("UNCHECKED_CAST")
-    override suspend fun handleClient(
-        sessionId: String,
-        connection: TypedServerConnection<A>,
-    ) {
+    override suspend fun handleClient(sessionId: String, connection: TypedServerConnection<A>) {
         sessionRegistry.addSession(sessionId, connection)
         val listenerDone = CompletableDeferred<Unit>()
         if (store.isClosed) {
@@ -188,15 +185,16 @@ fun <S : State, A : Action> createSharedStateServer(
 ): SharedStateServer<S, A> {
     val broadcaster = SessionBroadcaster(sessionRegistry, broadcastConfig)
 
-    val store = createMultiClientStore(
-        initialState = initialState,
-        reducer = reducer,
-        broadcaster = broadcaster,
-        processors = processors,
-        errorProcessor = errorProcessor,
-        logger = logger,
-        scope = scope,
-    )
+    val store =
+        createMultiClientStore(
+            initialState = initialState,
+            reducer = reducer,
+            broadcaster = broadcaster,
+            processors = processors,
+            errorProcessor = errorProcessor,
+            logger = logger,
+            scope = scope,
+        )
 
     // Start state broadcasting via FlowHolderAction directly
     store.dispatch(InternalStateServing(store.state, stateMapper as (Any) -> Action) as A)
@@ -282,15 +280,16 @@ fun <S : State, A : Action> createSessionAwareSharedStateServer(
 ): SharedStateServer<S, A> {
     val broadcaster = SessionBroadcaster(sessionRegistry, broadcastConfig)
 
-    val store = createMultiClientStore(
-        initialState = initialState,
-        reducer = reducer,
-        broadcaster = broadcaster,
-        processors = processors,
-        errorProcessor = errorProcessor,
-        logger = logger,
-        scope = scope,
-    )
+    val store =
+        createMultiClientStore(
+            initialState = initialState,
+            reducer = reducer,
+            broadcaster = broadcaster,
+            processors = processors,
+            errorProcessor = errorProcessor,
+            logger = logger,
+            scope = scope,
+        )
 
     // Start per-session state broadcasting via FlowHolderAction directly
     store.dispatch(

--- a/kotlin/remote/server/src/commonMain/kotlin/io/flowdux/remote/server/pattern/SingleClientServer.kt
+++ b/kotlin/remote/server/src/commonMain/kotlin/io/flowdux/remote/server/pattern/SingleClientServer.kt
@@ -81,13 +81,14 @@ fun <S : State, A : Action> createSingleClientStore(
     logger: StoreLogger<S, A> = NoOpStoreLogger(),
     scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
 ): Store<S, A> {
-    val middleware = if (processors.isEmpty()) {
-        SingleClientSyncMiddleware(connection)
-    } else {
-        object : SingleClientSyncMiddleware<S, A>(connection) {
-            override val processors: ActionProcessorMap<S, A> = processors
+    val middleware =
+        if (processors.isEmpty()) {
+            SingleClientSyncMiddleware(connection)
+        } else {
+            object : SingleClientSyncMiddleware<S, A>(connection) {
+                override val processors: ActionProcessorMap<S, A> = processors
+            }
         }
-    }
 
     return createServerStore(
         initialState = initialState,

--- a/kotlin/remote/server/src/commonMain/kotlin/io/flowdux/remote/server/session/InMemorySessionRegistry.kt
+++ b/kotlin/remote/server/src/commonMain/kotlin/io/flowdux/remote/server/session/InMemorySessionRegistry.kt
@@ -18,7 +18,6 @@ import kotlinx.coroutines.sync.withLock
  * @param A The action type used for typed connections.
  */
 class InMemorySessionRegistry<A : Action> : SessionRegistry<A> {
-
     private val sessions = mutableMapOf<String, TypedServerConnection<A>>()
     private val mutex = Mutex()
 

--- a/kotlin/remote/server/src/commonMain/kotlin/io/flowdux/remote/server/session/SessionBroadcaster.kt
+++ b/kotlin/remote/server/src/commonMain/kotlin/io/flowdux/remote/server/session/SessionBroadcaster.kt
@@ -2,12 +2,12 @@ package io.flowdux.remote.server.session
 
 import io.flowdux.Action
 import io.flowdux.remote.server.connection.TypedServerConnection
-import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flatMapMerge
 import kotlinx.coroutines.flow.flow
+import kotlin.coroutines.cancellation.CancellationException
 
 /**
  * Configuration for broadcast behavior.
@@ -17,9 +17,7 @@ import kotlinx.coroutines.flow.flow
  *   - `16-64` = recommended for 10k-100k clients
  *   - Higher values may improve throughput but increase memory usage
  */
-data class BroadcastConfig(
-    val concurrency: Int = 1,
-) {
+data class BroadcastConfig(val concurrency: Int = 1) {
     init {
         require(concurrency >= 1) { "concurrency must be at least 1" }
     }
@@ -54,7 +52,6 @@ class SessionBroadcaster<A : Action>(
     private val config: BroadcastConfig = BroadcastConfig.Sequential,
     private val onSendError: ((sessionId: String, Exception) -> Unit)? = null,
 ) {
-
     /**
      * Send an action to a specific client by session ID.
      * No-op if the session does not exist.
@@ -108,23 +105,20 @@ class SessionBroadcaster<A : Action>(
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    private suspend fun <T> forEachConcurrent(
-        items: Collection<T>,
-        action: suspend (T) -> Unit,
-    ) {
+    private suspend fun <T> forEachConcurrent(items: Collection<T>, action: suspend (T) -> Unit) {
         if (config.concurrency == 1) {
             for (item in items) {
                 action(item)
             }
         } else {
-            items.asFlow()
+            items
+                .asFlow()
                 .flatMapMerge(config.concurrency) { item ->
                     flow {
                         action(item)
                         emit(Unit)
                     }
-                }
-                .collect()
+                }.collect()
         }
     }
 

--- a/kotlin/remote/server/src/commonTest/kotlin/io/flowdux/remote/server/ClientSharedActionForwarderTest.kt
+++ b/kotlin/remote/server/src/commonTest/kotlin/io/flowdux/remote/server/ClientSharedActionForwarderTest.kt
@@ -7,19 +7,19 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class ClientSharedActionForwarderTest {
-
     @Test
     fun clientSharedAction_emitted_from_processor_is_automatically_sent_to_client() = runTest {
         val connection = MockTypedServerConnection<ServerAction>()
         val middleware = EmitClientActionTestMiddleware(connection)
 
-        val store = createServerStore(
-            initialState = ServerState(),
-            syncMiddleware = middleware,
-            reducer = serverReducer,
-            errorProcessor = serverErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createServerStore(
+                initialState = ServerState(),
+                syncMiddleware = middleware,
+                reducer = serverReducer,
+                errorProcessor = serverErrorProcessor,
+                scope = backgroundScope,
+            )
 
         // Start listening
         store.dispatchStartListening()
@@ -47,13 +47,14 @@ class ClientSharedActionForwarderTest {
         val connection = MockTypedServerConnection<ServerAction>()
         val middleware = EmitClientActionTestMiddleware(connection)
 
-        val store = createServerStore(
-            initialState = ServerState(),
-            syncMiddleware = middleware,
-            reducer = serverReducer,
-            errorProcessor = serverErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createServerStore(
+                initialState = ServerState(),
+                syncMiddleware = middleware,
+                reducer = serverReducer,
+                errorProcessor = serverErrorProcessor,
+                scope = backgroundScope,
+            )
 
         // Start listening
         store.dispatchStartListening()
@@ -77,13 +78,14 @@ class ClientSharedActionForwarderTest {
         val connection = MockTypedServerConnection<ServerAction>()
         val middleware = EmitClientActionTestMiddleware(connection)
 
-        val store = createServerStore(
-            initialState = ServerState(),
-            syncMiddleware = middleware,
-            reducer = serverReducer,
-            errorProcessor = serverErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createServerStore(
+                initialState = ServerState(),
+                syncMiddleware = middleware,
+                reducer = serverReducer,
+                errorProcessor = serverErrorProcessor,
+                scope = backgroundScope,
+            )
 
         // Start listening
         store.dispatchStartListening()
@@ -108,25 +110,28 @@ class ClientSharedActionForwarderTest {
         val connection = MockTypedServerConnection<ServerAction>()
 
         // Custom middleware that emits multiple ClientSharedActions
-        val middleware = object : io.flowdux.remote.server.middleware.SingleClientSyncMiddleware<ServerState, ServerAction>(
-            connection = connection,
-        ) {
-            override val processors = buildProcessors {
-                on<ServerAction.TriggerEmitClientAction> { _, action ->
-                    emit(ServerAction.Add(action.value))
-                    emit(ServerAction.SetValue(100))
-                    emit(ServerAction.InternalReset(1)) // local
-                }
+        val middleware =
+            object : io.flowdux.remote.server.middleware.SingleClientSyncMiddleware<ServerState, ServerAction>(
+                connection = connection,
+            ) {
+                override val processors =
+                    buildProcessors {
+                        on<ServerAction.TriggerEmitClientAction> { _, action ->
+                            emit(ServerAction.Add(action.value))
+                            emit(ServerAction.SetValue(100))
+                            emit(ServerAction.InternalReset(1)) // local
+                        }
+                    }
             }
-        }
 
-        val store = createServerStore(
-            initialState = ServerState(),
-            syncMiddleware = middleware,
-            reducer = serverReducer,
-            errorProcessor = serverErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createServerStore(
+                initialState = ServerState(),
+                syncMiddleware = middleware,
+                reducer = serverReducer,
+                errorProcessor = serverErrorProcessor,
+                scope = backgroundScope,
+            )
 
         // Start listening
         store.dispatchStartListening()

--- a/kotlin/remote/server/src/commonTest/kotlin/io/flowdux/remote/server/MultiClientSyncMiddlewareTest.kt
+++ b/kotlin/remote/server/src/commonTest/kotlin/io/flowdux/remote/server/MultiClientSyncMiddlewareTest.kt
@@ -15,20 +15,20 @@ import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 class MultiClientSyncMiddlewareTest {
-
     @Test
     fun `addSession registers session and sessionCount increases`() = runTest {
         val connection = MockTypedServerConnection<ServerAction>()
         val registry = InMemorySessionRegistry<ServerAction>()
         val broadcaster = SessionBroadcaster(registry, BroadcastConfig.Sequential)
         val middleware = MultiClientSyncMiddleware<ServerState, ServerAction>(broadcaster = broadcaster)
-        val store = createStore(
-            initialState = ServerState(),
-            reducer = serverReducer,
-            middlewares = listOf(middleware),
-            errorProcessor = serverErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = ServerState(),
+                reducer = serverReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = serverErrorProcessor,
+                scope = backgroundScope,
+            )
 
         registry.addSession("client-1", connection)
         store.dispatchSessionListener(connection)
@@ -45,13 +45,14 @@ class MultiClientSyncMiddlewareTest {
         val registry = InMemorySessionRegistry<ServerAction>()
         val broadcaster = SessionBroadcaster(registry, BroadcastConfig.Sequential)
         val middleware = MultiClientSyncMiddleware<ServerState, ServerAction>(broadcaster = broadcaster)
-        val store = createStore(
-            initialState = ServerState(),
-            reducer = serverReducer,
-            middlewares = listOf(middleware),
-            errorProcessor = serverErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = ServerState(),
+                reducer = serverReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = serverErrorProcessor,
+                scope = backgroundScope,
+            )
 
         registry.addSession("client-1", connection)
         store.dispatchSessionListener(connection)
@@ -70,13 +71,14 @@ class MultiClientSyncMiddlewareTest {
         val registry = InMemorySessionRegistry<ServerAction>()
         val broadcaster = SessionBroadcaster(registry, BroadcastConfig.Sequential)
         val middleware = MultiClientSyncMiddleware<ServerState, ServerAction>(broadcaster = broadcaster)
-        val store = createStore(
-            initialState = ServerState(),
-            reducer = serverReducer,
-            middlewares = listOf(middleware),
-            errorProcessor = serverErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = ServerState(),
+                reducer = serverReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = serverErrorProcessor,
+                scope = backgroundScope,
+            )
 
         for (i in 1..3) {
             val conn = MockTypedServerConnection<ServerAction>()
@@ -97,13 +99,14 @@ class MultiClientSyncMiddlewareTest {
         val registry = InMemorySessionRegistry<ServerAction>()
         val broadcaster = SessionBroadcaster(registry, BroadcastConfig.Sequential)
         val middleware = MultiClientSyncMiddleware<ServerState, ServerAction>(broadcaster = broadcaster)
-        val store = createStore(
-            initialState = ServerState(),
-            reducer = serverReducer,
-            middlewares = listOf(middleware),
-            errorProcessor = serverErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = ServerState(),
+                reducer = serverReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = serverErrorProcessor,
+                scope = backgroundScope,
+            )
 
         registry.addSession("client-1", conn1)
         store.dispatchSessionListener(conn1)
@@ -130,23 +133,24 @@ class MultiClientSyncMiddlewareTest {
     @Test
     fun `broadcast error isolation - one failure does not affect others`() = runTest {
         val goodConn = MockTypedServerConnection<ServerAction>()
-        val failingConn = object : TypedServerConnection<ServerAction> {
-            override val isActive: Boolean = true
-            override val incoming = goodConn.incoming // unused
-            override suspend fun send(action: ServerAction) {
-                throw RuntimeException("Connection failed")
+        val failingConn =
+            object : TypedServerConnection<ServerAction> {
+                override val isActive: Boolean = true
+                override val incoming = goodConn.incoming // unused
+
+                override suspend fun send(action: ServerAction): Unit = throw RuntimeException("Connection failed")
             }
-        }
         val registry = InMemorySessionRegistry<ServerAction>()
         val broadcaster = SessionBroadcaster(registry, BroadcastConfig.Sequential)
         val middleware = MultiClientSyncMiddleware<ServerState, ServerAction>(broadcaster = broadcaster)
-        val store = createStore(
-            initialState = ServerState(),
-            reducer = serverReducer,
-            middlewares = listOf(middleware),
-            errorProcessor = serverErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = ServerState(),
+                reducer = serverReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = serverErrorProcessor,
+                scope = backgroundScope,
+            )
 
         registry.addSession("failing", failingConn)
         store.dispatchSessionListener(failingConn)
@@ -172,30 +176,37 @@ class MultiClientSyncMiddlewareTest {
         val middleware = MultiClientSyncMiddleware<ServerState, ServerAction>(broadcaster = broadcaster)
 
         val action = ServerAction.InternalReset(42)
-        val result = middleware.process(
-            getState = { ServerState() },
-            action = action,
-        ).toList()
+        val result =
+            middleware
+                .process(
+                    getState = { ServerState() },
+                    action = action,
+                ).toList()
 
         assertEquals(listOf(action), result)
     }
 
     @Test
     fun `processor is invoked for registered action`() = runTest {
-        val processors = io.flowdux.Middleware.ActionProcessorBuilder<ServerState, ServerAction>().apply {
-            on<ServerAction.ClientAdd> { _, action ->
-                emit(ServerAction.Add(action.value))
-            }
-        }.build()
+        val processors =
+            io.flowdux.Middleware
+                .ActionProcessorBuilder<ServerState, ServerAction>()
+                .apply {
+                    on<ServerAction.ClientAdd> { _, action ->
+                        emit(ServerAction.Add(action.value))
+                    }
+                }.build()
 
         val registry = InMemorySessionRegistry<ServerAction>()
         val broadcaster = SessionBroadcaster(registry, BroadcastConfig.Sequential)
         val middleware = MultiClientSyncMiddleware(processors, broadcaster)
 
-        val result = middleware.process(
-            getState = { ServerState() },
-            action = ServerAction.ClientAdd(10),
-        ).toList()
+        val result =
+            middleware
+                .process(
+                    getState = { ServerState() },
+                    action = ServerAction.ClientAdd(10),
+                ).toList()
 
         assertEquals(1, result.size)
         assertIs<ServerAction.Add>(result[0])
@@ -208,13 +219,14 @@ class MultiClientSyncMiddlewareTest {
         val registry = InMemorySessionRegistry<ServerAction>()
         val broadcaster = SessionBroadcaster(registry, BroadcastConfig.Sequential)
         val middleware = MultiClientSyncMiddleware<ServerState, ServerAction>(broadcaster = broadcaster)
-        val store = createStore(
-            initialState = ServerState(),
-            reducer = serverReducer,
-            middlewares = listOf(middleware),
-            errorProcessor = serverErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = ServerState(),
+                reducer = serverReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = serverErrorProcessor,
+                scope = backgroundScope,
+            )
 
         registry.addSession("client-1", connection)
         store.dispatchSessionListener(connection)
@@ -236,13 +248,14 @@ class MultiClientSyncMiddlewareTest {
         val registry = InMemorySessionRegistry<ServerAction>()
         val broadcaster = SessionBroadcaster(registry, BroadcastConfig.Sequential)
         val middleware = MultiClientSyncMiddleware<ServerState, ServerAction>(broadcaster = broadcaster)
-        val store = createStore(
-            initialState = ServerState(),
-            reducer = serverReducer,
-            middlewares = listOf(middleware),
-            errorProcessor = serverErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = ServerState(),
+                reducer = serverReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = serverErrorProcessor,
+                scope = backgroundScope,
+            )
 
         registry.addSession("client-1", conn1)
         store.dispatchSessionListener(conn1)
@@ -275,13 +288,14 @@ class MultiClientSyncMiddlewareTest {
         val registry = InMemorySessionRegistry<ServerAction>()
         val broadcaster = SessionBroadcaster(registry, BroadcastConfig.Sequential)
         val middleware = MultiClientSyncMiddleware<ServerState, ServerAction>(broadcaster = broadcaster)
-        val store = createStore(
-            initialState = ServerState(),
-            reducer = serverReducer,
-            middlewares = listOf(middleware),
-            errorProcessor = serverErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = ServerState(),
+                reducer = serverReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = serverErrorProcessor,
+                scope = backgroundScope,
+            )
 
         registry.addSession("client-1", conn1)
         store.dispatchSessionListener(conn1)

--- a/kotlin/remote/server/src/commonTest/kotlin/io/flowdux/remote/server/PerClientServerTest.kt
+++ b/kotlin/remote/server/src/commonTest/kotlin/io/flowdux/remote/server/PerClientServerTest.kt
@@ -14,25 +14,26 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class PerClientServerTest {
-
     @Test
     fun `handleClient creates session and serves state`() = runTest {
-        val perClientServer = createPerClientServer(
-            initialStateFactory = { sessionId -> ServerState(count = sessionId.length) },
-            reducer = serverReducer,
-            stateMapper = { ServerAction.SyncState(it) },
-            errorProcessor = serverErrorProcessor,
-            scope = backgroundScope,
-        )
+        val perClientServer =
+            createPerClientServer(
+                initialStateFactory = { sessionId -> ServerState(count = sessionId.length) },
+                reducer = serverReducer,
+                stateMapper = { ServerAction.SyncState(it) },
+                errorProcessor = serverErrorProcessor,
+                scope = backgroundScope,
+            )
 
         val conn = MockTypedServerConnection<ServerAction>()
 
         assertEquals(0, perClientServer.sessionCount())
 
         // Connect client
-        val clientJob = backgroundScope.launch {
-            perClientServer.handleClient("player-1", conn)
-        }
+        val clientJob =
+            backgroundScope.launch {
+                perClientServer.handleClient("player-1", conn)
+            }
         delay(100)
 
         // Session created
@@ -50,19 +51,21 @@ class PerClientServerTest {
 
     @Test
     fun `handleClient removes session on disconnect`() = runTest {
-        val perClientServer = createPerClientServer(
-            initialStateFactory = { ServerState() },
-            reducer = serverReducer,
-            stateMapper = { ServerAction.SyncState(it) },
-            errorProcessor = serverErrorProcessor,
-            scope = backgroundScope,
-        )
+        val perClientServer =
+            createPerClientServer(
+                initialStateFactory = { ServerState() },
+                reducer = serverReducer,
+                stateMapper = { ServerAction.SyncState(it) },
+                errorProcessor = serverErrorProcessor,
+                scope = backgroundScope,
+            )
 
         val conn = MockTypedServerConnection<ServerAction>()
 
-        val clientJob = backgroundScope.launch {
-            perClientServer.handleClient("player-1", conn)
-        }
+        val clientJob =
+            backgroundScope.launch {
+                perClientServer.handleClient("player-1", conn)
+            }
         delay(100)
 
         assertEquals(1, perClientServer.sessionCount())
@@ -79,24 +82,27 @@ class PerClientServerTest {
 
     @Test
     fun `each client has independent state`() = runTest {
-        val perClientServer = createPerClientServer(
-            initialStateFactory = { ServerState() },
-            reducer = serverReducer,
-            stateMapper = { ServerAction.SyncState(it) },
-            errorProcessor = serverErrorProcessor,
-            scope = backgroundScope,
-        )
+        val perClientServer =
+            createPerClientServer(
+                initialStateFactory = { ServerState() },
+                reducer = serverReducer,
+                stateMapper = { ServerAction.SyncState(it) },
+                errorProcessor = serverErrorProcessor,
+                scope = backgroundScope,
+            )
 
         val conn1 = MockTypedServerConnection<ServerAction>()
         val conn2 = MockTypedServerConnection<ServerAction>()
 
         // Connect two clients
-        val job1 = backgroundScope.launch {
-            perClientServer.handleClient("player-1", conn1)
-        }
-        val job2 = backgroundScope.launch {
-            perClientServer.handleClient("player-2", conn2)
-        }
+        val job1 =
+            backgroundScope.launch {
+                perClientServer.handleClient("player-1", conn1)
+            }
+        val job2 =
+            backgroundScope.launch {
+                perClientServer.handleClient("player-2", conn2)
+            }
         delay(100)
 
         assertEquals(2, perClientServer.sessionCount())
@@ -131,22 +137,24 @@ class PerClientServerTest {
 
     @Test
     fun `getSession returns active session`() = runTest {
-        val perClientServer = createPerClientServer(
-            initialStateFactory = { ServerState() },
-            reducer = serverReducer,
-            stateMapper = { ServerAction.SyncState(it) },
-            errorProcessor = serverErrorProcessor,
-            scope = backgroundScope,
-        )
+        val perClientServer =
+            createPerClientServer(
+                initialStateFactory = { ServerState() },
+                reducer = serverReducer,
+                stateMapper = { ServerAction.SyncState(it) },
+                errorProcessor = serverErrorProcessor,
+                scope = backgroundScope,
+            )
 
         val conn = MockTypedServerConnection<ServerAction>()
 
         // No session yet
         assertNull(perClientServer.getSession("player-1"))
 
-        val clientJob = backgroundScope.launch {
-            perClientServer.handleClient("player-1", conn)
-        }
+        val clientJob =
+            backgroundScope.launch {
+                perClientServer.handleClient("player-1", conn)
+            }
         delay(100)
 
         // Session exists
@@ -168,25 +176,27 @@ class PerClientServerTest {
     fun `custom session factory is used`() = runTest {
         var factoryCalledWith: String? = null
 
-        val perClientServer = createPerClientServer(
-            stateMapper = { ServerAction.SyncState(it) },
-            scope = backgroundScope,
-        ) { sessionId, connection ->
-            factoryCalledWith = sessionId
-            createSingleClientServer(
-                initialState = ServerState(count = 42),
-                reducer = serverReducer,
-                connection = connection,
-                errorProcessor = serverErrorProcessor,
+        val perClientServer =
+            createPerClientServer(
+                stateMapper = { ServerAction.SyncState(it) },
                 scope = backgroundScope,
-            )
-        }
+            ) { sessionId, connection ->
+                factoryCalledWith = sessionId
+                createSingleClientServer(
+                    initialState = ServerState(count = 42),
+                    reducer = serverReducer,
+                    connection = connection,
+                    errorProcessor = serverErrorProcessor,
+                    scope = backgroundScope,
+                )
+            }
 
         val conn = MockTypedServerConnection<ServerAction>()
 
-        val clientJob = backgroundScope.launch {
-            perClientServer.handleClient("custom-player", conn)
-        }
+        val clientJob =
+            backgroundScope.launch {
+                perClientServer.handleClient("custom-player", conn)
+            }
         delay(100)
 
         // Factory was called with correct sessionId
@@ -202,26 +212,31 @@ class PerClientServerTest {
 
     @Test
     fun `processors work with PerClientServer`() = runTest {
-        val processors = Middleware.ActionProcessorBuilder<ServerState, ServerAction>().apply {
-            on<ServerAction.ClientAdd> { _, action ->
-                emit(ServerAction.InternalReset(action.value * 5))
-            }
-        }.build()
+        val processors =
+            Middleware
+                .ActionProcessorBuilder<ServerState, ServerAction>()
+                .apply {
+                    on<ServerAction.ClientAdd> { _, action ->
+                        emit(ServerAction.InternalReset(action.value * 5))
+                    }
+                }.build()
 
-        val perClientServer = createPerClientServer(
-            initialStateFactory = { ServerState() },
-            reducer = serverReducer,
-            stateMapper = { ServerAction.SyncState(it) },
-            processors = processors,
-            errorProcessor = serverErrorProcessor,
-            scope = backgroundScope,
-        )
+        val perClientServer =
+            createPerClientServer(
+                initialStateFactory = { ServerState() },
+                reducer = serverReducer,
+                stateMapper = { ServerAction.SyncState(it) },
+                processors = processors,
+                errorProcessor = serverErrorProcessor,
+                scope = backgroundScope,
+            )
 
         val conn = MockTypedServerConnection<ServerAction>()
 
-        val clientJob = backgroundScope.launch {
-            perClientServer.handleClient("player-1", conn)
-        }
+        val clientJob =
+            backgroundScope.launch {
+                perClientServer.handleClient("player-1", conn)
+            }
         delay(100)
 
         conn.sentActions.clear()
@@ -239,23 +254,26 @@ class PerClientServerTest {
 
     @Test
     fun `close shuts down all sessions`() = runTest {
-        val perClientServer = createPerClientServer(
-            initialStateFactory = { ServerState() },
-            reducer = serverReducer,
-            stateMapper = { ServerAction.SyncState(it) },
-            errorProcessor = serverErrorProcessor,
-            scope = backgroundScope,
-        )
+        val perClientServer =
+            createPerClientServer(
+                initialStateFactory = { ServerState() },
+                reducer = serverReducer,
+                stateMapper = { ServerAction.SyncState(it) },
+                errorProcessor = serverErrorProcessor,
+                scope = backgroundScope,
+            )
 
         val conn1 = MockTypedServerConnection<ServerAction>()
         val conn2 = MockTypedServerConnection<ServerAction>()
 
-        val job1 = backgroundScope.launch {
-            perClientServer.handleClient("player-1", conn1)
-        }
-        val job2 = backgroundScope.launch {
-            perClientServer.handleClient("player-2", conn2)
-        }
+        val job1 =
+            backgroundScope.launch {
+                perClientServer.handleClient("player-1", conn1)
+            }
+        val job2 =
+            backgroundScope.launch {
+                perClientServer.handleClient("player-2", conn2)
+            }
         delay(100)
 
         assertEquals(2, perClientServer.sessionCount())

--- a/kotlin/remote/server/src/commonTest/kotlin/io/flowdux/remote/server/ServeStateTest.kt
+++ b/kotlin/remote/server/src/commonTest/kotlin/io/flowdux/remote/server/ServeStateTest.kt
@@ -18,7 +18,6 @@ import kotlin.test.assertTrue
  * interception check.
  */
 class ServeStateTest {
-
     /**
      * Reproduces the sample-app bug.
      *
@@ -32,13 +31,14 @@ class ServeStateTest {
     fun `without serveState - server updates state but client receives nothing`() = runTest {
         val connection = MockTypedServerConnection<ServerAction>()
         val middleware = ProcessorEmittingMiddleware(connection)
-        val store = createStore(
-            initialState = ServerState(),
-            reducer = serverReducer,
-            middlewares = listOf(middleware),
-            errorProcessor = serverErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = ServerState(),
+                reducer = serverReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = serverErrorProcessor,
+                scope = backgroundScope,
+            )
 
         // Server starts listening
         store.dispatchStartListening()
@@ -68,18 +68,20 @@ class ServeStateTest {
     fun `with serveState - client receives state after each server change`() = runTest {
         val connection = MockTypedServerConnection<ServerAction>()
         val middleware = ProcessorEmittingMiddleware(connection)
-        val store = createStore(
-            initialState = ServerState(),
-            reducer = serverReducer,
-            middlewares = listOf(middleware),
-            errorProcessor = serverErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = ServerState(),
+                reducer = serverReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = serverErrorProcessor,
+                scope = backgroundScope,
+            )
 
         // serveState runs alongside the store (like sample server: store.serveState { ... })
-        val serveJob = backgroundScope.launch {
-            store.serveState { ServerAction.SyncState(it) }
-        }
+        val serveJob =
+            backgroundScope.launch {
+                store.serveState { ServerAction.SyncState(it) }
+            }
         delay(100)
 
         store.dispatchStartListening()
@@ -111,17 +113,19 @@ class ServeStateTest {
     fun `serve - auto starts listening and syncs state`() = runTest {
         val connection = MockTypedServerConnection<ServerAction>()
         val middleware = ProcessorEmittingMiddleware(connection)
-        val store = createStore(
-            initialState = ServerState(),
-            reducer = serverReducer,
-            middlewares = listOf(middleware),
-            errorProcessor = serverErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = ServerState(),
+                reducer = serverReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = serverErrorProcessor,
+                scope = backgroundScope,
+            )
 
-        val serveJob = backgroundScope.launch {
-            store.serve { ServerAction.SyncState(it) }
-        }
+        val serveJob =
+            backgroundScope.launch {
+                store.serve { ServerAction.SyncState(it) }
+            }
         delay(100)
 
         // Client sends actions
@@ -148,17 +152,19 @@ class ServeStateTest {
     fun `serve - closes store after cancellation`() = runTest {
         val connection = MockTypedServerConnection<ServerAction>()
         val middleware = SingleClientSyncMiddleware<ServerState, ServerAction>(connection)
-        val store = createStore(
-            initialState = ServerState(),
-            reducer = serverReducer,
-            middlewares = listOf(middleware),
-            errorProcessor = serverErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = ServerState(),
+                reducer = serverReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = serverErrorProcessor,
+                scope = backgroundScope,
+            )
 
-        val serveJob = backgroundScope.launch {
-            store.serve { ServerAction.SyncState(it) }
-        }
+        val serveJob =
+            backgroundScope.launch {
+                store.serve { ServerAction.SyncState(it) }
+            }
         delay(100)
 
         serveJob.cancel()
@@ -174,13 +180,14 @@ class ServeStateTest {
     fun `use - closes store after block`() = runTest {
         val connection = MockTypedServerConnection<ServerAction>()
         val middleware = SingleClientSyncMiddleware<ServerState, ServerAction>(connection)
-        val store = createStore(
-            initialState = ServerState(),
-            reducer = serverReducer,
-            middlewares = listOf(middleware),
-            errorProcessor = serverErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = ServerState(),
+                reducer = serverReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = serverErrorProcessor,
+                scope = backgroundScope,
+            )
 
         store.use {
             delay(50)

--- a/kotlin/remote/server/src/commonTest/kotlin/io/flowdux/remote/server/SessionAwareSharedStateServerTest.kt
+++ b/kotlin/remote/server/src/commonTest/kotlin/io/flowdux/remote/server/SessionAwareSharedStateServerTest.kt
@@ -13,30 +13,33 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class SessionAwareSharedStateServerTest {
-
     @Test
     fun `state changes trigger per-session mapping for all connected clients`() = runTest {
         val connAlice = MockTypedServerConnection<PokerAction>()
         val connBob = MockTypedServerConnection<PokerAction>()
 
         // Use a processor that transforms PlayerAction into DealCards
-        val processors = Middleware.ActionProcessorBuilder<PokerState, PokerAction>().apply {
-            on<PokerAction.DealCards> { _, action ->
-                emit(action) // pass through — this action reaches the reducer
-            }
-        }.build()
+        val processors =
+            Middleware
+                .ActionProcessorBuilder<PokerState, PokerAction>()
+                .apply {
+                    on<PokerAction.DealCards> { _, action ->
+                        emit(action) // pass through — this action reaches the reducer
+                    }
+                }.build()
 
-        val server = createSessionAwareSharedStateServer(
-            initialState = PokerState(),
-            reducer = pokerReducer,
-            processors = processors,
-            sessionStateMapper = { state, sessionId ->
-                val hand = state.hands[sessionId] ?: return@createSessionAwareSharedStateServer null
-                PokerAction.SyncPlayerView(hand = hand, communityCards = state.communityCards)
-            },
-            errorProcessor = pokerErrorProcessor,
-            scope = backgroundScope,
-        )
+        val server =
+            createSessionAwareSharedStateServer(
+                initialState = PokerState(),
+                reducer = pokerReducer,
+                processors = processors,
+                sessionStateMapper = { state, sessionId ->
+                    val hand = state.hands[sessionId] ?: return@createSessionAwareSharedStateServer null
+                    PokerAction.SyncPlayerView(hand = hand, communityCards = state.communityCards)
+                },
+                errorProcessor = pokerErrorProcessor,
+                scope = backgroundScope,
+            )
 
         val jobAlice = backgroundScope.launch { server.handleClient("alice", connAlice) }
         val jobBob = backgroundScope.launch { server.handleClient("bob", connBob) }
@@ -46,10 +49,12 @@ class SessionAwareSharedStateServerTest {
         connBob.sentActions.clear()
 
         // Trigger state change via a client sending DealCards (which passes through processor)
-        connAlice.simulateClientAction(PokerAction.DealCards(
-            hands = mapOf("alice" to listOf("A♠", "K♠"), "bob" to listOf("2♣", "3♦")),
-            communityCards = listOf("Q♥", "J♦", "10♠"),
-        ))
+        connAlice.simulateClientAction(
+            PokerAction.DealCards(
+                hands = mapOf("alice" to listOf("A♠", "K♠"), "bob" to listOf("2♣", "3♦")),
+                communityCards = listOf("Q♥", "J♦", "10♠"),
+            ),
+        )
         delay(200)
 
         // State should be updated
@@ -79,16 +84,17 @@ class SessionAwareSharedStateServerTest {
     fun `client connect and disconnect works correctly`() = runTest {
         val connAlice = MockTypedServerConnection<PokerAction>()
 
-        val server = createSessionAwareSharedStateServer(
-            initialState = PokerState(),
-            reducer = pokerReducer,
-            sessionStateMapper = { state, sessionId ->
-                val hand = state.hands[sessionId] ?: return@createSessionAwareSharedStateServer null
-                PokerAction.SyncPlayerView(hand = hand, communityCards = state.communityCards)
-            },
-            errorProcessor = pokerErrorProcessor,
-            scope = backgroundScope,
-        )
+        val server =
+            createSessionAwareSharedStateServer(
+                initialState = PokerState(),
+                reducer = pokerReducer,
+                sessionStateMapper = { state, sessionId ->
+                    val hand = state.hands[sessionId] ?: return@createSessionAwareSharedStateServer null
+                    PokerAction.SyncPlayerView(hand = hand, communityCards = state.communityCards)
+                },
+                errorProcessor = pokerErrorProcessor,
+                scope = backgroundScope,
+            )
 
         assertEquals(0, server.sessionCount())
 
@@ -110,27 +116,33 @@ class SessionAwareSharedStateServerTest {
     fun `processors work with session-aware session`() = runTest {
         val connAlice = MockTypedServerConnection<PokerAction>()
 
-        val processors = Middleware.ActionProcessorBuilder<PokerState, PokerAction>().apply {
-            on<PokerAction.PlayerAction> { _, action ->
-                // Transform PlayerAction into DealCards
-                emit(PokerAction.DealCards(
-                    hands = mapOf(action.playerId to listOf("A♠", "K♠")),
-                    communityCards = listOf("Q♥"),
-                ))
-            }
-        }.build()
+        val processors =
+            Middleware
+                .ActionProcessorBuilder<PokerState, PokerAction>()
+                .apply {
+                    on<PokerAction.PlayerAction> { _, action ->
+                        // Transform PlayerAction into DealCards
+                        emit(
+                            PokerAction.DealCards(
+                                hands = mapOf(action.playerId to listOf("A♠", "K♠")),
+                                communityCards = listOf("Q♥"),
+                            ),
+                        )
+                    }
+                }.build()
 
-        val server = createSessionAwareSharedStateServer(
-            initialState = PokerState(),
-            reducer = pokerReducer,
-            processors = processors,
-            sessionStateMapper = { state, sessionId ->
-                val hand = state.hands[sessionId] ?: return@createSessionAwareSharedStateServer null
-                PokerAction.SyncPlayerView(hand = hand, communityCards = state.communityCards)
-            },
-            errorProcessor = pokerErrorProcessor,
-            scope = backgroundScope,
-        )
+        val server =
+            createSessionAwareSharedStateServer(
+                initialState = PokerState(),
+                reducer = pokerReducer,
+                processors = processors,
+                sessionStateMapper = { state, sessionId ->
+                    val hand = state.hands[sessionId] ?: return@createSessionAwareSharedStateServer null
+                    PokerAction.SyncPlayerView(hand = hand, communityCards = state.communityCards)
+                },
+                errorProcessor = pokerErrorProcessor,
+                scope = backgroundScope,
+            )
 
         val job = backgroundScope.launch { server.handleClient("alice", connAlice) }
         delay(100)
@@ -158,23 +170,27 @@ class SessionAwareSharedStateServerTest {
         val connAlice = MockTypedServerConnection<PokerAction>()
         val connSpectator = MockTypedServerConnection<PokerAction>()
 
-        val processors = Middleware.ActionProcessorBuilder<PokerState, PokerAction>().apply {
-            on<PokerAction.DealCards> { _, action ->
-                emit(action)
-            }
-        }.build()
+        val processors =
+            Middleware
+                .ActionProcessorBuilder<PokerState, PokerAction>()
+                .apply {
+                    on<PokerAction.DealCards> { _, action ->
+                        emit(action)
+                    }
+                }.build()
 
-        val server = createSessionAwareSharedStateServer(
-            initialState = PokerState(),
-            reducer = pokerReducer,
-            processors = processors,
-            sessionStateMapper = { state, sessionId ->
-                val hand = state.hands[sessionId] ?: return@createSessionAwareSharedStateServer null
-                PokerAction.SyncPlayerView(hand = hand, communityCards = state.communityCards)
-            },
-            errorProcessor = pokerErrorProcessor,
-            scope = backgroundScope,
-        )
+        val server =
+            createSessionAwareSharedStateServer(
+                initialState = PokerState(),
+                reducer = pokerReducer,
+                processors = processors,
+                sessionStateMapper = { state, sessionId ->
+                    val hand = state.hands[sessionId] ?: return@createSessionAwareSharedStateServer null
+                    PokerAction.SyncPlayerView(hand = hand, communityCards = state.communityCards)
+                },
+                errorProcessor = pokerErrorProcessor,
+                scope = backgroundScope,
+            )
 
         val jobAlice = backgroundScope.launch { server.handleClient("alice", connAlice) }
         val jobSpectator = backgroundScope.launch { server.handleClient("spectator", connSpectator) }
@@ -184,10 +200,12 @@ class SessionAwareSharedStateServerTest {
         connSpectator.sentActions.clear()
 
         // Deal only to alice — spectator has no hand
-        connAlice.simulateClientAction(PokerAction.DealCards(
-            hands = mapOf("alice" to listOf("A♠", "K♠")),
-            communityCards = listOf("Q♥"),
-        ))
+        connAlice.simulateClientAction(
+            PokerAction.DealCards(
+                hands = mapOf("alice" to listOf("A♠", "K♠")),
+                communityCards = listOf("Q♥"),
+            ),
+        )
         delay(200)
 
         // Alice gets her view
@@ -206,29 +224,33 @@ class SessionAwareSharedStateServerTest {
     @Test
     fun `error in one session does not affect others during per-session send`() = runTest {
         val connAlice = MockTypedServerConnection<PokerAction>()
-        val failingConn = object : TypedServerConnection<PokerAction> {
-            override val isActive: Boolean = true
-            override val incoming = emptyFlow<PokerAction>()
-            override suspend fun send(action: PokerAction) {
-                throw RuntimeException("Connection failed")
+        val failingConn =
+            object : TypedServerConnection<PokerAction> {
+                override val isActive: Boolean = true
+                override val incoming = emptyFlow<PokerAction>()
+
+                override suspend fun send(action: PokerAction): Unit = throw RuntimeException("Connection failed")
             }
-        }
 
-        val processors = Middleware.ActionProcessorBuilder<PokerState, PokerAction>().apply {
-            on<PokerAction.DealCards> { _, action -> emit(action) }
-        }.build()
+        val processors =
+            Middleware
+                .ActionProcessorBuilder<PokerState, PokerAction>()
+                .apply {
+                    on<PokerAction.DealCards> { _, action -> emit(action) }
+                }.build()
 
-        val server = createSessionAwareSharedStateServer(
-            initialState = PokerState(),
-            reducer = pokerReducer,
-            processors = processors,
-            sessionStateMapper = { state, sessionId ->
-                val hand = state.hands[sessionId] ?: return@createSessionAwareSharedStateServer null
-                PokerAction.SyncPlayerView(hand = hand, communityCards = state.communityCards)
-            },
-            errorProcessor = pokerErrorProcessor,
-            scope = backgroundScope,
-        )
+        val server =
+            createSessionAwareSharedStateServer(
+                initialState = PokerState(),
+                reducer = pokerReducer,
+                processors = processors,
+                sessionStateMapper = { state, sessionId ->
+                    val hand = state.hands[sessionId] ?: return@createSessionAwareSharedStateServer null
+                    PokerAction.SyncPlayerView(hand = hand, communityCards = state.communityCards)
+                },
+                errorProcessor = pokerErrorProcessor,
+                scope = backgroundScope,
+            )
 
         val jobFailing = backgroundScope.launch { server.handleClient("failing", failingConn) }
         val jobAlice = backgroundScope.launch { server.handleClient("alice", connAlice) }
@@ -236,10 +258,12 @@ class SessionAwareSharedStateServerTest {
 
         connAlice.sentActions.clear()
 
-        connAlice.simulateClientAction(PokerAction.DealCards(
-            hands = mapOf("failing" to listOf("X♠"), "alice" to listOf("A♠", "K♠")),
-            communityCards = listOf("Q♥"),
-        ))
+        connAlice.simulateClientAction(
+            PokerAction.DealCards(
+                hands = mapOf("failing" to listOf("X♠"), "alice" to listOf("A♠", "K♠")),
+                communityCards = listOf("Q♥"),
+            ),
+        )
         delay(200)
 
         // Alice still receives her view despite failing connection

--- a/kotlin/remote/server/src/commonTest/kotlin/io/flowdux/remote/server/SessionBroadcasterTest.kt
+++ b/kotlin/remote/server/src/commonTest/kotlin/io/flowdux/remote/server/SessionBroadcasterTest.kt
@@ -11,24 +11,23 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class SessionBroadcasterTest {
-
     private fun failingConnection(id: String = "failing"): TypedServerConnection<ServerAction> =
         object : TypedServerConnection<ServerAction> {
             override val isActive: Boolean = true
             override val incoming = emptyFlow<ServerAction>()
-            override suspend fun send(action: ServerAction) {
-                throw RuntimeException("Connection $id failed")
-            }
+
+            override suspend fun send(action: ServerAction): Unit = throw RuntimeException("Connection $id failed")
         }
 
     @Test
     fun `onSendError invoked with correct sessionId and exception on sendToClient`() = runTest {
         val errors = mutableListOf<Pair<String, Exception>>()
         val registry = InMemorySessionRegistry<ServerAction>()
-        val broadcaster = SessionBroadcaster(
-            registry = registry,
-            onSendError = { sessionId, e -> errors.add(sessionId to e) },
-        )
+        val broadcaster =
+            SessionBroadcaster(
+                registry = registry,
+                onSendError = { sessionId, e -> errors.add(sessionId to e) },
+            )
 
         registry.addSession("session-1", failingConnection())
 
@@ -43,11 +42,12 @@ class SessionBroadcasterTest {
     fun `onSendError invoked for each failing connection during broadcast`() = runTest {
         val errors = mutableListOf<Pair<String, Exception>>()
         val registry = InMemorySessionRegistry<ServerAction>()
-        val broadcaster = SessionBroadcaster(
-            registry = registry,
-            config = BroadcastConfig.Sequential,
-            onSendError = { sessionId, e -> errors.add(sessionId to e) },
-        )
+        val broadcaster =
+            SessionBroadcaster(
+                registry = registry,
+                config = BroadcastConfig.Sequential,
+                onSendError = { sessionId, e -> errors.add(sessionId to e) },
+            )
 
         registry.addSession("fail-1", failingConnection("fail-1"))
         registry.addSession("fail-2", failingConnection("fail-2"))
@@ -64,10 +64,11 @@ class SessionBroadcasterTest {
     fun `onSendError invoked during sendPerSession`() = runTest {
         val errors = mutableListOf<Pair<String, Exception>>()
         val registry = InMemorySessionRegistry<ServerAction>()
-        val broadcaster = SessionBroadcaster(
-            registry = registry,
-            onSendError = { sessionId, e -> errors.add(sessionId to e) },
-        )
+        val broadcaster =
+            SessionBroadcaster(
+                registry = registry,
+                onSendError = { sessionId, e -> errors.add(sessionId to e) },
+            )
 
         registry.addSession("session-x", failingConnection())
 
@@ -80,10 +81,11 @@ class SessionBroadcasterTest {
     @Test
     fun `null onSendError does not throw`() = runTest {
         val registry = InMemorySessionRegistry<ServerAction>()
-        val broadcaster = SessionBroadcaster(
-            registry = registry,
-            onSendError = null,
-        )
+        val broadcaster =
+            SessionBroadcaster(
+                registry = registry,
+                onSendError = null,
+            )
 
         registry.addSession("session-1", failingConnection())
 
@@ -98,10 +100,11 @@ class SessionBroadcasterTest {
         val errors = mutableListOf<Pair<String, Exception>>()
         val goodConn = MockTypedServerConnection<ServerAction>()
         val registry = InMemorySessionRegistry<ServerAction>()
-        val broadcaster = SessionBroadcaster(
-            registry = registry,
-            onSendError = { sessionId, e -> errors.add(sessionId to e) },
-        )
+        val broadcaster =
+            SessionBroadcaster(
+                registry = registry,
+                onSendError = { sessionId, e -> errors.add(sessionId to e) },
+            )
 
         registry.addSession("good-session", goodConn)
 

--- a/kotlin/remote/server/src/commonTest/kotlin/io/flowdux/remote/server/SessionRegistryTest.kt
+++ b/kotlin/remote/server/src/commonTest/kotlin/io/flowdux/remote/server/SessionRegistryTest.kt
@@ -11,7 +11,6 @@ import kotlin.test.assertTrue
  * Tests for [SessionRegistry] interface contract, using [InMemorySessionRegistry].
  */
 class SessionRegistryTest {
-
     @Test
     fun `empty registry has zero count and empty ids`() = runTest {
         val registry = InMemorySessionRegistry<ServerAction>()

--- a/kotlin/remote/server/src/commonTest/kotlin/io/flowdux/remote/server/SharedStateServerTest.kt
+++ b/kotlin/remote/server/src/commonTest/kotlin/io/flowdux/remote/server/SharedStateServerTest.kt
@@ -394,4 +394,95 @@ class SharedStateServerTest {
         assertEquals(16, BroadcastConfig.Default.concurrency)
         assertEquals(64, BroadcastConfig.HighThroughput.concurrency)
     }
+
+    // -- Dead Session Cleanup Tests --
+
+    @Test
+    fun `handleClient removes session when connection incoming flow completes normally`() = runTest {
+        val connection = MockTypedServerConnection<ServerAction>()
+        val server = createSharedStateServer(
+            initialState = ServerState(),
+            reducer = serverReducer,
+            stateMapper = { ServerAction.SyncState(it) },
+            errorProcessor = serverErrorProcessor,
+            scope = backgroundScope,
+        )
+
+        val clientJob = backgroundScope.launch {
+            server.handleClient("client-1", connection)
+        }
+        delay(100)
+        assertEquals(1, server.sessionCount())
+
+        // Simulate clean disconnection — incoming flow completes
+        connection.closeIncoming()
+        delay(200)
+
+        // Session should be removed automatically
+        assertEquals(0, server.sessionCount())
+        assertTrue(clientJob.isCompleted)
+    }
+
+    @Test
+    fun `handleClient removes session when connection incoming flow errors`() = runTest {
+        val connection = MockTypedServerConnection<ServerAction>()
+        val server = createSharedStateServer(
+            initialState = ServerState(),
+            reducer = serverReducer,
+            stateMapper = { ServerAction.SyncState(it) },
+            errorProcessor = serverErrorProcessor,
+            scope = backgroundScope,
+        )
+
+        val clientJob = backgroundScope.launch {
+            server.handleClient("client-1", connection)
+        }
+        delay(100)
+        assertEquals(1, server.sessionCount())
+
+        // Simulate connection failure — incoming flow throws
+        connection.closeIncomingWithError(RuntimeException("connection lost"))
+        delay(200)
+
+        // Session should be removed automatically
+        assertEquals(0, server.sessionCount())
+        assertTrue(clientJob.isCompleted)
+    }
+
+    @Test
+    fun `dead session does not leak when other sessions remain active`() = runTest {
+        val conn1 = MockTypedServerConnection<ServerAction>()
+        val conn2 = MockTypedServerConnection<ServerAction>()
+
+        val server = createSharedStateServer(
+            initialState = ServerState(),
+            reducer = serverReducer,
+            stateMapper = { ServerAction.SyncState(it) },
+            errorProcessor = serverErrorProcessor,
+            scope = backgroundScope,
+        )
+
+        val job1 = backgroundScope.launch { server.handleClient("client-1", conn1) }
+        val job2 = backgroundScope.launch { server.handleClient("client-2", conn2) }
+        delay(100)
+        assertEquals(2, server.sessionCount())
+
+        // Client 1 disconnects with error
+        conn1.closeIncomingWithError(RuntimeException("network error"))
+        delay(200)
+
+        // Only dead session is removed; active session remains
+        assertEquals(1, server.sessionCount())
+        assertTrue(server.sessionIds().contains("client-2"))
+        assertFalse(server.sessionIds().contains("client-1"))
+        assertTrue(job1.isCompleted)
+        assertFalse(job2.isCompleted)
+
+        // Active session still works
+        conn2.simulateClientAction(ServerAction.ClientAdd(5))
+        delay(100)
+        assertEquals(5, server.currentState.count)
+
+        job2.cancel()
+    }
 }

--- a/kotlin/remote/server/src/commonTest/kotlin/io/flowdux/remote/server/SharedStateServerTest.kt
+++ b/kotlin/remote/server/src/commonTest/kotlin/io/flowdux/remote/server/SharedStateServerTest.kt
@@ -14,24 +14,25 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class SharedStateServerTest {
-
     @Test
     fun `handleClient adds session and removes on cancellation`() = runTest {
         val connection = MockTypedServerConnection<ServerAction>()
-        val server = createSharedStateServer(
-            initialState = ServerState(),
-            reducer = serverReducer,
-            stateMapper = { ServerAction.SyncState(it) },
-            errorProcessor = serverErrorProcessor,
-            scope = backgroundScope,
-        )
+        val server =
+            createSharedStateServer(
+                initialState = ServerState(),
+                reducer = serverReducer,
+                stateMapper = { ServerAction.SyncState(it) },
+                errorProcessor = serverErrorProcessor,
+                scope = backgroundScope,
+            )
 
         assertEquals(0, server.sessionCount())
 
         // Start client handler
-        val clientJob = backgroundScope.launch {
-            server.handleClient("client-1", connection)
-        }
+        val clientJob =
+            backgroundScope.launch {
+                server.handleClient("client-1", connection)
+            }
         delay(100)
 
         // Session registered
@@ -50,13 +51,14 @@ class SharedStateServerTest {
         val conn1 = MockTypedServerConnection<ServerAction>()
         val conn2 = MockTypedServerConnection<ServerAction>()
 
-        val server = createSharedStateServer(
-            initialState = ServerState(),
-            reducer = serverReducer,
-            stateMapper = { ServerAction.SyncState(it) },
-            errorProcessor = serverErrorProcessor,
-            scope = backgroundScope,
-        )
+        val server =
+            createSharedStateServer(
+                initialState = ServerState(),
+                reducer = serverReducer,
+                stateMapper = { ServerAction.SyncState(it) },
+                errorProcessor = serverErrorProcessor,
+                scope = backgroundScope,
+            )
 
         // Connect two clients
         val job1 = backgroundScope.launch { server.handleClient("client-1", conn1) }
@@ -83,13 +85,14 @@ class SharedStateServerTest {
         val conn1 = MockTypedServerConnection<ServerAction>()
         val conn2 = MockTypedServerConnection<ServerAction>()
 
-        val server = createSharedStateServer(
-            initialState = ServerState(),
-            reducer = serverReducer,
-            stateMapper = { ServerAction.SyncState(it) },
-            errorProcessor = serverErrorProcessor,
-            scope = backgroundScope,
-        )
+        val server =
+            createSharedStateServer(
+                initialState = ServerState(),
+                reducer = serverReducer,
+                stateMapper = { ServerAction.SyncState(it) },
+                errorProcessor = serverErrorProcessor,
+                scope = backgroundScope,
+            )
 
         // Connect two clients
         val job1 = backgroundScope.launch { server.handleClient("client-1", conn1) }
@@ -119,13 +122,14 @@ class SharedStateServerTest {
         val conn1 = MockTypedServerConnection<ServerAction>()
         val conn2 = MockTypedServerConnection<ServerAction>()
 
-        val server = createSharedStateServer(
-            initialState = ServerState(),
-            reducer = serverReducer,
-            stateMapper = { ServerAction.SyncState(it) },
-            errorProcessor = serverErrorProcessor,
-            scope = backgroundScope,
-        )
+        val server =
+            createSharedStateServer(
+                initialState = ServerState(),
+                reducer = serverReducer,
+                stateMapper = { ServerAction.SyncState(it) },
+                errorProcessor = serverErrorProcessor,
+                scope = backgroundScope,
+            )
 
         val job1 = backgroundScope.launch { server.handleClient("client-1", conn1) }
         val job2 = backgroundScope.launch { server.handleClient("client-2", conn2) }
@@ -151,13 +155,14 @@ class SharedStateServerTest {
         val conn1 = MockTypedServerConnection<ServerAction>()
         val conn2 = MockTypedServerConnection<ServerAction>()
 
-        val server = createSharedStateServer(
-            initialState = ServerState(),
-            reducer = serverReducer,
-            stateMapper = { ServerAction.SyncState(it) },
-            errorProcessor = serverErrorProcessor,
-            scope = backgroundScope,
-        )
+        val server =
+            createSharedStateServer(
+                initialState = ServerState(),
+                reducer = serverReducer,
+                stateMapper = { ServerAction.SyncState(it) },
+                errorProcessor = serverErrorProcessor,
+                scope = backgroundScope,
+            )
 
         val job1 = backgroundScope.launch { server.handleClient("client-1", conn1) }
         val job2 = backgroundScope.launch { server.handleClient("client-2", conn2) }
@@ -181,13 +186,14 @@ class SharedStateServerTest {
 
     @Test
     fun `close stops the session`() = runTest {
-        val server = createSharedStateServer(
-            initialState = ServerState(),
-            reducer = serverReducer,
-            stateMapper = { ServerAction.SyncState(it) },
-            errorProcessor = serverErrorProcessor,
-            scope = backgroundScope,
-        )
+        val server =
+            createSharedStateServer(
+                initialState = ServerState(),
+                reducer = serverReducer,
+                stateMapper = { ServerAction.SyncState(it) },
+                errorProcessor = serverErrorProcessor,
+                scope = backgroundScope,
+            )
 
         assertFalse(server.state.value.count != 0) // initial state
 
@@ -202,23 +208,27 @@ class SharedStateServerTest {
         val conn2 = MockTypedServerConnection<ServerAction>()
 
         // Processor that emits a ClientSharedAction
-        val processors = Middleware.ActionProcessorBuilder<ServerState, ServerAction>().apply {
-            on<ServerAction.TriggerEmitClientAction> { _, action ->
-                // emit(ClientSharedAction) - should be auto-forwarded and broadcast
-                emit(ServerAction.Add(action.value))
-                // Also emit local action to verify processor runs
-                emit(ServerAction.InternalReset(1))
-            }
-        }.build()
+        val processors =
+            Middleware
+                .ActionProcessorBuilder<ServerState, ServerAction>()
+                .apply {
+                    on<ServerAction.TriggerEmitClientAction> { _, action ->
+                        // emit(ClientSharedAction) - should be auto-forwarded and broadcast
+                        emit(ServerAction.Add(action.value))
+                        // Also emit local action to verify processor runs
+                        emit(ServerAction.InternalReset(1))
+                    }
+                }.build()
 
-        val server = createSharedStateServer(
-            initialState = ServerState(),
-            reducer = serverReducer,
-            processors = processors,
-            stateMapper = { ServerAction.SyncState(it) },
-            errorProcessor = serverErrorProcessor,
-            scope = backgroundScope,
-        )
+        val server =
+            createSharedStateServer(
+                initialState = ServerState(),
+                reducer = serverReducer,
+                processors = processors,
+                stateMapper = { ServerAction.SyncState(it) },
+                errorProcessor = serverErrorProcessor,
+                scope = backgroundScope,
+            )
 
         val job1 = backgroundScope.launch { server.handleClient("client-1", conn1) }
         val job2 = backgroundScope.launch { server.handleClient("client-2", conn2) }
@@ -251,22 +261,26 @@ class SharedStateServerTest {
     fun `processors are invoked for matching actions`() = runTest {
         val conn = MockTypedServerConnection<ServerAction>()
 
-        val processors = Middleware.ActionProcessorBuilder<ServerState, ServerAction>().apply {
-            on<ServerAction.ClientAdd> { _, action ->
-                // Processor transforms ClientAdd into InternalReset (a non-shared action)
-                // to verify the processor was invoked and the result reaches the reducer
-                emit(ServerAction.InternalReset(action.value * 2))
-            }
-        }.build()
+        val processors =
+            Middleware
+                .ActionProcessorBuilder<ServerState, ServerAction>()
+                .apply {
+                    on<ServerAction.ClientAdd> { _, action ->
+                        // Processor transforms ClientAdd into InternalReset (a non-shared action)
+                        // to verify the processor was invoked and the result reaches the reducer
+                        emit(ServerAction.InternalReset(action.value * 2))
+                    }
+                }.build()
 
-        val server = createSharedStateServer(
-            initialState = ServerState(),
-            reducer = serverReducer,
-            processors = processors,
-            stateMapper = { ServerAction.SyncState(it) },
-            errorProcessor = serverErrorProcessor,
-            scope = backgroundScope,
-        )
+        val server =
+            createSharedStateServer(
+                initialState = ServerState(),
+                reducer = serverReducer,
+                processors = processors,
+                stateMapper = { ServerAction.SyncState(it) },
+                errorProcessor = serverErrorProcessor,
+                scope = backgroundScope,
+            )
 
         val job = backgroundScope.launch { server.handleClient("client-1", conn) }
         delay(100)
@@ -289,14 +303,15 @@ class SharedStateServerTest {
         val conn2 = MockTypedServerConnection<ServerAction>()
         val conn3 = MockTypedServerConnection<ServerAction>()
 
-        val server = createSharedStateServer(
-            initialState = ServerState(),
-            reducer = serverReducer,
-            stateMapper = { ServerAction.SyncState(it) },
-            broadcastConfig = BroadcastConfig(concurrency = 4),
-            errorProcessor = serverErrorProcessor,
-            scope = backgroundScope,
-        )
+        val server =
+            createSharedStateServer(
+                initialState = ServerState(),
+                reducer = serverReducer,
+                stateMapper = { ServerAction.SyncState(it) },
+                broadcastConfig = BroadcastConfig(concurrency = 4),
+                errorProcessor = serverErrorProcessor,
+                scope = backgroundScope,
+            )
 
         val job1 = backgroundScope.launch { server.handleClient("client-1", conn1) }
         val job2 = backgroundScope.launch { server.handleClient("client-2", conn2) }
@@ -330,15 +345,16 @@ class SharedStateServerTest {
 
         val customRegistry = InMemorySessionRegistry<ServerAction>()
 
-        val server = createSharedStateServer(
-            initialState = ServerState(),
-            reducer = serverReducer,
-            stateMapper = { ServerAction.SyncState(it) },
-            sessionRegistry = customRegistry,
-            broadcastConfig = BroadcastConfig(concurrency = 16),
-            errorProcessor = serverErrorProcessor,
-            scope = backgroundScope,
-        )
+        val server =
+            createSharedStateServer(
+                initialState = ServerState(),
+                reducer = serverReducer,
+                stateMapper = { ServerAction.SyncState(it) },
+                sessionRegistry = customRegistry,
+                broadcastConfig = BroadcastConfig(concurrency = 16),
+                errorProcessor = serverErrorProcessor,
+                scope = backgroundScope,
+            )
 
         val job1 = backgroundScope.launch { server.handleClient("client-1", conn1) }
         val job2 = backgroundScope.launch { server.handleClient("client-2", conn2) }
@@ -400,17 +416,19 @@ class SharedStateServerTest {
     @Test
     fun `handleClient removes session when connection incoming flow completes normally`() = runTest {
         val connection = MockTypedServerConnection<ServerAction>()
-        val server = createSharedStateServer(
-            initialState = ServerState(),
-            reducer = serverReducer,
-            stateMapper = { ServerAction.SyncState(it) },
-            errorProcessor = serverErrorProcessor,
-            scope = backgroundScope,
-        )
+        val server =
+            createSharedStateServer(
+                initialState = ServerState(),
+                reducer = serverReducer,
+                stateMapper = { ServerAction.SyncState(it) },
+                errorProcessor = serverErrorProcessor,
+                scope = backgroundScope,
+            )
 
-        val clientJob = backgroundScope.launch {
-            server.handleClient("client-1", connection)
-        }
+        val clientJob =
+            backgroundScope.launch {
+                server.handleClient("client-1", connection)
+            }
         delay(100)
         assertEquals(1, server.sessionCount())
 
@@ -426,17 +444,19 @@ class SharedStateServerTest {
     @Test
     fun `handleClient removes session when connection incoming flow errors`() = runTest {
         val connection = MockTypedServerConnection<ServerAction>()
-        val server = createSharedStateServer(
-            initialState = ServerState(),
-            reducer = serverReducer,
-            stateMapper = { ServerAction.SyncState(it) },
-            errorProcessor = serverErrorProcessor,
-            scope = backgroundScope,
-        )
+        val server =
+            createSharedStateServer(
+                initialState = ServerState(),
+                reducer = serverReducer,
+                stateMapper = { ServerAction.SyncState(it) },
+                errorProcessor = serverErrorProcessor,
+                scope = backgroundScope,
+            )
 
-        val clientJob = backgroundScope.launch {
-            server.handleClient("client-1", connection)
-        }
+        val clientJob =
+            backgroundScope.launch {
+                server.handleClient("client-1", connection)
+            }
         delay(100)
         assertEquals(1, server.sessionCount())
 
@@ -454,13 +474,14 @@ class SharedStateServerTest {
         val conn1 = MockTypedServerConnection<ServerAction>()
         val conn2 = MockTypedServerConnection<ServerAction>()
 
-        val server = createSharedStateServer(
-            initialState = ServerState(),
-            reducer = serverReducer,
-            stateMapper = { ServerAction.SyncState(it) },
-            errorProcessor = serverErrorProcessor,
-            scope = backgroundScope,
-        )
+        val server =
+            createSharedStateServer(
+                initialState = ServerState(),
+                reducer = serverReducer,
+                stateMapper = { ServerAction.SyncState(it) },
+                errorProcessor = serverErrorProcessor,
+                scope = backgroundScope,
+            )
 
         val job1 = backgroundScope.launch { server.handleClient("client-1", conn1) }
         val job2 = backgroundScope.launch { server.handleClient("client-2", conn2) }

--- a/kotlin/remote/server/src/commonTest/kotlin/io/flowdux/remote/server/SingleClientServerTest.kt
+++ b/kotlin/remote/server/src/commonTest/kotlin/io/flowdux/remote/server/SingleClientServerTest.kt
@@ -13,18 +13,18 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class SingleClientServerTest {
-
     @Test
     fun `createSingleClientServer creates store with SingleClientSyncMiddleware`() = runTest {
         val connection = MockTypedServerConnection<ServerAction>()
 
-        val server = createSingleClientServer(
-            initialState = ServerState(),
-            reducer = serverReducer,
-            connection = connection,
-            errorProcessor = serverErrorProcessor,
-            scope = backgroundScope,
-        )
+        val server =
+            createSingleClientServer(
+                initialState = ServerState(),
+                reducer = serverReducer,
+                connection = connection,
+                errorProcessor = serverErrorProcessor,
+                scope = backgroundScope,
+            )
 
         // Start listening
         server.dispatchStartListening()
@@ -44,13 +44,14 @@ class SingleClientServerTest {
     fun `ClientSharedAction is sent to client`() = runTest {
         val connection = MockTypedServerConnection<ServerAction>()
 
-        val server = createSingleClientServer(
-            initialState = ServerState(),
-            reducer = serverReducer,
-            connection = connection,
-            errorProcessor = serverErrorProcessor,
-            scope = backgroundScope,
-        )
+        val server =
+            createSingleClientServer(
+                initialState = ServerState(),
+                reducer = serverReducer,
+                connection = connection,
+                errorProcessor = serverErrorProcessor,
+                scope = backgroundScope,
+            )
 
         // Dispatch a ClientSharedAction
         server.dispatch(ServerAction.Add(42))
@@ -67,13 +68,14 @@ class SingleClientServerTest {
     fun `serve syncs state to client`() = runTest {
         val connection = MockTypedServerConnection<ServerAction>()
 
-        val server = createSingleClientServer(
-            initialState = ServerState(),
-            reducer = serverReducer,
-            connection = connection,
-            errorProcessor = serverErrorProcessor,
-            scope = backgroundScope,
-        )
+        val server =
+            createSingleClientServer(
+                initialState = ServerState(),
+                reducer = serverReducer,
+                connection = connection,
+                errorProcessor = serverErrorProcessor,
+                scope = backgroundScope,
+            )
 
         // Use serve to start listening and syncing state
         val serveJob = backgroundScope.launchServe(server) { ServerAction.SyncState(it) }
@@ -100,21 +102,25 @@ class SingleClientServerTest {
     fun `processors are invoked for matching actions`() = runTest {
         val connection = MockTypedServerConnection<ServerAction>()
 
-        val processors = Middleware.ActionProcessorBuilder<ServerState, ServerAction>().apply {
-            on<ServerAction.ClientAdd> { _, action ->
-                // Transform ClientAdd into InternalReset
-                emit(ServerAction.InternalReset(action.value * 3))
-            }
-        }.build()
+        val processors =
+            Middleware
+                .ActionProcessorBuilder<ServerState, ServerAction>()
+                .apply {
+                    on<ServerAction.ClientAdd> { _, action ->
+                        // Transform ClientAdd into InternalReset
+                        emit(ServerAction.InternalReset(action.value * 3))
+                    }
+                }.build()
 
-        val server = createSingleClientServer(
-            initialState = ServerState(),
-            reducer = serverReducer,
-            connection = connection,
-            processors = processors,
-            errorProcessor = serverErrorProcessor,
-            scope = backgroundScope,
-        )
+        val server =
+            createSingleClientServer(
+                initialState = ServerState(),
+                reducer = serverReducer,
+                connection = connection,
+                processors = processors,
+                errorProcessor = serverErrorProcessor,
+                scope = backgroundScope,
+            )
 
         // Start listening
         server.dispatchStartListening()
@@ -135,23 +141,27 @@ class SingleClientServerTest {
         val connection = MockTypedServerConnection<ServerAction>()
 
         // Processor that emits a ClientSharedAction
-        val processors = Middleware.ActionProcessorBuilder<ServerState, ServerAction>().apply {
-            on<ServerAction.TriggerEmitClientAction> { _, action ->
-                // emit(ClientSharedAction) - should be auto-forwarded to client
-                emit(ServerAction.Add(action.value))
-                // Also emit local action to verify processor runs
-                emit(ServerAction.InternalReset(1))
-            }
-        }.build()
+        val processors =
+            Middleware
+                .ActionProcessorBuilder<ServerState, ServerAction>()
+                .apply {
+                    on<ServerAction.TriggerEmitClientAction> { _, action ->
+                        // emit(ClientSharedAction) - should be auto-forwarded to client
+                        emit(ServerAction.Add(action.value))
+                        // Also emit local action to verify processor runs
+                        emit(ServerAction.InternalReset(1))
+                    }
+                }.build()
 
-        val server = createSingleClientServer(
-            initialState = ServerState(),
-            reducer = serverReducer,
-            connection = connection,
-            processors = processors,
-            errorProcessor = serverErrorProcessor,
-            scope = backgroundScope,
-        )
+        val server =
+            createSingleClientServer(
+                initialState = ServerState(),
+                reducer = serverReducer,
+                connection = connection,
+                processors = processors,
+                errorProcessor = serverErrorProcessor,
+                scope = backgroundScope,
+            )
 
         // Start listening
         server.dispatchStartListening()
@@ -176,13 +186,14 @@ class SingleClientServerTest {
     fun `non-ClientSharedAction passes through to reducer`() = runTest {
         val connection = MockTypedServerConnection<ServerAction>()
 
-        val server = createSingleClientServer(
-            initialState = ServerState(),
-            reducer = serverReducer,
-            connection = connection,
-            errorProcessor = serverErrorProcessor,
-            scope = backgroundScope,
-        )
+        val server =
+            createSingleClientServer(
+                initialState = ServerState(),
+                reducer = serverReducer,
+                connection = connection,
+                errorProcessor = serverErrorProcessor,
+                scope = backgroundScope,
+            )
 
         // Dispatch a non-ClientSharedAction
         server.dispatch(ServerAction.InternalReset(100))

--- a/kotlin/remote/server/src/commonTest/kotlin/io/flowdux/remote/server/SingleClientSyncMiddlewareTest.kt
+++ b/kotlin/remote/server/src/commonTest/kotlin/io/flowdux/remote/server/SingleClientSyncMiddlewareTest.kt
@@ -10,18 +10,20 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class SingleClientSyncMiddlewareTest {
-
     @Test
     fun `ClientSharedAction is intercepted and sent to client`() = runTest {
         val connection = MockTypedServerConnection<ServerAction>()
-        val middleware = SingleClientSyncMiddleware<ServerState, ServerAction>(
-            connection = connection,
-        )
+        val middleware =
+            SingleClientSyncMiddleware<ServerState, ServerAction>(
+                connection = connection,
+            )
 
-        val result = middleware.process(
-            getState = { ServerState() },
-            action = ServerAction.Add(10),
-        ).toList()
+        val result =
+            middleware
+                .process(
+                    getState = { ServerState() },
+                    action = ServerAction.Add(10),
+                ).toList()
 
         // ClientSharedAction is consumed — not emitted downstream
         assertTrue(result.isEmpty())
@@ -35,15 +37,18 @@ class SingleClientSyncMiddlewareTest {
     @Test
     fun `non-ClientSharedAction passes through unchanged`() = runTest {
         val connection = MockTypedServerConnection<ServerAction>()
-        val middleware = SingleClientSyncMiddleware<ServerState, ServerAction>(
-            connection = connection,
-        )
+        val middleware =
+            SingleClientSyncMiddleware<ServerState, ServerAction>(
+                connection = connection,
+            )
 
         val action = ServerAction.InternalReset(42)
-        val result = middleware.process(
-            getState = { ServerState() },
-            action = action,
-        ).toList()
+        val result =
+            middleware
+                .process(
+                    getState = { ServerState() },
+                    action = action,
+                ).toList()
 
         // Non-ClientSharedAction passes through
         assertEquals(listOf(action), result)
@@ -55,19 +60,22 @@ class SingleClientSyncMiddlewareTest {
     @Test
     fun `multiple ClientSharedActions are each sent separately`() = runTest {
         val connection = MockTypedServerConnection<ServerAction>()
-        val middleware = SingleClientSyncMiddleware<ServerState, ServerAction>(
-            connection = connection,
-        )
+        val middleware =
+            SingleClientSyncMiddleware<ServerState, ServerAction>(
+                connection = connection,
+            )
 
-        middleware.process(
-            getState = { ServerState() },
-            action = ServerAction.Increment,
-        ).toList()
+        middleware
+            .process(
+                getState = { ServerState() },
+                action = ServerAction.Increment,
+            ).toList()
 
-        middleware.process(
-            getState = { ServerState(1) },
-            action = ServerAction.Add(5),
-        ).toList()
+        middleware
+            .process(
+                getState = { ServerState(1) },
+                action = ServerAction.Add(5),
+            ).toList()
 
         assertEquals(2, connection.sentActions.size)
 
@@ -79,14 +87,16 @@ class SingleClientSyncMiddlewareTest {
     @Test
     fun `typed action roundtrip preserves action data`() = runTest {
         val connection = MockTypedServerConnection<ServerAction>()
-        val middleware = SingleClientSyncMiddleware<ServerState, ServerAction>(
-            connection = connection,
-        )
+        val middleware =
+            SingleClientSyncMiddleware<ServerState, ServerAction>(
+                connection = connection,
+            )
 
-        middleware.process(
-            getState = { ServerState() },
-            action = ServerAction.Add(42),
-        ).toList()
+        middleware
+            .process(
+                getState = { ServerState() },
+                action = ServerAction.Add(42),
+            ).toList()
 
         val sentAction = connection.sentActions[0]
         assertTrue(sentAction is ServerAction.Add)
@@ -96,17 +106,19 @@ class SingleClientSyncMiddlewareTest {
     @Test
     fun `incoming client messages are dispatched through pipeline via FlowHolderAction`() = runTest {
         val connection = MockTypedServerConnection<ServerAction>()
-        val middleware = SingleClientSyncMiddleware<ServerState, ServerAction>(
-            connection = connection,
-        )
+        val middleware =
+            SingleClientSyncMiddleware<ServerState, ServerAction>(
+                connection = connection,
+            )
 
-        val store = createStore(
-            initialState = ServerState(),
-            reducer = serverReducer,
-            middlewares = listOf(middleware),
-            errorProcessor = serverErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = ServerState(),
+                reducer = serverReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = serverErrorProcessor,
+                scope = backgroundScope,
+            )
 
         // Start listening
         store.dispatchStartListening()
@@ -126,13 +138,14 @@ class SingleClientSyncMiddlewareTest {
     fun `InternalStartListening is consumed by middleware and does not reach reducer`() = runTest {
         val connection = MockTypedServerConnection<ServerAction>()
         val middleware = SingleClientSyncMiddleware<ServerState, ServerAction>(connection)
-        val store = createStore(
-            initialState = ServerState(),
-            reducer = serverReducer, // sealed when — would crash if InternalStartListening leaked
-            middlewares = listOf(middleware),
-            errorProcessor = serverErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = ServerState(),
+                reducer = serverReducer, // sealed when — would crash if InternalStartListening leaked
+                middlewares = listOf(middleware),
+                errorProcessor = serverErrorProcessor,
+                scope = backgroundScope,
+            )
 
         // If InternalStartListening leaked to the reducer, the sealed when would crash
         store.dispatchStartListening()
@@ -148,13 +161,14 @@ class SingleClientSyncMiddlewareTest {
     fun `InternalStartListening is handled before processors`() = runTest {
         val connection = MockTypedServerConnection<ServerAction>()
         val middleware = ProcessorEmittingMiddleware(connection) // has processors for ClientAdd
-        val store = createStore(
-            initialState = ServerState(),
-            reducer = serverReducer,
-            middlewares = listOf(middleware),
-            errorProcessor = serverErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createStore(
+                initialState = ServerState(),
+                reducer = serverReducer,
+                middlewares = listOf(middleware),
+                errorProcessor = serverErrorProcessor,
+                scope = backgroundScope,
+            )
 
         // InternalStartListening should be caught at step 0, not fall into processors
         store.dispatchStartListening()
@@ -174,10 +188,12 @@ class SingleClientSyncMiddlewareTest {
         val middleware = SingleClientSyncMiddleware<ServerState, ServerAction>(connection)
 
         val action = ServerAction.ClientAdd(10)
-        val result = middleware.process(
-            getState = { ServerState() },
-            action = action,
-        ).toList()
+        val result =
+            middleware
+                .process(
+                    getState = { ServerState() },
+                    action = action,
+                ).toList()
 
         // ServerSharedAction passes through (not intercepted by middleware)
         assertEquals(listOf(action), result)

--- a/kotlin/remote/server/src/commonTest/kotlin/io/flowdux/remote/server/TestFixtures.kt
+++ b/kotlin/remote/server/src/commonTest/kotlin/io/flowdux/remote/server/TestFixtures.kt
@@ -21,13 +21,24 @@ data class ServerState(val count: Int = 0) : State
 
 sealed interface ServerAction : Action {
     // Client → Server (received from client via incoming)
-    data class ClientAdd(val value: Int) : ServerAction, ServerSharedAction
+    data class ClientAdd(val value: Int) :
+        ServerAction,
+        ServerSharedAction
 
     // Server → Client (intercepted by SRM)
-    data class Add(val value: Int) : ServerAction, ClientSharedAction
-    data class SetValue(val value: Int) : ServerAction, ClientSharedAction
+    data class Add(val value: Int) :
+        ServerAction,
+        ClientSharedAction
+
+    data class SetValue(val value: Int) :
+        ServerAction,
+        ClientSharedAction
+
     object Increment : ServerAction, ClientSharedAction
-    data class SyncState(val state: ServerState) : ServerAction, ClientSharedAction
+
+    data class SyncState(val state: ServerState) :
+        ServerAction,
+        ClientSharedAction
 
     // Server-internal only (passes through SRM, reaches reducer)
     data class InternalReset(val value: Int) : ServerAction
@@ -36,37 +47,39 @@ sealed interface ServerAction : Action {
     data class TriggerEmitClientAction(val value: Int) : ServerAction
 }
 
-val serverReducer = Reducer<ServerState, ServerAction> { state, action ->
-    when (action) {
-        is ServerAction.ClientAdd -> state.copy(count = state.count + action.value)
-        is ServerAction.Add -> state.copy(count = state.count + action.value)
-        is ServerAction.SetValue -> state.copy(count = action.value)
-        is ServerAction.Increment -> state.copy(count = state.count + 1)
-        is ServerAction.SyncState -> state // intercepted by SRM, never reaches reducer
-        is ServerAction.InternalReset -> state.copy(count = action.value)
-        is ServerAction.TriggerEmitClientAction -> state // handled by processor, not reducer
+val serverReducer =
+    Reducer<ServerState, ServerAction> { state, action ->
+        when (action) {
+            is ServerAction.ClientAdd -> state.copy(count = state.count + action.value)
+            is ServerAction.Add -> state.copy(count = state.count + action.value)
+            is ServerAction.SetValue -> state.copy(count = action.value)
+            is ServerAction.Increment -> state.copy(count = state.count + 1)
+            is ServerAction.SyncState -> state // intercepted by SRM, never reaches reducer
+            is ServerAction.InternalReset -> state.copy(count = action.value)
+            is ServerAction.TriggerEmitClientAction -> state // handled by processor, not reducer
+        }
     }
-}
 
-val serverErrorProcessor = object : ErrorProcessor<ServerAction> {
-    override fun process(throwable: Throwable): Flow<ServerAction> = emptyFlow()
-}
+val serverErrorProcessor =
+    object : ErrorProcessor<ServerAction> {
+        override fun process(throwable: Throwable): Flow<ServerAction> = emptyFlow()
+    }
 
 /**
  * Middleware subclass whose processor emits a [ClientSharedAction].
  * Reproduces the scenario where the emitted action bypasses the middleware's
  * ClientSharedAction interception and is NOT sent to the client.
  */
-class ProcessorEmittingMiddleware(
-    connection: TypedServerConnection<ServerAction>,
-) : SingleClientSyncMiddleware<ServerState, ServerAction>(
-    connection = connection,
-) {
-    override val processors = buildProcessors {
-        on<ServerAction.ClientAdd> { _, action ->
-            emit(ServerAction.Add(action.value))
+class ProcessorEmittingMiddleware(connection: TypedServerConnection<ServerAction>) :
+    SingleClientSyncMiddleware<ServerState, ServerAction>(
+        connection = connection,
+    ) {
+    override val processors =
+        buildProcessors {
+            on<ServerAction.ClientAdd> { _, action ->
+                emit(ServerAction.Add(action.value))
+            }
         }
-    }
 }
 
 /**
@@ -74,19 +87,19 @@ class ProcessorEmittingMiddleware(
  * With [ClientSharedActionForwarder] (via createServerStore), the emitted action
  * is auto re-dispatched through the middleware pipeline and sent to the client.
  */
-class EmitClientActionTestMiddleware(
-    connection: TypedServerConnection<ServerAction>,
-) : SingleClientSyncMiddleware<ServerState, ServerAction>(
-    connection = connection,
-) {
-    override val processors = buildProcessors {
-        on<ServerAction.TriggerEmitClientAction> { _, action ->
-            // ClientSharedActionForwarder will auto re-dispatch this to the client
-            emit(ServerAction.Add(action.value))
-            // Also emit a local action to verify processor runs
-            emit(ServerAction.InternalReset(1))
+class EmitClientActionTestMiddleware(connection: TypedServerConnection<ServerAction>) :
+    SingleClientSyncMiddleware<ServerState, ServerAction>(
+        connection = connection,
+    ) {
+    override val processors =
+        buildProcessors {
+            on<ServerAction.TriggerEmitClientAction> { _, action ->
+                // ClientSharedActionForwarder will auto re-dispatch this to the client
+                emit(ServerAction.Add(action.value))
+                // Also emit a local action to verify processor runs
+                emit(ServerAction.InternalReset(1))
+            }
         }
-    }
 }
 
 /** Dispatch [InternalStartListening] via unchecked cast (type-erased at runtime). */
@@ -119,29 +132,32 @@ data class PokerState(
 
 sealed interface PokerAction : Action {
     /** Client → Server: a player takes an action. */
-    data class PlayerAction(val playerId: String, val action: String) : PokerAction, io.flowdux.remote.ServerSharedAction
+    data class PlayerAction(val playerId: String, val action: String) :
+        PokerAction,
+        io.flowdux.remote.ServerSharedAction
 
     /** Server → Client: send a player their personal view of the game. */
-    data class SyncPlayerView(
-        val hand: List<String>,
-        val communityCards: List<String>,
-    ) : PokerAction, io.flowdux.remote.ClientSharedAction
+    data class SyncPlayerView(val hand: List<String>, val communityCards: List<String>) :
+        PokerAction,
+        io.flowdux.remote.ClientSharedAction
 
     /** Server-internal: deal cards. */
     data class DealCards(val hands: Map<String, List<String>>, val communityCards: List<String>) : PokerAction
 }
 
-val pokerReducer = Reducer<PokerState, PokerAction> { state, action ->
-    when (action) {
-        is PokerAction.PlayerAction -> state // handled externally
-        is PokerAction.SyncPlayerView -> state // client-side only
-        is PokerAction.DealCards -> state.copy(hands = action.hands, communityCards = action.communityCards)
+val pokerReducer =
+    Reducer<PokerState, PokerAction> { state, action ->
+        when (action) {
+            is PokerAction.PlayerAction -> state // handled externally
+            is PokerAction.SyncPlayerView -> state // client-side only
+            is PokerAction.DealCards -> state.copy(hands = action.hands, communityCards = action.communityCards)
+        }
     }
-}
 
-val pokerErrorProcessor = object : ErrorProcessor<PokerAction> {
-    override fun process(throwable: Throwable): Flow<PokerAction> = emptyFlow()
-}
+val pokerErrorProcessor =
+    object : ErrorProcessor<PokerAction> {
+        override fun process(throwable: Throwable): Flow<PokerAction> = emptyFlow()
+    }
 
 // -- Mock TypedServerConnection --
 

--- a/kotlin/remote/server/src/commonTest/kotlin/io/flowdux/remote/server/TestFixtures.kt
+++ b/kotlin/remote/server/src/commonTest/kotlin/io/flowdux/remote/server/TestFixtures.kt
@@ -99,8 +99,9 @@ fun <S : State, A : Action> Store<S, A>.dispatchStartListening() {
 @Suppress("UNCHECKED_CAST")
 fun <S : State, A : Action> Store<S, A>.dispatchSessionListener(
     connection: TypedServerConnection<*>,
+    onTerminate: (() -> Unit)? = null,
 ) {
-    dispatch(InternalSessionListener(connection) as A)
+    dispatch(InternalSessionListener(connection, onTerminate) as A)
 }
 
 /** Dispatch [InternalSendToClient] via unchecked cast (type-erased at runtime). */
@@ -158,5 +159,15 @@ class MockTypedServerConnection<A : Action> : TypedServerConnection<A> {
     /** Simulate receiving a typed action from the client. */
     suspend fun simulateClientAction(action: A) {
         incomingChannel.send(action)
+    }
+
+    /** Close the incoming channel to simulate a clean disconnection. */
+    fun closeIncoming() {
+        incomingChannel.close()
+    }
+
+    /** Close the incoming channel with an error to simulate a connection failure. */
+    fun closeIncomingWithError(cause: Throwable) {
+        incomingChannel.close(cause)
     }
 }

--- a/kotlin/samples/flowdux-remote/auth/client/src/main/kotlin/io/flowdux/sample/chat/authclient/ChatRemoteMiddleware.kt
+++ b/kotlin/samples/flowdux-remote/auth/client/src/main/kotlin/io/flowdux/sample/chat/authclient/ChatRemoteMiddleware.kt
@@ -5,17 +5,17 @@ import io.flowdux.remote.SyncMiddleware
 import io.flowdux.remote.TypedClientConnection
 import io.flowdux.sample.chat.ChatAction
 
-class ChatRemoteMiddleware(
-    connection: TypedClientConnection<ChatAction>,
-) : SyncMiddleware<ClientChatState, ChatAction>(
-    connection = connection,
-) {
-    override val processors: ActionProcessorMap<ClientChatState, ChatAction> = buildProcessors {
-        on<ClientChatAction.Connect> { _, _ ->
-            startConnection()
+class ChatRemoteMiddleware(connection: TypedClientConnection<ChatAction>) :
+    SyncMiddleware<ClientChatState, ChatAction>(
+        connection = connection,
+    ) {
+    override val processors: ActionProcessorMap<ClientChatState, ChatAction> =
+        buildProcessors {
+            on<ClientChatAction.Connect> { _, _ ->
+                startConnection()
+            }
+            on<ClientChatAction.Disconnect> { _, _ ->
+                stopConnection()
+            }
         }
-        on<ClientChatAction.Disconnect> { _, _ ->
-            stopConnection()
-        }
-    }
 }

--- a/kotlin/samples/flowdux-remote/auth/client/src/main/kotlin/io/flowdux/sample/chat/authclient/ClientChatAction.kt
+++ b/kotlin/samples/flowdux-remote/auth/client/src/main/kotlin/io/flowdux/sample/chat/authclient/ClientChatAction.kt
@@ -4,6 +4,8 @@ import io.flowdux.sample.chat.ChatAction
 
 sealed interface ClientChatAction : ChatAction {
     data object Connect : ClientChatAction
+
     data object Disconnect : ClientChatAction
+
     data class SetCurrentUser(val user: String) : ClientChatAction
 }

--- a/kotlin/samples/flowdux-remote/auth/client/src/main/kotlin/io/flowdux/sample/chat/authclient/ClientChatReducer.kt
+++ b/kotlin/samples/flowdux-remote/auth/client/src/main/kotlin/io/flowdux/sample/chat/authclient/ClientChatReducer.kt
@@ -5,18 +5,19 @@ import io.flowdux.buildReducer
 import io.flowdux.sample.chat.ChatAction
 import io.flowdux.sample.chat.SharedChatAction
 
-val clientChatReducer: Reducer<ClientChatState, ChatAction> = buildReducer {
-    on<SharedChatAction.SyncState> { state, action ->
-        state.copy(
-            messages = action.state.messages,
-            users = action.state.users,
-            lastEvent = action.state.lastEvent,
-        )
+val clientChatReducer: Reducer<ClientChatState, ChatAction> =
+    buildReducer {
+        on<SharedChatAction.SyncState> { state, action ->
+            state.copy(
+                messages = action.state.messages,
+                users = action.state.users,
+                lastEvent = action.state.lastEvent,
+            )
+        }
+        on<SharedChatAction.SystemAnnouncement> { state, action ->
+            state.copy(systemAnnouncement = action.message)
+        }
+        on<ClientChatAction.SetCurrentUser> { state, action ->
+            state.copy(currentUser = action.user)
+        }
     }
-    on<SharedChatAction.SystemAnnouncement> { state, action ->
-        state.copy(systemAnnouncement = action.message)
-    }
-    on<ClientChatAction.SetCurrentUser> { state, action ->
-        state.copy(currentUser = action.user)
-    }
-}

--- a/kotlin/samples/flowdux-remote/auth/client/src/main/kotlin/io/flowdux/sample/chat/authclient/Main.kt
+++ b/kotlin/samples/flowdux-remote/auth/client/src/main/kotlin/io/flowdux/sample/chat/authclient/Main.kt
@@ -15,14 +15,15 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 
 fun main(args: Array<String>) = runBlocking {
-    val username = args.firstOrNull() ?: run {
-        print("Enter your name: ")
-        System.out.flush()
-        readlnOrNull()?.trim()?.ifEmpty { null }
-    } ?: run {
-        println("No name provided. Exiting.")
-        return@runBlocking
-    }
+    val username =
+        args.firstOrNull() ?: run {
+            print("Enter your name: ")
+            System.out.flush()
+            readlnOrNull()?.trim()?.ifEmpty { null }
+        } ?: run {
+            println("No name provided. Exiting.")
+            return@runBlocking
+        }
 
     println()
     println("=== Flowdux Auth Chat ===")
@@ -34,26 +35,27 @@ fun main(args: Array<String>) = runBlocking {
     val store = createChatStore(username)
 
     var lastAnnouncement: String? = null
-    val collectorJob = launch {
-        store.state.collect { state ->
-            if (state.systemAnnouncement != null && state.systemAnnouncement != lastAnnouncement) {
-                lastAnnouncement = state.systemAnnouncement
-                println()
-                println("  *** SYSTEM: ${state.systemAnnouncement} ***")
-                println()
-            }
+    val collectorJob =
+        launch {
+            store.state.collect { state ->
+                if (state.systemAnnouncement != null && state.systemAnnouncement != lastAnnouncement) {
+                    lastAnnouncement = state.systemAnnouncement
+                    println()
+                    println("  *** SYSTEM: ${state.systemAnnouncement} ***")
+                    println()
+                }
 
-            when (val event = state.lastEvent) {
-                is ChatEvent.UserJoined ->
-                    println("  * ${event.user} joined (online: ${state.users})")
-                is ChatEvent.UserLeft ->
-                    println("  * ${event.user} left (online: ${state.users})")
-                is ChatEvent.MessageReceived ->
-                    println("  [${event.user}] ${event.text}")
-                null -> {}
+                when (val event = state.lastEvent) {
+                    is ChatEvent.UserJoined ->
+                        println("  * ${event.user} joined (online: ${state.users})")
+                    is ChatEvent.UserLeft ->
+                        println("  * ${event.user} left (online: ${state.users})")
+                    is ChatEvent.MessageReceived ->
+                        println("  [${event.user}] ${event.text}")
+                    null -> {}
+                }
             }
         }
-    }
 
     store.dispatch(ClientChatAction.SetCurrentUser(username))
     store.dispatch(ClientChatAction.Connect)
@@ -102,13 +104,14 @@ fun main(args: Array<String>) = runBlocking {
 }
 
 private fun createChatStore(username: String): Store<ClientChatState, ChatAction> {
-    val connection = KtorWebSocketClientConnection.create(
-        host = "localhost",
-        port = 8080,
-        path = "/chat",
-    )
-        .withAuth(token = "user:$username")
-        .typedJsonAs<SharedChatAction, ChatAction>()
+    val connection =
+        KtorWebSocketClientConnection
+            .create(
+                host = "localhost",
+                port = 8080,
+                path = "/chat",
+            ).withAuth(token = "user:$username")
+            .typedJsonAs<SharedChatAction, ChatAction>()
 
     return createClientStore(
         initialState = ClientChatState(),

--- a/kotlin/samples/flowdux-remote/auth/server/src/main/kotlin/io/flowdux/sample/chat/authserver/ChatPrincipal.kt
+++ b/kotlin/samples/flowdux-remote/auth/server/src/main/kotlin/io/flowdux/sample/chat/authserver/ChatPrincipal.kt
@@ -2,7 +2,4 @@ package io.flowdux.sample.chat.authserver
 
 import io.flowdux.remote.auth.server.AuthPrincipal
 
-data class ChatPrincipal(
-    val userId: String,
-    val displayName: String,
-) : AuthPrincipal
+data class ChatPrincipal(val userId: String, val displayName: String) : AuthPrincipal

--- a/kotlin/samples/flowdux-remote/auth/server/src/main/kotlin/io/flowdux/sample/chat/authserver/Main.kt
+++ b/kotlin/samples/flowdux-remote/auth/server/src/main/kotlin/io/flowdux/sample/chat/authserver/Main.kt
@@ -48,7 +48,7 @@ fun main() {
                     messages = serverState.messages,
                     users = serverState.users,
                     lastEvent = serverState.lastEvent,
-                )
+                ),
             )
         },
         scope = applicationScope,
@@ -93,15 +93,14 @@ fun main() {
     server.close()
 }
 
-private fun chatProcessors() =
-    Middleware.ActionProcessorBuilder<ServerChatState, ChatAction>().apply {
-        on<SharedChatAction.SendMessage> { _, action ->
-            emit(ServerChatAction.MessageReceived(user = action.user, text = action.text))
-        }
-        on<SharedChatAction.JoinRoom> { _, action ->
-            emit(ServerChatAction.UserJoined(user = action.user))
-        }
-        on<SharedChatAction.LeaveRoom> { _, action ->
-            emit(ServerChatAction.UserLeft(user = action.user))
-        }
-    }.build()
+private fun chatProcessors() = Middleware.ActionProcessorBuilder<ServerChatState, ChatAction>().apply {
+    on<SharedChatAction.SendMessage> { _, action ->
+        emit(ServerChatAction.MessageReceived(user = action.user, text = action.text))
+    }
+    on<SharedChatAction.JoinRoom> { _, action ->
+        emit(ServerChatAction.UserJoined(user = action.user))
+    }
+    on<SharedChatAction.LeaveRoom> { _, action ->
+        emit(ServerChatAction.UserLeft(user = action.user))
+    }
+}.build()

--- a/kotlin/samples/flowdux-remote/auth/server/src/main/kotlin/io/flowdux/sample/chat/authserver/ServerChatAction.kt
+++ b/kotlin/samples/flowdux-remote/auth/server/src/main/kotlin/io/flowdux/sample/chat/authserver/ServerChatAction.kt
@@ -4,6 +4,8 @@ import io.flowdux.sample.chat.ChatAction
 
 sealed interface ServerChatAction : ChatAction {
     data class MessageReceived(val user: String, val text: String) : ServerChatAction
+
     data class UserJoined(val user: String) : ServerChatAction
+
     data class UserLeft(val user: String) : ServerChatAction
 }

--- a/kotlin/samples/flowdux-remote/auth/server/src/main/kotlin/io/flowdux/sample/chat/authserver/ServerChatReducer.kt
+++ b/kotlin/samples/flowdux-remote/auth/server/src/main/kotlin/io/flowdux/sample/chat/authserver/ServerChatReducer.kt
@@ -6,24 +6,25 @@ import io.flowdux.sample.chat.ChatAction
 import io.flowdux.sample.chat.ChatEvent
 import io.flowdux.sample.chat.ChatMessage
 
-val serverChatReducer: Reducer<ServerChatState, ChatAction> = buildReducer {
-    on<ServerChatAction.MessageReceived> { state, action ->
-        state.copy(
-            messages = state.messages + ChatMessage(action.user, action.text),
-            lastEvent = ChatEvent.MessageReceived(user = action.user, text = action.text),
-            totalMessagesProcessed = state.totalMessagesProcessed + 1,
-        )
+val serverChatReducer: Reducer<ServerChatState, ChatAction> =
+    buildReducer {
+        on<ServerChatAction.MessageReceived> { state, action ->
+            state.copy(
+                messages = state.messages + ChatMessage(action.user, action.text),
+                lastEvent = ChatEvent.MessageReceived(user = action.user, text = action.text),
+                totalMessagesProcessed = state.totalMessagesProcessed + 1,
+            )
+        }
+        on<ServerChatAction.UserJoined> { state, action ->
+            state.copy(
+                users = state.users + action.user,
+                lastEvent = ChatEvent.UserJoined(user = action.user),
+            )
+        }
+        on<ServerChatAction.UserLeft> { state, action ->
+            state.copy(
+                users = state.users - action.user,
+                lastEvent = ChatEvent.UserLeft(user = action.user),
+            )
+        }
     }
-    on<ServerChatAction.UserJoined> { state, action ->
-        state.copy(
-            users = state.users + action.user,
-            lastEvent = ChatEvent.UserJoined(user = action.user),
-        )
-    }
-    on<ServerChatAction.UserLeft> { state, action ->
-        state.copy(
-            users = state.users - action.user,
-            lastEvent = ChatEvent.UserLeft(user = action.user),
-        )
-    }
-}

--- a/kotlin/samples/flowdux-remote/multi-client/client/src/main/kotlin/io/flowdux/sample/chat/multiclient/ChatRemoteMiddleware.kt
+++ b/kotlin/samples/flowdux-remote/multi-client/client/src/main/kotlin/io/flowdux/sample/chat/multiclient/ChatRemoteMiddleware.kt
@@ -5,17 +5,17 @@ import io.flowdux.remote.SyncMiddleware
 import io.flowdux.remote.TypedClientConnection
 import io.flowdux.sample.chat.ChatAction
 
-class ChatRemoteMiddleware(
-    connection: TypedClientConnection<ChatAction>,
-) : SyncMiddleware<ClientChatState, ChatAction>(
-    connection = connection,
-) {
-    override val processors: ActionProcessorMap<ClientChatState, ChatAction> = buildProcessors {
-        on<ClientChatAction.Connect> { _, _ ->
-            startConnection()
+class ChatRemoteMiddleware(connection: TypedClientConnection<ChatAction>) :
+    SyncMiddleware<ClientChatState, ChatAction>(
+        connection = connection,
+    ) {
+    override val processors: ActionProcessorMap<ClientChatState, ChatAction> =
+        buildProcessors {
+            on<ClientChatAction.Connect> { _, _ ->
+                startConnection()
+            }
+            on<ClientChatAction.Disconnect> { _, _ ->
+                stopConnection()
+            }
         }
-        on<ClientChatAction.Disconnect> { _, _ ->
-            stopConnection()
-        }
-    }
 }

--- a/kotlin/samples/flowdux-remote/multi-client/client/src/main/kotlin/io/flowdux/sample/chat/multiclient/ClientChatAction.kt
+++ b/kotlin/samples/flowdux-remote/multi-client/client/src/main/kotlin/io/flowdux/sample/chat/multiclient/ClientChatAction.kt
@@ -4,6 +4,8 @@ import io.flowdux.sample.chat.ChatAction
 
 sealed interface ClientChatAction : ChatAction {
     data object Connect : ClientChatAction
+
     data object Disconnect : ClientChatAction
+
     data class SetCurrentUser(val user: String) : ClientChatAction
 }

--- a/kotlin/samples/flowdux-remote/multi-client/client/src/main/kotlin/io/flowdux/sample/chat/multiclient/ClientChatReducer.kt
+++ b/kotlin/samples/flowdux-remote/multi-client/client/src/main/kotlin/io/flowdux/sample/chat/multiclient/ClientChatReducer.kt
@@ -5,18 +5,19 @@ import io.flowdux.buildReducer
 import io.flowdux.sample.chat.ChatAction
 import io.flowdux.sample.chat.SharedChatAction
 
-val clientChatReducer: Reducer<ClientChatState, ChatAction> = buildReducer {
-    on<SharedChatAction.SyncState> { state, action ->
-        state.copy(
-            messages = action.state.messages,
-            users = action.state.users,
-            lastEvent = action.state.lastEvent,
-        )
+val clientChatReducer: Reducer<ClientChatState, ChatAction> =
+    buildReducer {
+        on<SharedChatAction.SyncState> { state, action ->
+            state.copy(
+                messages = action.state.messages,
+                users = action.state.users,
+                lastEvent = action.state.lastEvent,
+            )
+        }
+        on<SharedChatAction.SystemAnnouncement> { state, action ->
+            state.copy(systemAnnouncement = action.message)
+        }
+        on<ClientChatAction.SetCurrentUser> { state, action ->
+            state.copy(currentUser = action.user)
+        }
     }
-    on<SharedChatAction.SystemAnnouncement> { state, action ->
-        state.copy(systemAnnouncement = action.message)
-    }
-    on<ClientChatAction.SetCurrentUser> { state, action ->
-        state.copy(currentUser = action.user)
-    }
-}

--- a/kotlin/samples/flowdux-remote/multi-client/client/src/main/kotlin/io/flowdux/sample/chat/multiclient/Main.kt
+++ b/kotlin/samples/flowdux-remote/multi-client/client/src/main/kotlin/io/flowdux/sample/chat/multiclient/Main.kt
@@ -14,14 +14,15 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 
 fun main(args: Array<String>) = runBlocking {
-    val username = args.firstOrNull() ?: run {
-        print("Enter your name: ")
-        System.out.flush()
-        readlnOrNull()?.trim()?.ifEmpty { null }
-    } ?: run {
-        println("No name provided. Exiting.")
-        return@runBlocking
-    }
+    val username =
+        args.firstOrNull() ?: run {
+            print("Enter your name: ")
+            System.out.flush()
+            readlnOrNull()?.trim()?.ifEmpty { null }
+        } ?: run {
+            println("No name provided. Exiting.")
+            return@runBlocking
+        }
 
     println()
     println("=== Flowdux Multi-Client Chat ===")
@@ -33,27 +34,28 @@ fun main(args: Array<String>) = runBlocking {
 
     // Observe events
     var lastAnnouncement: String? = null
-    val collectorJob = launch {
-        store.state.collect { state ->
-            // Show system announcements
-            if (state.systemAnnouncement != null && state.systemAnnouncement != lastAnnouncement) {
-                lastAnnouncement = state.systemAnnouncement
-                println()
-                println("  *** SYSTEM: ${state.systemAnnouncement} ***")
-                println()
-            }
+    val collectorJob =
+        launch {
+            store.state.collect { state ->
+                // Show system announcements
+                if (state.systemAnnouncement != null && state.systemAnnouncement != lastAnnouncement) {
+                    lastAnnouncement = state.systemAnnouncement
+                    println()
+                    println("  *** SYSTEM: ${state.systemAnnouncement} ***")
+                    println()
+                }
 
-            when (val event = state.lastEvent) {
-                is ChatEvent.UserJoined ->
-                    println("  * ${event.user} joined (online: ${state.users})")
-                is ChatEvent.UserLeft ->
-                    println("  * ${event.user} left (online: ${state.users})")
-                is ChatEvent.MessageReceived ->
-                    println("  [${event.user}] ${event.text}")
-                null -> {}
+                when (val event = state.lastEvent) {
+                    is ChatEvent.UserJoined ->
+                        println("  * ${event.user} joined (online: ${state.users})")
+                    is ChatEvent.UserLeft ->
+                        println("  * ${event.user} left (online: ${state.users})")
+                    is ChatEvent.MessageReceived ->
+                        println("  [${event.user}] ${event.text}")
+                    null -> {}
+                }
             }
         }
-    }
 
     // Connect and join
     store.dispatch(ClientChatAction.SetCurrentUser(username))
@@ -104,11 +106,13 @@ fun main(args: Array<String>) = runBlocking {
 }
 
 private fun createChatStore(): Store<ClientChatState, ChatAction> {
-    val connection = KtorWebSocketClientConnection.create(
-        host = "localhost",
-        port = 8080,
-        path = "/chat",
-    ).typedJsonAs<SharedChatAction, ChatAction>()
+    val connection =
+        KtorWebSocketClientConnection
+            .create(
+                host = "localhost",
+                port = 8080,
+                path = "/chat",
+            ).typedJsonAs<SharedChatAction, ChatAction>()
     return createClientStore(
         initialState = ClientChatState(),
         syncMiddleware = ChatRemoteMiddleware(connection),

--- a/kotlin/samples/flowdux-remote/multi-client/server/src/main/kotlin/io/flowdux/sample/chat/multiserver/Main.kt
+++ b/kotlin/samples/flowdux-remote/multi-client/server/src/main/kotlin/io/flowdux/sample/chat/multiserver/Main.kt
@@ -36,7 +36,7 @@ fun main() {
                     messages = serverState.messages,
                     users = serverState.users,
                     lastEvent = serverState.lastEvent,
-                )
+                ),
             )
         },
         scope = applicationScope,
@@ -45,8 +45,10 @@ fun main() {
     // Monitor state changes
     applicationScope.launch {
         server.state.collect { state ->
-            println("[Server] clients=${runCatching { server.sessionCount() }.getOrDefault(0)}, " +
-                "users=${state.users}, messages=${state.totalMessagesProcessed}")
+            println(
+                "[Server] clients=${runCatching { server.sessionCount() }.getOrDefault(0)}, " +
+                    "users=${state.users}, messages=${state.totalMessagesProcessed}",
+            )
         }
     }
 
@@ -93,15 +95,14 @@ fun main() {
     server.close()
 }
 
-private fun chatProcessors() =
-    Middleware.ActionProcessorBuilder<ServerChatState, ChatAction>().apply {
-        on<SharedChatAction.SendMessage> { _, action ->
-            emit(ServerChatAction.MessageReceived(user = action.user, text = action.text))
-        }
-        on<SharedChatAction.JoinRoom> { _, action ->
-            emit(ServerChatAction.UserJoined(user = action.user))
-        }
-        on<SharedChatAction.LeaveRoom> { _, action ->
-            emit(ServerChatAction.UserLeft(user = action.user))
-        }
-    }.build()
+private fun chatProcessors() = Middleware.ActionProcessorBuilder<ServerChatState, ChatAction>().apply {
+    on<SharedChatAction.SendMessage> { _, action ->
+        emit(ServerChatAction.MessageReceived(user = action.user, text = action.text))
+    }
+    on<SharedChatAction.JoinRoom> { _, action ->
+        emit(ServerChatAction.UserJoined(user = action.user))
+    }
+    on<SharedChatAction.LeaveRoom> { _, action ->
+        emit(ServerChatAction.UserLeft(user = action.user))
+    }
+}.build()

--- a/kotlin/samples/flowdux-remote/multi-client/server/src/main/kotlin/io/flowdux/sample/chat/multiserver/ServerChatAction.kt
+++ b/kotlin/samples/flowdux-remote/multi-client/server/src/main/kotlin/io/flowdux/sample/chat/multiserver/ServerChatAction.kt
@@ -4,6 +4,8 @@ import io.flowdux.sample.chat.ChatAction
 
 sealed interface ServerChatAction : ChatAction {
     data class MessageReceived(val user: String, val text: String) : ServerChatAction
+
     data class UserJoined(val user: String) : ServerChatAction
+
     data class UserLeft(val user: String) : ServerChatAction
 }

--- a/kotlin/samples/flowdux-remote/multi-client/server/src/main/kotlin/io/flowdux/sample/chat/multiserver/ServerChatReducer.kt
+++ b/kotlin/samples/flowdux-remote/multi-client/server/src/main/kotlin/io/flowdux/sample/chat/multiserver/ServerChatReducer.kt
@@ -6,24 +6,25 @@ import io.flowdux.sample.chat.ChatAction
 import io.flowdux.sample.chat.ChatEvent
 import io.flowdux.sample.chat.ChatMessage
 
-val serverChatReducer: Reducer<ServerChatState, ChatAction> = buildReducer {
-    on<ServerChatAction.MessageReceived> { state, action ->
-        state.copy(
-            messages = state.messages + ChatMessage(action.user, action.text),
-            lastEvent = ChatEvent.MessageReceived(user = action.user, text = action.text),
-            totalMessagesProcessed = state.totalMessagesProcessed + 1,
-        )
+val serverChatReducer: Reducer<ServerChatState, ChatAction> =
+    buildReducer {
+        on<ServerChatAction.MessageReceived> { state, action ->
+            state.copy(
+                messages = state.messages + ChatMessage(action.user, action.text),
+                lastEvent = ChatEvent.MessageReceived(user = action.user, text = action.text),
+                totalMessagesProcessed = state.totalMessagesProcessed + 1,
+            )
+        }
+        on<ServerChatAction.UserJoined> { state, action ->
+            state.copy(
+                users = state.users + action.user,
+                lastEvent = ChatEvent.UserJoined(user = action.user),
+            )
+        }
+        on<ServerChatAction.UserLeft> { state, action ->
+            state.copy(
+                users = state.users - action.user,
+                lastEvent = ChatEvent.UserLeft(user = action.user),
+            )
+        }
     }
-    on<ServerChatAction.UserJoined> { state, action ->
-        state.copy(
-            users = state.users + action.user,
-            lastEvent = ChatEvent.UserJoined(user = action.user),
-        )
-    }
-    on<ServerChatAction.UserLeft> { state, action ->
-        state.copy(
-            users = state.users - action.user,
-            lastEvent = ChatEvent.UserLeft(user = action.user),
-        )
-    }
-}

--- a/kotlin/samples/flowdux-remote/multi-device/client/src/main/kotlin/io/flowdux/sample/note/multidevice/client/ClientNoteAction.kt
+++ b/kotlin/samples/flowdux-remote/multi-device/client/src/main/kotlin/io/flowdux/sample/note/multidevice/client/ClientNoteAction.kt
@@ -4,7 +4,10 @@ import io.flowdux.sample.note.NoteAction
 
 sealed interface ClientNoteAction : NoteAction {
     data object Connect : ClientNoteAction
+
     data object Disconnect : ClientNoteAction
+
     data object Connected : ClientNoteAction
+
     data object Disconnected : ClientNoteAction
 }

--- a/kotlin/samples/flowdux-remote/multi-device/client/src/main/kotlin/io/flowdux/sample/note/multidevice/client/ClientNoteReducer.kt
+++ b/kotlin/samples/flowdux-remote/multi-device/client/src/main/kotlin/io/flowdux/sample/note/multidevice/client/ClientNoteReducer.kt
@@ -5,18 +5,19 @@ import io.flowdux.buildReducer
 import io.flowdux.sample.note.NoteAction
 import io.flowdux.sample.note.SharedNoteAction
 
-val clientNoteReducer: Reducer<ClientNoteState, NoteAction> = buildReducer {
-    on<SharedNoteAction.SyncState> { state, action ->
-        state.copy(
-            notes = action.state.notes,
-            connectedDevices = action.state.connectedDevices,
-            lastEvent = action.state.lastEvent,
-        )
+val clientNoteReducer: Reducer<ClientNoteState, NoteAction> =
+    buildReducer {
+        on<SharedNoteAction.SyncState> { state, action ->
+            state.copy(
+                notes = action.state.notes,
+                connectedDevices = action.state.connectedDevices,
+                lastEvent = action.state.lastEvent,
+            )
+        }
+        on<ClientNoteAction.Connected> { state, _ ->
+            state.copy(isConnected = true)
+        }
+        on<ClientNoteAction.Disconnected> { state, _ ->
+            state.copy(isConnected = false)
+        }
     }
-    on<ClientNoteAction.Connected> { state, _ ->
-        state.copy(isConnected = true)
-    }
-    on<ClientNoteAction.Disconnected> { state, _ ->
-        state.copy(isConnected = false)
-    }
-}

--- a/kotlin/samples/flowdux-remote/multi-device/client/src/main/kotlin/io/flowdux/sample/note/multidevice/client/Main.kt
+++ b/kotlin/samples/flowdux-remote/multi-device/client/src/main/kotlin/io/flowdux/sample/note/multidevice/client/Main.kt
@@ -31,64 +31,69 @@ import kotlinx.coroutines.withContext
  * - /quit — Exit
  */
 fun main(args: Array<String>) = runBlocking {
-    val userId = args.getOrNull(0) ?: run {
-        print("Enter user ID: ")
-        System.out.flush()
-        readlnOrNull()?.trim()?.ifEmpty { null }
-    } ?: run {
-        println("No user ID provided. Exiting.")
-        return@runBlocking
-    }
+    val userId =
+        args.getOrNull(0) ?: run {
+            print("Enter user ID: ")
+            System.out.flush()
+            readlnOrNull()?.trim()?.ifEmpty { null }
+        } ?: run {
+            println("No user ID provided. Exiting.")
+            return@runBlocking
+        }
 
-    val deviceName = args.getOrNull(1) ?: run {
-        print("Enter device name (phone/tablet/desktop): ")
-        System.out.flush()
-        readlnOrNull()?.trim()?.ifEmpty { null }
-    } ?: run {
-        println("No device name provided. Exiting.")
-        return@runBlocking
-    }
+    val deviceName =
+        args.getOrNull(1) ?: run {
+            print("Enter device name (phone/tablet/desktop): ")
+            System.out.flush()
+            readlnOrNull()?.trim()?.ifEmpty { null }
+        } ?: run {
+            println("No device name provided. Exiting.")
+            return@runBlocking
+        }
 
-    println("""
+    println(
+        """
 
-        ╔══════════════════════════════════════════════════════╗
-        ║     FlowDux Multi-Device Notes Client                ║
-        ╠══════════════════════════════════════════════════════╣
-        ║  User: $userId
-        ║  Device: $deviceName
-        ╠══════════════════════════════════════════════════════╣
-        ║  Commands:                                           ║
-        ║    /add <title> | <content>       - Add a note      ║
-        ║    /edit <id> <title> | <content> - Edit a note     ║
-        ║    /delete <id>                   - Delete a note   ║
-        ║    /list                          - List all notes  ║
-        ║    /devices                       - Show devices    ║
-        ║    /quit                          - Exit            ║
-        ╚══════════════════════════════════════════════════════╝
+            ╔══════════════════════════════════════════════════════╗
+            ║     FlowDux Multi-Device Notes Client                ║
+            ╠══════════════════════════════════════════════════════╣
+            ║  User: $userId
+            ║  Device: $deviceName
+            ╠══════════════════════════════════════════════════════╣
+            ║  Commands:                                           ║
+            ║    /add <title> | <content>       - Add a note      ║
+            ║    /edit <id> <title> | <content> - Edit a note     ║
+            ║    /delete <id>                   - Delete a note   ║
+            ║    /list                          - List all notes  ║
+            ║    /devices                       - Show devices    ║
+            ║    /quit                          - Exit            ║
+            ╚══════════════════════════════════════════════════════╝
 
-    """.trimIndent())
+        """.trimIndent(),
+    )
 
     // Connect to the user's room (roomId = userId)
     val store = createNoteStore(userId)
 
     // Observe state changes
-    val collectorJob = launch {
-        store.state.collect { state ->
-            when (val event = state.lastEvent) {
-                is NoteEvent.NoteAdded ->
-                    println("  + Note added: [${event.note.id}] ${event.note.title}")
-                is NoteEvent.NoteDeleted ->
-                    println("  - Note deleted: ${event.noteId}")
-                is NoteEvent.NoteEdited ->
-                    println("  ~ Note edited: [${event.note.id}] ${event.note.title}")
-                is NoteEvent.DeviceJoined ->
-                    println("  * Device joined: ${event.deviceName} (online: ${state.connectedDevices})")
-                is NoteEvent.DeviceLeft ->
-                    println("  * Device left: ${event.deviceName} (online: ${state.connectedDevices})")
-                null -> {}
+    val collectorJob =
+        launch {
+            store.state.collect { state ->
+                when (val event = state.lastEvent) {
+                    is NoteEvent.NoteAdded ->
+                        println("  + Note added: [${event.note.id}] ${event.note.title}")
+                    is NoteEvent.NoteDeleted ->
+                        println("  - Note deleted: ${event.noteId}")
+                    is NoteEvent.NoteEdited ->
+                        println("  ~ Note edited: [${event.note.id}] ${event.note.title}")
+                    is NoteEvent.DeviceJoined ->
+                        println("  * Device joined: ${event.deviceName} (online: ${state.connectedDevices})")
+                    is NoteEvent.DeviceLeft ->
+                        println("  * Device left: ${event.deviceName} (online: ${state.connectedDevices})")
+                    null -> {}
+                }
             }
         }
-    }
 
     // Connect and announce device
     store.dispatch(ClientNoteAction.Connect)
@@ -183,11 +188,13 @@ fun main(args: Array<String>) = runBlocking {
 
 @Suppress("UNCHECKED_CAST")
 private fun createNoteStore(userId: String): Store<ClientNoteState, NoteAction> {
-    val connection = KtorWebSocketClientConnection.create(
-        host = "localhost",
-        port = 8080,
-        path = "/sync/$userId",
-    ).typedJson<SharedNoteAction>() as TypedClientConnection<NoteAction>
+    val connection =
+        KtorWebSocketClientConnection
+            .create(
+                host = "localhost",
+                port = 8080,
+                path = "/sync/$userId",
+            ).typedJson<SharedNoteAction>() as TypedClientConnection<NoteAction>
 
     return createClientStore(
         initialState = ClientNoteState(userId = userId),

--- a/kotlin/samples/flowdux-remote/multi-device/client/src/main/kotlin/io/flowdux/sample/note/multidevice/client/NoteRemoteMiddleware.kt
+++ b/kotlin/samples/flowdux-remote/multi-device/client/src/main/kotlin/io/flowdux/sample/note/multidevice/client/NoteRemoteMiddleware.kt
@@ -5,19 +5,19 @@ import io.flowdux.remote.SyncMiddleware
 import io.flowdux.remote.TypedClientConnection
 import io.flowdux.sample.note.NoteAction
 
-class NoteRemoteMiddleware(
-    connection: TypedClientConnection<NoteAction>,
-) : SyncMiddleware<ClientNoteState, NoteAction>(
-    connection = connection,
-) {
-    override val processors: ActionProcessorMap<ClientNoteState, NoteAction> = buildProcessors {
-        on<ClientNoteAction.Connect> { _, _ ->
-            startConnection()
-            emit(ClientNoteAction.Connected)
+class NoteRemoteMiddleware(connection: TypedClientConnection<NoteAction>) :
+    SyncMiddleware<ClientNoteState, NoteAction>(
+        connection = connection,
+    ) {
+    override val processors: ActionProcessorMap<ClientNoteState, NoteAction> =
+        buildProcessors {
+            on<ClientNoteAction.Connect> { _, _ ->
+                startConnection()
+                emit(ClientNoteAction.Connected)
+            }
+            on<ClientNoteAction.Disconnect> { _, _ ->
+                stopConnection()
+                emit(ClientNoteAction.Disconnected)
+            }
         }
-        on<ClientNoteAction.Disconnect> { _, _ ->
-            stopConnection()
-            emit(ClientNoteAction.Disconnected)
-        }
-    }
 }

--- a/kotlin/samples/flowdux-remote/multi-device/server/src/main/kotlin/io/flowdux/sample/note/multidevice/server/Main.kt
+++ b/kotlin/samples/flowdux-remote/multi-device/server/src/main/kotlin/io/flowdux/sample/note/multidevice/server/Main.kt
@@ -47,13 +47,15 @@ fun main() {
         reducer = serverNoteReducer,
         processors = noteProcessors(),
         stateMapper = { state ->
-            println("[User ${state.userId}] State changed: devices=${state.connectedDevices}, notes=${state.notes.size}")
+            println(
+                "[User ${state.userId}] State changed: devices=${state.connectedDevices}, notes=${state.notes.size}",
+            )
             SharedNoteAction.SyncState(
                 NoteState(
                     notes = state.notes,
                     connectedDevices = state.connectedDevices,
                     lastEvent = state.lastEvent,
-                )
+                ),
             )
         },
         scope = applicationScope,
@@ -78,7 +80,8 @@ fun main() {
         }
     }
 
-    println("""
+    println(
+        """
         ╔══════════════════════════════════════════════════════╗
         ║     FlowDux Multi-Device Notes Server                ║
         ╠══════════════════════════════════════════════════════╣
@@ -90,7 +93,8 @@ fun main() {
         ╠══════════════════════════════════════════════════════╣
         ║  Same userId = same room = shared notes!             ║
         ╚══════════════════════════════════════════════════════╝
-    """.trimIndent())
+        """.trimIndent(),
+    )
     println()
 
     embeddedServer(CIO, port = 8080) {
@@ -99,7 +103,11 @@ fun main() {
         routing {
             get("/users") {
                 val userIds = roomServer.roomIds()
-                call.respondText("Active user sessions (${userIds.size}): ${userIds.joinToString(", ").ifEmpty { "(none)" }}")
+                call.respondText(
+                    "Active user sessions (${userIds.size}): ${userIds.joinToString(", ").ifEmpty {
+                        "(none)"
+                    }}",
+                )
             }
 
             // userId as roomId — all devices of the same user connect here
@@ -140,32 +148,35 @@ private suspend fun printStatus(roomServer: io.flowdux.remote.server.pattern.Roo
     } else {
         userIds.forEach { userId ->
             @Suppress("UNCHECKED_CAST")
-            val room = roomServer.getRoom(userId) as? io.flowdux.remote.server.pattern.SharedStateServer<ServerNoteState, NoteAction>
+            val room = roomServer.getRoom(
+                userId,
+            ) as? io.flowdux.remote.server.pattern.SharedStateServer<ServerNoteState, NoteAction>
             room?.let {
                 val state = it.currentState
-                println("  [$userId] devices=${state.connectedDevices}, notes=${state.notes.size}, edits=${state.totalEdits}")
+                println(
+                    "  [$userId] devices=${state.connectedDevices}, notes=${state.notes.size}, edits=${state.totalEdits}",
+                )
             }
         }
     }
     println("===========================\n")
 }
 
-private fun noteProcessors() =
-    Middleware.ActionProcessorBuilder<ServerNoteState, NoteAction>().apply {
-        on<SharedNoteAction.AddNote> { _, action ->
-            val noteId = UUID.randomUUID().toString().take(8)
-            emit(ServerNoteAction.NoteAdded(id = noteId, title = action.title, content = action.content))
-        }
-        on<SharedNoteAction.DeleteNote> { _, action ->
-            emit(ServerNoteAction.NoteDeleted(noteId = action.noteId))
-        }
-        on<SharedNoteAction.EditNote> { _, action ->
-            emit(ServerNoteAction.NoteEdited(noteId = action.noteId, title = action.title, content = action.content))
-        }
-        on<SharedNoteAction.DeviceConnected> { _, action ->
-            emit(ServerNoteAction.DeviceJoined(deviceName = action.deviceName))
-        }
-        on<SharedNoteAction.DeviceDisconnected> { _, action ->
-            emit(ServerNoteAction.DeviceLeft(deviceName = action.deviceName))
-        }
-    }.build()
+private fun noteProcessors() = Middleware.ActionProcessorBuilder<ServerNoteState, NoteAction>().apply {
+    on<SharedNoteAction.AddNote> { _, action ->
+        val noteId = UUID.randomUUID().toString().take(8)
+        emit(ServerNoteAction.NoteAdded(id = noteId, title = action.title, content = action.content))
+    }
+    on<SharedNoteAction.DeleteNote> { _, action ->
+        emit(ServerNoteAction.NoteDeleted(noteId = action.noteId))
+    }
+    on<SharedNoteAction.EditNote> { _, action ->
+        emit(ServerNoteAction.NoteEdited(noteId = action.noteId, title = action.title, content = action.content))
+    }
+    on<SharedNoteAction.DeviceConnected> { _, action ->
+        emit(ServerNoteAction.DeviceJoined(deviceName = action.deviceName))
+    }
+    on<SharedNoteAction.DeviceDisconnected> { _, action ->
+        emit(ServerNoteAction.DeviceLeft(deviceName = action.deviceName))
+    }
+}.build()

--- a/kotlin/samples/flowdux-remote/multi-device/server/src/main/kotlin/io/flowdux/sample/note/multidevice/server/ServerNoteAction.kt
+++ b/kotlin/samples/flowdux-remote/multi-device/server/src/main/kotlin/io/flowdux/sample/note/multidevice/server/ServerNoteAction.kt
@@ -4,8 +4,12 @@ import io.flowdux.sample.note.NoteAction
 
 sealed interface ServerNoteAction : NoteAction {
     data class NoteAdded(val id: String, val title: String, val content: String) : ServerNoteAction
+
     data class NoteDeleted(val noteId: String) : ServerNoteAction
+
     data class NoteEdited(val noteId: String, val title: String, val content: String) : ServerNoteAction
+
     data class DeviceJoined(val deviceName: String) : ServerNoteAction
+
     data class DeviceLeft(val deviceName: String) : ServerNoteAction
 }

--- a/kotlin/samples/flowdux-remote/multi-device/server/src/main/kotlin/io/flowdux/sample/note/multidevice/server/ServerNoteReducer.kt
+++ b/kotlin/samples/flowdux-remote/multi-device/server/src/main/kotlin/io/flowdux/sample/note/multidevice/server/ServerNoteReducer.kt
@@ -6,40 +6,41 @@ import io.flowdux.sample.note.Note
 import io.flowdux.sample.note.NoteAction
 import io.flowdux.sample.note.NoteEvent
 
-val serverNoteReducer: Reducer<ServerNoteState, NoteAction> = buildReducer {
-    on<ServerNoteAction.NoteAdded> { state, action ->
-        val note = Note(id = action.id, title = action.title, content = action.content)
-        state.copy(
-            notes = state.notes + note,
-            lastEvent = NoteEvent.NoteAdded(note),
-            totalEdits = state.totalEdits + 1,
-        )
+val serverNoteReducer: Reducer<ServerNoteState, NoteAction> =
+    buildReducer {
+        on<ServerNoteAction.NoteAdded> { state, action ->
+            val note = Note(id = action.id, title = action.title, content = action.content)
+            state.copy(
+                notes = state.notes + note,
+                lastEvent = NoteEvent.NoteAdded(note),
+                totalEdits = state.totalEdits + 1,
+            )
+        }
+        on<ServerNoteAction.NoteDeleted> { state, action ->
+            state.copy(
+                notes = state.notes.filter { it.id != action.noteId },
+                lastEvent = NoteEvent.NoteDeleted(action.noteId),
+                totalEdits = state.totalEdits + 1,
+            )
+        }
+        on<ServerNoteAction.NoteEdited> { state, action ->
+            val updatedNote = Note(id = action.noteId, title = action.title, content = action.content)
+            state.copy(
+                notes = state.notes.map { if (it.id == action.noteId) updatedNote else it },
+                lastEvent = NoteEvent.NoteEdited(updatedNote),
+                totalEdits = state.totalEdits + 1,
+            )
+        }
+        on<ServerNoteAction.DeviceJoined> { state, action ->
+            state.copy(
+                connectedDevices = state.connectedDevices + action.deviceName,
+                lastEvent = NoteEvent.DeviceJoined(action.deviceName),
+            )
+        }
+        on<ServerNoteAction.DeviceLeft> { state, action ->
+            state.copy(
+                connectedDevices = state.connectedDevices - action.deviceName,
+                lastEvent = NoteEvent.DeviceLeft(action.deviceName),
+            )
+        }
     }
-    on<ServerNoteAction.NoteDeleted> { state, action ->
-        state.copy(
-            notes = state.notes.filter { it.id != action.noteId },
-            lastEvent = NoteEvent.NoteDeleted(action.noteId),
-            totalEdits = state.totalEdits + 1,
-        )
-    }
-    on<ServerNoteAction.NoteEdited> { state, action ->
-        val updatedNote = Note(id = action.noteId, title = action.title, content = action.content)
-        state.copy(
-            notes = state.notes.map { if (it.id == action.noteId) updatedNote else it },
-            lastEvent = NoteEvent.NoteEdited(updatedNote),
-            totalEdits = state.totalEdits + 1,
-        )
-    }
-    on<ServerNoteAction.DeviceJoined> { state, action ->
-        state.copy(
-            connectedDevices = state.connectedDevices + action.deviceName,
-            lastEvent = NoteEvent.DeviceJoined(action.deviceName),
-        )
-    }
-    on<ServerNoteAction.DeviceLeft> { state, action ->
-        state.copy(
-            connectedDevices = state.connectedDevices - action.deviceName,
-            lastEvent = NoteEvent.DeviceLeft(action.deviceName),
-        )
-    }
-}

--- a/kotlin/samples/flowdux-remote/multi-device/shared/src/main/kotlin/io/flowdux/sample/note/NoteContract.kt
+++ b/kotlin/samples/flowdux-remote/multi-device/shared/src/main/kotlin/io/flowdux/sample/note/NoteContract.kt
@@ -12,14 +12,30 @@ interface NoteAction : Action
 @Serializable
 sealed interface SharedNoteAction : NoteAction {
     // Client → Server
-    @Serializable data class AddNote(val title: String, val content: String) : SharedNoteAction, ServerSharedAction
-    @Serializable data class DeleteNote(val noteId: String) : SharedNoteAction, ServerSharedAction
-    @Serializable data class EditNote(val noteId: String, val title: String, val content: String) : SharedNoteAction, ServerSharedAction
-    @Serializable data class DeviceConnected(val deviceName: String) : SharedNoteAction, ServerSharedAction
-    @Serializable data class DeviceDisconnected(val deviceName: String) : SharedNoteAction, ServerSharedAction
+    @Serializable data class AddNote(val title: String, val content: String) :
+        SharedNoteAction,
+        ServerSharedAction
+
+    @Serializable data class DeleteNote(val noteId: String) :
+        SharedNoteAction,
+        ServerSharedAction
+
+    @Serializable data class EditNote(val noteId: String, val title: String, val content: String) :
+        SharedNoteAction,
+        ServerSharedAction
+
+    @Serializable data class DeviceConnected(val deviceName: String) :
+        SharedNoteAction,
+        ServerSharedAction
+
+    @Serializable data class DeviceDisconnected(val deviceName: String) :
+        SharedNoteAction,
+        ServerSharedAction
 
     // Server → Client
-    @Serializable data class SyncState(val state: NoteState) : SharedNoteAction, ClientSharedAction
+    @Serializable data class SyncState(val state: NoteState) :
+        SharedNoteAction,
+        ClientSharedAction
 }
 
 // -- State --
@@ -31,17 +47,17 @@ data class NoteState(
 ) : State
 
 @Serializable
-data class Note(
-    val id: String,
-    val title: String,
-    val content: String,
-)
+data class Note(val id: String, val title: String, val content: String)
 
 @Serializable
 sealed interface NoteEvent {
     @Serializable data class NoteAdded(val note: Note) : NoteEvent
+
     @Serializable data class NoteDeleted(val noteId: String) : NoteEvent
+
     @Serializable data class NoteEdited(val note: Note) : NoteEvent
+
     @Serializable data class DeviceJoined(val deviceName: String) : NoteEvent
+
     @Serializable data class DeviceLeft(val deviceName: String) : NoteEvent
 }

--- a/kotlin/samples/flowdux-remote/multi-room/client/src/main/kotlin/io/flowdux/sample/chat/multiroomclient/ChatRemoteMiddleware.kt
+++ b/kotlin/samples/flowdux-remote/multi-room/client/src/main/kotlin/io/flowdux/sample/chat/multiroomclient/ChatRemoteMiddleware.kt
@@ -5,19 +5,19 @@ import io.flowdux.remote.SyncMiddleware
 import io.flowdux.remote.TypedClientConnection
 import io.flowdux.sample.chat.ChatAction
 
-class ChatRemoteMiddleware(
-    connection: TypedClientConnection<ChatAction>,
-) : SyncMiddleware<ClientChatState, ChatAction>(
-    connection = connection,
-) {
-    override val processors: ActionProcessorMap<ClientChatState, ChatAction> = buildProcessors {
-        on<ClientChatAction.Connect> { _, _ ->
-            startConnection()
-            emit(ClientChatAction.Connected)
+class ChatRemoteMiddleware(connection: TypedClientConnection<ChatAction>) :
+    SyncMiddleware<ClientChatState, ChatAction>(
+        connection = connection,
+    ) {
+    override val processors: ActionProcessorMap<ClientChatState, ChatAction> =
+        buildProcessors {
+            on<ClientChatAction.Connect> { _, _ ->
+                startConnection()
+                emit(ClientChatAction.Connected)
+            }
+            on<ClientChatAction.Disconnect> { _, _ ->
+                stopConnection()
+                emit(ClientChatAction.Disconnected)
+            }
         }
-        on<ClientChatAction.Disconnect> { _, _ ->
-            stopConnection()
-            emit(ClientChatAction.Disconnected)
-        }
-    }
 }

--- a/kotlin/samples/flowdux-remote/multi-room/client/src/main/kotlin/io/flowdux/sample/chat/multiroomclient/ClientChatAction.kt
+++ b/kotlin/samples/flowdux-remote/multi-room/client/src/main/kotlin/io/flowdux/sample/chat/multiroomclient/ClientChatAction.kt
@@ -4,9 +4,14 @@ import io.flowdux.sample.chat.ChatAction
 
 sealed interface ClientChatAction : ChatAction {
     data object Connect : ClientChatAction
+
     data object Disconnect : ClientChatAction
+
     data class SetCurrentUser(val user: String) : ClientChatAction
+
     data class SetRoomId(val roomId: String) : ClientChatAction
+
     data object Connected : ClientChatAction
+
     data object Disconnected : ClientChatAction
 }

--- a/kotlin/samples/flowdux-remote/multi-room/client/src/main/kotlin/io/flowdux/sample/chat/multiroomclient/ClientChatReducer.kt
+++ b/kotlin/samples/flowdux-remote/multi-room/client/src/main/kotlin/io/flowdux/sample/chat/multiroomclient/ClientChatReducer.kt
@@ -5,24 +5,25 @@ import io.flowdux.buildReducer
 import io.flowdux.sample.chat.ChatAction
 import io.flowdux.sample.chat.SharedChatAction
 
-val clientChatReducer: Reducer<ClientChatState, ChatAction> = buildReducer {
-    on<SharedChatAction.SyncState> { state, action ->
-        state.copy(
-            messages = action.state.messages,
-            users = action.state.users,
-            lastEvent = action.state.lastEvent,
-        )
+val clientChatReducer: Reducer<ClientChatState, ChatAction> =
+    buildReducer {
+        on<SharedChatAction.SyncState> { state, action ->
+            state.copy(
+                messages = action.state.messages,
+                users = action.state.users,
+                lastEvent = action.state.lastEvent,
+            )
+        }
+        on<ClientChatAction.SetCurrentUser> { state, action ->
+            state.copy(currentUser = action.user)
+        }
+        on<ClientChatAction.SetRoomId> { state, action ->
+            state.copy(roomId = action.roomId)
+        }
+        on<ClientChatAction.Connected> { state, _ ->
+            state.copy(isConnected = true)
+        }
+        on<ClientChatAction.Disconnected> { state, _ ->
+            state.copy(isConnected = false)
+        }
     }
-    on<ClientChatAction.SetCurrentUser> { state, action ->
-        state.copy(currentUser = action.user)
-    }
-    on<ClientChatAction.SetRoomId> { state, action ->
-        state.copy(roomId = action.roomId)
-    }
-    on<ClientChatAction.Connected> { state, _ ->
-        state.copy(isConnected = true)
-    }
-    on<ClientChatAction.Disconnected> { state, _ ->
-        state.copy(isConnected = false)
-    }
-}

--- a/kotlin/samples/flowdux-remote/multi-room/client/src/main/kotlin/io/flowdux/sample/chat/multiroomclient/Main.kt
+++ b/kotlin/samples/flowdux-remote/multi-room/client/src/main/kotlin/io/flowdux/sample/chat/multiroomclient/Main.kt
@@ -29,33 +29,36 @@ import kotlinx.coroutines.withContext
  * - /quit — Exit
  */
 fun main(args: Array<String>) = runBlocking {
-    val username = args.firstOrNull() ?: run {
-        print("Enter your name: ")
-        System.out.flush()
-        readlnOrNull()?.trim()?.ifEmpty { null }
-    } ?: run {
-        println("No name provided. Exiting.")
-        return@runBlocking
-    }
+    val username =
+        args.firstOrNull() ?: run {
+            print("Enter your name: ")
+            System.out.flush()
+            readlnOrNull()?.trim()?.ifEmpty { null }
+        } ?: run {
+            println("No name provided. Exiting.")
+            return@runBlocking
+        }
 
     val initialRoom = args.getOrNull(1) ?: "general"
 
-    println("""
+    println(
+        """
 
-        ╔══════════════════════════════════════════════════╗
-        ║     FlowDux Multi-Room Chat Client               ║
-        ╠══════════════════════════════════════════════════╣
-        ║  Commands:                                       ║
-        ║    /join <room>  - Join a different room         ║
-        ║    /rooms        - List suggested rooms          ║
-        ║    /users        - Show users in current room    ║
-        ║    /history      - Show message history          ║
-        ║    /quit         - Exit                          ║
-        ╠══════════════════════════════════════════════════╣
-        ║  Just type to send a message!                    ║
-        ╚══════════════════════════════════════════════════╝
+            ╔══════════════════════════════════════════════════╗
+            ║     FlowDux Multi-Room Chat Client               ║
+            ╠══════════════════════════════════════════════════╣
+            ║  Commands:                                       ║
+            ║    /join <room>  - Join a different room         ║
+            ║    /rooms        - List suggested rooms          ║
+            ║    /users        - Show users in current room    ║
+            ║    /history      - Show message history          ║
+            ║    /quit         - Exit                          ║
+            ╠══════════════════════════════════════════════════╣
+            ║  Just type to send a message!                    ║
+            ╚══════════════════════════════════════════════════╝
 
-    """.trimIndent())
+        """.trimIndent(),
+    )
 
     var currentRoom = initialRoom
     var store: Store<ClientChatState, ChatAction>? = null
@@ -80,19 +83,20 @@ fun main(args: Array<String>) = runBlocking {
         val newStore = createChatStore(roomId)
 
         // Observe state changes
-        collectorJob = launch {
-            newStore.state.collect { state ->
-                when (val event = state.lastEvent) {
-                    is ChatEvent.UserJoined ->
-                        println("  * ${event.user} joined [$roomId] (online: ${state.users})")
-                    is ChatEvent.UserLeft ->
-                        println("  * ${event.user} left [$roomId] (online: ${state.users})")
-                    is ChatEvent.MessageReceived ->
-                        println("  [$roomId] [${event.user}] ${event.text}")
-                    null -> {}
+        collectorJob =
+            launch {
+                newStore.state.collect { state ->
+                    when (val event = state.lastEvent) {
+                        is ChatEvent.UserJoined ->
+                            println("  * ${event.user} joined [$roomId] (online: ${state.users})")
+                        is ChatEvent.UserLeft ->
+                            println("  * ${event.user} left [$roomId] (online: ${state.users})")
+                        is ChatEvent.MessageReceived ->
+                            println("  [$roomId] [${event.user}] ${event.text}")
+                        null -> {}
+                    }
                 }
             }
-        }
 
         // Connect and join
         newStore.dispatch(ClientChatAction.SetRoomId(roomId))
@@ -181,11 +185,13 @@ fun main(args: Array<String>) = runBlocking {
 
 @Suppress("UNCHECKED_CAST")
 private fun createChatStore(roomId: String): Store<ClientChatState, ChatAction> {
-    val connection = KtorWebSocketClientConnection.create(
-        host = "localhost",
-        port = 8080,
-        path = "/room/$roomId",
-    ).typedJson<SharedChatAction>() as TypedClientConnection<ChatAction>
+    val connection =
+        KtorWebSocketClientConnection
+            .create(
+                host = "localhost",
+                port = 8080,
+                path = "/room/$roomId",
+            ).typedJson<SharedChatAction>() as TypedClientConnection<ChatAction>
 
     return createClientStore(
         initialState = ClientChatState(roomId = roomId),

--- a/kotlin/samples/flowdux-remote/multi-room/server/src/main/kotlin/io/flowdux/sample/chat/multiroom/Main.kt
+++ b/kotlin/samples/flowdux-remote/multi-room/server/src/main/kotlin/io/flowdux/sample/chat/multiroom/Main.kt
@@ -54,7 +54,7 @@ fun main() {
                     messages = state.messages,
                     users = state.users,
                     lastEvent = state.lastEvent,
-                )
+                ),
             )
         },
         scope = applicationScope,
@@ -79,7 +79,8 @@ fun main() {
         }
     }
 
-    println("""
+    println(
+        """
         ╔══════════════════════════════════════════════════╗
         ║     FlowDux Multi-Room Chat Server               ║
         ╠══════════════════════════════════════════════════╣
@@ -89,7 +90,8 @@ fun main() {
         ╠══════════════════════════════════════════════════╣
         ║  Example rooms: general, random, kotlin, java    ║
         ╚══════════════════════════════════════════════════╝
-    """.trimIndent())
+        """.trimIndent(),
+    )
     println()
 
     embeddedServer(CIO, port = 8080) {
@@ -142,7 +144,9 @@ private suspend fun printStatus(roomServer: io.flowdux.remote.server.pattern.Roo
     } else {
         roomIds.forEach { roomId ->
             @Suppress("UNCHECKED_CAST")
-            val room = roomServer.getRoom(roomId) as? io.flowdux.remote.server.pattern.SharedStateServer<ServerChatState, ChatAction>
+            val room = roomServer.getRoom(
+                roomId,
+            ) as? io.flowdux.remote.server.pattern.SharedStateServer<ServerChatState, ChatAction>
             room?.let {
                 val state = it.currentState
                 println("  [$roomId] users=${state.users}, messages=${state.messages.size}")
@@ -152,15 +156,14 @@ private suspend fun printStatus(roomServer: io.flowdux.remote.server.pattern.Roo
     println("===================\n")
 }
 
-private fun chatProcessors() =
-    Middleware.ActionProcessorBuilder<ServerChatState, ChatAction>().apply {
-        on<SharedChatAction.SendMessage> { _, action ->
-            emit(ServerChatAction.MessageReceived(user = action.user, text = action.text))
-        }
-        on<SharedChatAction.JoinRoom> { _, action ->
-            emit(ServerChatAction.UserJoined(user = action.user))
-        }
-        on<SharedChatAction.LeaveRoom> { _, action ->
-            emit(ServerChatAction.UserLeft(user = action.user))
-        }
-    }.build()
+private fun chatProcessors() = Middleware.ActionProcessorBuilder<ServerChatState, ChatAction>().apply {
+    on<SharedChatAction.SendMessage> { _, action ->
+        emit(ServerChatAction.MessageReceived(user = action.user, text = action.text))
+    }
+    on<SharedChatAction.JoinRoom> { _, action ->
+        emit(ServerChatAction.UserJoined(user = action.user))
+    }
+    on<SharedChatAction.LeaveRoom> { _, action ->
+        emit(ServerChatAction.UserLeft(user = action.user))
+    }
+}.build()

--- a/kotlin/samples/flowdux-remote/multi-room/server/src/main/kotlin/io/flowdux/sample/chat/multiroom/ServerChatAction.kt
+++ b/kotlin/samples/flowdux-remote/multi-room/server/src/main/kotlin/io/flowdux/sample/chat/multiroom/ServerChatAction.kt
@@ -4,6 +4,8 @@ import io.flowdux.sample.chat.ChatAction
 
 sealed interface ServerChatAction : ChatAction {
     data class MessageReceived(val user: String, val text: String) : ServerChatAction
+
     data class UserJoined(val user: String) : ServerChatAction
+
     data class UserLeft(val user: String) : ServerChatAction
 }

--- a/kotlin/samples/flowdux-remote/multi-room/server/src/main/kotlin/io/flowdux/sample/chat/multiroom/ServerChatReducer.kt
+++ b/kotlin/samples/flowdux-remote/multi-room/server/src/main/kotlin/io/flowdux/sample/chat/multiroom/ServerChatReducer.kt
@@ -6,24 +6,25 @@ import io.flowdux.sample.chat.ChatAction
 import io.flowdux.sample.chat.ChatEvent
 import io.flowdux.sample.chat.ChatMessage
 
-val serverChatReducer: Reducer<ServerChatState, ChatAction> = buildReducer {
-    on<ServerChatAction.MessageReceived> { state, action ->
-        state.copy(
-            messages = state.messages + ChatMessage(action.user, action.text),
-            lastEvent = ChatEvent.MessageReceived(user = action.user, text = action.text),
-            totalMessagesProcessed = state.totalMessagesProcessed + 1,
-        )
+val serverChatReducer: Reducer<ServerChatState, ChatAction> =
+    buildReducer {
+        on<ServerChatAction.MessageReceived> { state, action ->
+            state.copy(
+                messages = state.messages + ChatMessage(action.user, action.text),
+                lastEvent = ChatEvent.MessageReceived(user = action.user, text = action.text),
+                totalMessagesProcessed = state.totalMessagesProcessed + 1,
+            )
+        }
+        on<ServerChatAction.UserJoined> { state, action ->
+            state.copy(
+                users = state.users + action.user,
+                lastEvent = ChatEvent.UserJoined(user = action.user),
+            )
+        }
+        on<ServerChatAction.UserLeft> { state, action ->
+            state.copy(
+                users = state.users - action.user,
+                lastEvent = ChatEvent.UserLeft(user = action.user),
+            )
+        }
     }
-    on<ServerChatAction.UserJoined> { state, action ->
-        state.copy(
-            users = state.users + action.user,
-            lastEvent = ChatEvent.UserJoined(user = action.user),
-        )
-    }
-    on<ServerChatAction.UserLeft> { state, action ->
-        state.copy(
-            users = state.users - action.user,
-            lastEvent = ChatEvent.UserLeft(user = action.user),
-        )
-    }
-}

--- a/kotlin/samples/flowdux-remote/multiplexer/client/src/main/kotlin/io/flowdux/sample/multiplexer/client/ClientRoomManager.kt
+++ b/kotlin/samples/flowdux-remote/multiplexer/client/src/main/kotlin/io/flowdux/sample/multiplexer/client/ClientRoomManager.kt
@@ -63,10 +63,11 @@ class ClientRoomManager(
 
     /** Leave a room */
     suspend fun leaveRoom(roomId: String) {
-        val roomConnection = rooms.remove(roomId) ?: run {
-            println("[Client] Not in room: $roomId")
-            return
-        }
+        val roomConnection =
+            rooms.remove(roomId) ?: run {
+                println("[Client] Not in room: $roomId")
+                return
+            }
 
         println("[Client] Leaving room: $roomId")
 
@@ -122,51 +123,47 @@ class ClientRoomManager(
     private fun createRoomStore(
         roomId: String,
         connection: TypedClientConnection<ChatAction>,
-    ): Store<ClientRoomState, ChatAction> {
-        return createClientStore(
-            initialState = ClientRoomState(roomId = roomId),
-            syncMiddleware = RoomRemoteMiddleware(connection),
-            reducer = clientRoomReducer,
-        )
-    }
+    ): Store<ClientRoomState, ChatAction> = createClientStore(
+        initialState = ClientRoomState(roomId = roomId),
+        syncMiddleware = RoomRemoteMiddleware(connection),
+        reducer = clientRoomReducer,
+    )
 }
 
 /**
  * Represents a connection to a single room.
  */
-class RoomConnection(
-    val roomId: String,
-    val store: Store<ClientRoomState, ChatAction>,
-) {
+class RoomConnection(val roomId: String, val store: Store<ClientRoomState, ChatAction>) {
     private var observerJob: kotlinx.coroutines.Job? = null
 
     fun startObserving(scope: CoroutineScope, currentUser: String) {
-        observerJob = scope.launch {
-            var lastEventId = 0
-            store.state.collect { state ->
-                // Only show events we haven't seen
-                val event = state.lastEvent
-                if (event != null && state.hashCode() != lastEventId) {
-                    lastEventId = state.hashCode()
+        observerJob =
+            scope.launch {
+                var lastEventId = 0
+                store.state.collect { state ->
+                    // Only show events we haven't seen
+                    val event = state.lastEvent
+                    if (event != null && state.hashCode() != lastEventId) {
+                        lastEventId = state.hashCode()
 
-                    when (event) {
-                        is io.flowdux.sample.multiplexer.ChatEvent.UserJoined -> {
-                            if (event.user != currentUser) {
-                                println("\n[$roomId] ${event.user} joined the room")
+                        when (event) {
+                            is io.flowdux.sample.multiplexer.ChatEvent.UserJoined -> {
+                                if (event.user != currentUser) {
+                                    println("\n[$roomId] ${event.user} joined the room")
+                                }
                             }
-                        }
-                        is io.flowdux.sample.multiplexer.ChatEvent.UserLeft -> {
-                            println("\n[$roomId] ${event.user} left the room")
-                        }
-                        is io.flowdux.sample.multiplexer.ChatEvent.MessageReceived -> {
-                            if (event.user != currentUser) {
-                                println("\n[$roomId] ${event.user}: ${event.text}")
+                            is io.flowdux.sample.multiplexer.ChatEvent.UserLeft -> {
+                                println("\n[$roomId] ${event.user} left the room")
+                            }
+                            is io.flowdux.sample.multiplexer.ChatEvent.MessageReceived -> {
+                                if (event.user != currentUser) {
+                                    println("\n[$roomId] ${event.user}: ${event.text}")
+                                }
                             }
                         }
                     }
                 }
             }
-        }
     }
 
     fun close() {

--- a/kotlin/samples/flowdux-remote/multiplexer/client/src/main/kotlin/io/flowdux/sample/multiplexer/client/ClientRoomState.kt
+++ b/kotlin/samples/flowdux-remote/multiplexer/client/src/main/kotlin/io/flowdux/sample/multiplexer/client/ClientRoomState.kt
@@ -23,27 +23,29 @@ data class ClientRoomState(
  */
 sealed interface ClientRoomAction : ChatAction {
     data object Connect : ClientRoomAction
+
     data object Disconnect : ClientRoomAction
 }
 
 /**
  * Client-side reducer for room state.
  */
-val clientRoomReducer = buildReducer<ClientRoomState, ChatAction> {
-    on<SharedChatAction.SyncState> { state, action ->
-        state.copy(
-            roomId = action.state.roomId,
-            messages = action.state.messages,
-            users = action.state.users,
-            lastEvent = action.state.lastEvent,
-        )
-    }
+val clientRoomReducer =
+    buildReducer<ClientRoomState, ChatAction> {
+        on<SharedChatAction.SyncState> { state, action ->
+            state.copy(
+                roomId = action.state.roomId,
+                messages = action.state.messages,
+                users = action.state.users,
+                lastEvent = action.state.lastEvent,
+            )
+        }
 
-    on<ClientRoomAction.Connect> { state, _ ->
-        state.copy(isConnected = true)
-    }
+        on<ClientRoomAction.Connect> { state, _ ->
+            state.copy(isConnected = true)
+        }
 
-    on<ClientRoomAction.Disconnect> { state, _ ->
-        state.copy(isConnected = false)
+        on<ClientRoomAction.Disconnect> { state, _ ->
+            state.copy(isConnected = false)
+        }
     }
-}

--- a/kotlin/samples/flowdux-remote/multiplexer/client/src/main/kotlin/io/flowdux/sample/multiplexer/client/Main.kt
+++ b/kotlin/samples/flowdux-remote/multiplexer/client/src/main/kotlin/io/flowdux/sample/multiplexer/client/Main.kt
@@ -1,18 +1,14 @@
 package io.flowdux.sample.multiplexer.client
 
-import io.flowdux.Store
-import io.flowdux.createStore
 import io.flowdux.remote.ktor.KtorWebSocketClientConnection
 import io.flowdux.remote.multiplexer.ClientConnectionMultiplexer
 import io.flowdux.remote.multiplexer.typedRoutedJson
-import io.flowdux.sample.multiplexer.ChatAction
 import io.flowdux.sample.multiplexer.SharedChatAction
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 
@@ -36,30 +32,32 @@ fun main(args: Array<String>) = runBlocking {
 
     println(
         """
-        ╔══════════════════════════════════════════════════════════╗
-        ║     FlowDux Connection Multiplexer Demo Client           ║
-        ╠══════════════════════════════════════════════════════════╣
-        ║  Single WebSocket, multiple rooms!                       ║
-        ╠══════════════════════════════════════════════════════════╣
-        ║  Commands:                                               ║
-        ║    /join <room>   - Join a room                          ║
-        ║    /leave <room>  - Leave a room                         ║
-        ║    /rooms         - List joined rooms                    ║
-        ║    /switch <room> - Switch active room                   ║
-        ║    /quit          - Disconnect and exit                  ║
-        ║    <message>      - Send message to active room          ║
-        ╚══════════════════════════════════════════════════════════╝
-        """.trimIndent()
+            ╔══════════════════════════════════════════════════════════╗
+            ║     FlowDux Connection Multiplexer Demo Client           ║
+            ╠══════════════════════════════════════════════════════════╣
+            ║  Single WebSocket, multiple rooms!                       ║
+            ╠══════════════════════════════════════════════════════════╣
+            ║  Commands:                                               ║
+            ║    /join <room>   - Join a room                          ║
+            ║    /leave <room>  - Leave a room                         ║
+            ║    /rooms         - List joined rooms                    ║
+            ║    /switch <room> - Switch active room                   ║
+            ║    /quit          - Disconnect and exit                  ║
+            ║    <message>      - Send message to active room          ║
+            ╚══════════════════════════════════════════════════════════╝
+        """.trimIndent(),
     )
     println()
     println("Welcome, $username!")
 
     // Create the physical connection
-    val physicalConnection = KtorWebSocketClientConnection.create(
-        host = "localhost",
-        port = 8080,
-        path = "/ws",
-    ).typedRoutedJson<SharedChatAction>()
+    val physicalConnection =
+        KtorWebSocketClientConnection
+            .create(
+                host = "localhost",
+                port = 8080,
+                path = "/ws",
+            ).typedRoutedJson<SharedChatAction>()
 
     // Create the multiplexer
     val multiplexer = ClientConnectionMultiplexer(physicalConnection, scope)

--- a/kotlin/samples/flowdux-remote/multiplexer/client/src/main/kotlin/io/flowdux/sample/multiplexer/client/RoomRemoteMiddleware.kt
+++ b/kotlin/samples/flowdux-remote/multiplexer/client/src/main/kotlin/io/flowdux/sample/multiplexer/client/RoomRemoteMiddleware.kt
@@ -10,18 +10,18 @@ import io.flowdux.sample.multiplexer.ChatAction
  * Each room has its own middleware instance that handles communication
  * through its virtual connection from the multiplexer.
  */
-class RoomRemoteMiddleware(
-    connection: TypedClientConnection<ChatAction>,
-) : SyncMiddleware<ClientRoomState, ChatAction>(
-    connection = connection,
-) {
-    override val processors = buildProcessors {
-        on<ClientRoomAction.Connect> { _, _ ->
-            startConnection()
-        }
+class RoomRemoteMiddleware(connection: TypedClientConnection<ChatAction>) :
+    SyncMiddleware<ClientRoomState, ChatAction>(
+        connection = connection,
+    ) {
+    override val processors =
+        buildProcessors {
+            on<ClientRoomAction.Connect> { _, _ ->
+                startConnection()
+            }
 
-        on<ClientRoomAction.Disconnect> { _, _ ->
-            stopConnection()
+            on<ClientRoomAction.Disconnect> { _, _ ->
+                stopConnection()
+            }
         }
-    }
 }

--- a/kotlin/samples/flowdux-remote/multiplexer/server/src/main/kotlin/io/flowdux/sample/multiplexer/server/ClientSession.kt
+++ b/kotlin/samples/flowdux-remote/multiplexer/server/src/main/kotlin/io/flowdux/sample/multiplexer/server/ClientSession.kt
@@ -85,12 +85,13 @@ class ClientSession(
         // Track the job so we can cancel it when leaving the room
         // The upcast is needed because SharedChatAction extends ChatAction
         @Suppress("UNCHECKED_CAST")
-        val job = scope.launch {
-            room.handleClient(
-                sessionId,
-                virtualConnection as io.flowdux.remote.server.connection.TypedServerConnection<ChatAction>,
-            )
-        }
+        val job =
+            scope.launch {
+                room.handleClient(
+                    sessionId,
+                    virtualConnection as io.flowdux.remote.server.connection.TypedServerConnection<ChatAction>,
+                )
+            }
 
         // Store the job for cleanup on leave
         roomJobs[roomId] = job

--- a/kotlin/samples/flowdux-remote/multiplexer/server/src/main/kotlin/io/flowdux/sample/multiplexer/server/Main.kt
+++ b/kotlin/samples/flowdux-remote/multiplexer/server/src/main/kotlin/io/flowdux/sample/multiplexer/server/Main.kt
@@ -64,7 +64,7 @@ fun main() {
                     messages = state.messages,
                     users = state.users,
                     lastEvent = state.lastEvent,
-                )
+                ),
             )
         },
         scope = applicationScope,
@@ -106,7 +106,7 @@ fun main() {
         ╠══════════════════════════════════════════════════════════╣
         ║  Example rooms: general, kotlin, java, random            ║
         ╚══════════════════════════════════════════════════════════╝
-        """.trimIndent()
+        """.trimIndent(),
     )
     println()
 
@@ -172,7 +172,9 @@ fun main() {
     roomServer.close()
 }
 
-private suspend fun printStatus(roomServer: io.flowdux.remote.server.pattern.RoomServer<SharedStateServer<ServerRoomState, ChatAction>>) {
+private suspend fun printStatus(
+    roomServer: io.flowdux.remote.server.pattern.RoomServer<SharedStateServer<ServerRoomState, ChatAction>>,
+) {
     val roomIds = roomServer.roomIds()
     if (roomIds.isEmpty()) {
         println("  No active rooms")
@@ -187,15 +189,14 @@ private suspend fun printStatus(roomServer: io.flowdux.remote.server.pattern.Roo
     }
 }
 
-private fun roomProcessors() =
-    Middleware.ActionProcessorBuilder<ServerRoomState, ChatAction>().apply {
-        on<SharedChatAction.SendMessage> { _, action ->
-            emit(ServerRoomAction.MessageReceived(user = action.user, text = action.text))
-        }
-        on<SharedChatAction.JoinRoom> { _, action ->
-            emit(ServerRoomAction.UserJoined(user = action.user))
-        }
-        on<SharedChatAction.LeaveRoom> { _, action ->
-            emit(ServerRoomAction.UserLeft(user = action.user))
-        }
-    }.build()
+private fun roomProcessors() = Middleware.ActionProcessorBuilder<ServerRoomState, ChatAction>().apply {
+    on<SharedChatAction.SendMessage> { _, action ->
+        emit(ServerRoomAction.MessageReceived(user = action.user, text = action.text))
+    }
+    on<SharedChatAction.JoinRoom> { _, action ->
+        emit(ServerRoomAction.UserJoined(user = action.user))
+    }
+    on<SharedChatAction.LeaveRoom> { _, action ->
+        emit(ServerRoomAction.UserLeft(user = action.user))
+    }
+}.build()

--- a/kotlin/samples/flowdux-remote/multiplexer/server/src/main/kotlin/io/flowdux/sample/multiplexer/server/ServerRoomState.kt
+++ b/kotlin/samples/flowdux-remote/multiplexer/server/src/main/kotlin/io/flowdux/sample/multiplexer/server/ServerRoomState.kt
@@ -22,33 +22,36 @@ data class ServerRoomState(
  */
 sealed interface ServerRoomAction : ChatAction {
     data class MessageReceived(val user: String, val text: String) : ServerRoomAction
+
     data class UserJoined(val user: String) : ServerRoomAction
+
     data class UserLeft(val user: String) : ServerRoomAction
 }
 
 /**
  * Server-side reducer for room state.
  */
-val serverRoomReducer = buildReducer<ServerRoomState, ChatAction> {
-    on<ServerRoomAction.MessageReceived> { state, action ->
-        state.copy(
-            messages = state.messages + ChatMessage(action.user, action.text),
-            lastEvent = ChatEvent.MessageReceived(user = action.user, text = action.text),
-            totalMessagesProcessed = state.totalMessagesProcessed + 1,
-        )
-    }
+val serverRoomReducer =
+    buildReducer<ServerRoomState, ChatAction> {
+        on<ServerRoomAction.MessageReceived> { state, action ->
+            state.copy(
+                messages = state.messages + ChatMessage(action.user, action.text),
+                lastEvent = ChatEvent.MessageReceived(user = action.user, text = action.text),
+                totalMessagesProcessed = state.totalMessagesProcessed + 1,
+            )
+        }
 
-    on<ServerRoomAction.UserJoined> { state, action ->
-        state.copy(
-            users = state.users + action.user,
-            lastEvent = ChatEvent.UserJoined(user = action.user),
-        )
-    }
+        on<ServerRoomAction.UserJoined> { state, action ->
+            state.copy(
+                users = state.users + action.user,
+                lastEvent = ChatEvent.UserJoined(user = action.user),
+            )
+        }
 
-    on<ServerRoomAction.UserLeft> { state, action ->
-        state.copy(
-            users = state.users - action.user,
-            lastEvent = ChatEvent.UserLeft(user = action.user),
-        )
+        on<ServerRoomAction.UserLeft> { state, action ->
+            state.copy(
+                users = state.users - action.user,
+                lastEvent = ChatEvent.UserLeft(user = action.user),
+            )
+        }
     }
-}

--- a/kotlin/samples/flowdux-remote/multiplexer/shared/src/main/kotlin/io/flowdux/sample/multiplexer/MultiplexerContract.kt
+++ b/kotlin/samples/flowdux-remote/multiplexer/shared/src/main/kotlin/io/flowdux/sample/multiplexer/MultiplexerContract.kt
@@ -22,17 +22,25 @@ interface ChatAction : Action
 sealed interface SharedChatAction : ChatAction {
     // Client → Server
     @Serializable
-    data class SendMessage(val user: String, val text: String) : SharedChatAction, ServerSharedAction
+    data class SendMessage(val user: String, val text: String) :
+        SharedChatAction,
+        ServerSharedAction
 
     @Serializable
-    data class JoinRoom(val user: String) : SharedChatAction, ServerSharedAction
+    data class JoinRoom(val user: String) :
+        SharedChatAction,
+        ServerSharedAction
 
     @Serializable
-    data class LeaveRoom(val user: String) : SharedChatAction, ServerSharedAction
+    data class LeaveRoom(val user: String) :
+        SharedChatAction,
+        ServerSharedAction
 
     // Server → Client
     @Serializable
-    data class SyncState(val state: RoomState) : SharedChatAction, ClientSharedAction
+    data class SyncState(val state: RoomState) :
+        SharedChatAction,
+        ClientSharedAction
 }
 
 /**
@@ -47,10 +55,7 @@ data class RoomState(
 ) : State
 
 @Serializable
-data class ChatMessage(
-    val user: String,
-    val text: String,
-)
+data class ChatMessage(val user: String, val text: String)
 
 @Serializable
 sealed interface ChatEvent {

--- a/kotlin/samples/flowdux-remote/node-mediator/central/src/main/kotlin/io/flowdux/sample/nodemediator/central/Main.kt
+++ b/kotlin/samples/flowdux-remote/node-mediator/central/src/main/kotlin/io/flowdux/sample/nodemediator/central/Main.kt
@@ -90,7 +90,7 @@ fun main() {
         ╠════════════════════════════════════════════════╣
         ║  Default port: 8080                            ║
         ╚════════════════════════════════════════════════╝
-        """.trimIndent()
+        """.trimIndent(),
     )
     println()
 
@@ -118,10 +118,12 @@ fun main() {
         }
     }
 
-    Runtime.getRuntime().addShutdownHook(Thread {
-        println("[Central] Shutting down...")
-        kotlinx.coroutines.runBlocking { manager.close() }
-    })
+    Runtime.getRuntime().addShutdownHook(
+        Thread {
+            println("[Central] Shutting down...")
+            kotlinx.coroutines.runBlocking { manager.close() }
+        },
+    )
 
     server.start(wait = true)
 }

--- a/kotlin/samples/flowdux-remote/node-mediator/client/src/main/kotlin/io/flowdux/sample/nodemediator/client/ClientState.kt
+++ b/kotlin/samples/flowdux-remote/node-mediator/client/src/main/kotlin/io/flowdux/sample/nodemediator/client/ClientState.kt
@@ -23,24 +23,27 @@ data class ClientChatState(
  */
 sealed interface ClientChatAction : ChatAction {
     data object Connect : ClientChatAction
+
     data object Disconnect : ClientChatAction
+
     data class SetCurrentUser(val user: String) : ClientChatAction
 }
 
 /**
  * Client-side reducer.
  */
-val clientChatReducer = buildReducer<ClientChatState, ChatAction> {
-    on<SharedChatAction.SyncState> { state, action ->
-        state.copy(
-            messages = action.state.messages,
-            users = action.state.users,
-            lastEvent = action.state.lastEvent,
-            currentRoom = action.state.roomId,
-        )
-    }
+val clientChatReducer =
+    buildReducer<ClientChatState, ChatAction> {
+        on<SharedChatAction.SyncState> { state, action ->
+            state.copy(
+                messages = action.state.messages,
+                users = action.state.users,
+                lastEvent = action.state.lastEvent,
+                currentRoom = action.state.roomId,
+            )
+        }
 
-    on<ClientChatAction.SetCurrentUser> { state, action ->
-        state.copy(currentUser = action.user)
+        on<ClientChatAction.SetCurrentUser> { state, action ->
+            state.copy(currentUser = action.user)
+        }
     }
-}

--- a/kotlin/samples/flowdux-remote/node-mediator/client/src/main/kotlin/io/flowdux/sample/nodemediator/client/Main.kt
+++ b/kotlin/samples/flowdux-remote/node-mediator/client/src/main/kotlin/io/flowdux/sample/nodemediator/client/Main.kt
@@ -27,11 +27,12 @@ import kotlinx.coroutines.withContext
  * Args: username [roomId] [nodeHost] [nodePort]
  */
 fun main(args: Array<String>) = runBlocking {
-    val username = args.getOrElse(0) {
-        print("Enter your name: ")
-        System.out.flush()
-        readlnOrNull()?.trim()?.ifEmpty { null } ?: "User${(1..1000).random()}"
-    }
+    val username =
+        args.getOrElse(0) {
+            print("Enter your name: ")
+            System.out.flush()
+            readlnOrNull()?.trim()?.ifEmpty { null } ?: "User${(1..1000).random()}"
+        }
     var currentRoom = args.getOrElse(1) { "lobby" }
     val nodeHost = args.getOrElse(2) { "localhost" }
     val nodePort = args.getOrElse(3) { "8081" }.toInt()
@@ -48,19 +49,20 @@ fun main(args: Array<String>) = runBlocking {
     var collectorJob: Job? = null
 
     fun startCollector() {
-        collectorJob = launch {
-            store.state.collect { state ->
-                when (val event = state.lastEvent) {
-                    is ChatEvent.UserJoined ->
-                        println("  [${state.currentRoom}] * ${event.user} joined (online: ${state.users})")
-                    is ChatEvent.UserLeft ->
-                        println("  [${state.currentRoom}] * ${event.user} left (online: ${state.users})")
-                    is ChatEvent.MessageReceived ->
-                        println("  [${state.currentRoom}] [${event.user}] ${event.text}")
-                    null -> {}
+        collectorJob =
+            launch {
+                store.state.collect { state ->
+                    when (val event = state.lastEvent) {
+                        is ChatEvent.UserJoined ->
+                            println("  [${state.currentRoom}] * ${event.user} joined (online: ${state.users})")
+                        is ChatEvent.UserLeft ->
+                            println("  [${state.currentRoom}] * ${event.user} left (online: ${state.users})")
+                        is ChatEvent.MessageReceived ->
+                            println("  [${state.currentRoom}] [${event.user}] ${event.text}")
+                        null -> {}
+                    }
                 }
             }
-        }
     }
 
     // Connect and join default room
@@ -141,11 +143,13 @@ private fun createChatStore(
     roomId: String,
     username: String,
 ): Store<ClientChatState, ChatAction> {
-    val connection = KtorWebSocketClientConnection.create(
-        host = host,
-        port = port,
-        path = "/ws/$roomId?user=$username",
-    ).typedJsonAs<SharedChatAction, ChatAction>()
+    val connection =
+        KtorWebSocketClientConnection
+            .create(
+                host = host,
+                port = port,
+                path = "/ws/$roomId?user=$username",
+            ).typedJsonAs<SharedChatAction, ChatAction>()
 
     return createClientStore(
         initialState = ClientChatState(),
@@ -154,17 +158,17 @@ private fun createChatStore(
     )
 }
 
-private class ChatRemoteMiddleware(
-    connection: TypedClientConnection<ChatAction>,
-) : SyncMiddleware<ClientChatState, ChatAction>(
-    connection = connection,
-) {
-    override val processors: ActionProcessorMap<ClientChatState, ChatAction> = buildProcessors {
-        on<ClientChatAction.Connect> { _, _ ->
-            startConnection()
+private class ChatRemoteMiddleware(connection: TypedClientConnection<ChatAction>) :
+    SyncMiddleware<ClientChatState, ChatAction>(
+        connection = connection,
+    ) {
+    override val processors: ActionProcessorMap<ClientChatState, ChatAction> =
+        buildProcessors {
+            on<ClientChatAction.Connect> { _, _ ->
+                startConnection()
+            }
+            on<ClientChatAction.Disconnect> { _, _ ->
+                stopConnection()
+            }
         }
-        on<ClientChatAction.Disconnect> { _, _ ->
-            stopConnection()
-        }
-    }
 }

--- a/kotlin/samples/flowdux-remote/node-mediator/node/src/main/kotlin/io/flowdux/sample/nodemediator/node/Main.kt
+++ b/kotlin/samples/flowdux-remote/node-mediator/node/src/main/kotlin/io/flowdux/sample/nodemediator/node/Main.kt
@@ -61,7 +61,7 @@ fun main(args: Array<String>) {
                     messages = state.messages,
                     users = state.users,
                     lastEvent = state.lastEvent,
-                )
+                ),
             )
         },
         scope = applicationScope,
@@ -118,7 +118,7 @@ fun main(args: Array<String>) {
         ║    WS  /ws/{roomId} — Client connections       ║
         ║    GET /rooms       — Local room list          ║
         ╚════════════════════════════════════════════════╝
-        """.trimIndent()
+        """.trimIndent(),
     )
     println()
 
@@ -130,7 +130,11 @@ fun main(args: Array<String>) {
         routing {
             get("/rooms") {
                 val roomIds = nodeRoomServer.roomIds()
-                call.respondText("Rooms on $nodeId (${roomIds.size}): ${roomIds.joinToString(", ").ifEmpty { "(none)" }}")
+                call.respondText(
+                    "Rooms on $nodeId (${roomIds.size}): ${roomIds.joinToString(", ").ifEmpty {
+                        "(none)"
+                    }}",
+                )
             }
 
             webSocket("/ws/{roomId}") {
@@ -155,13 +159,15 @@ fun main(args: Array<String>) {
         }
     }
 
-    Runtime.getRuntime().addShutdownHook(Thread {
-        println("[$nodeId] Shutting down...")
-        cleanupJob.cancel()
-        kotlinx.coroutines.runBlocking {
-            nodeRoomServer.close()
-        }
-    })
+    Runtime.getRuntime().addShutdownHook(
+        Thread {
+            println("[$nodeId] Shutting down...")
+            cleanupJob.cancel()
+            kotlinx.coroutines.runBlocking {
+                nodeRoomServer.close()
+            }
+        },
+    )
 
     server.start(wait = true)
 }

--- a/kotlin/samples/flowdux-remote/node-mediator/node/src/main/kotlin/io/flowdux/sample/nodemediator/node/ServerRoomState.kt
+++ b/kotlin/samples/flowdux-remote/node-mediator/node/src/main/kotlin/io/flowdux/sample/nodemediator/node/ServerRoomState.kt
@@ -21,26 +21,27 @@ data class ServerRoomState(
  * Server-side reducer for room state.
  * Handles SharedChatAction directly without intermediate server-only actions.
  */
-val serverRoomReducer = buildReducer<ServerRoomState, SharedChatAction> {
-    on<SharedChatAction.SendMessage> { state, action ->
-        state.copy(
-            messages = state.messages + ChatMessage(action.user, action.text),
-            lastEvent = ChatEvent.MessageReceived(user = action.user, text = action.text),
-            totalMessagesProcessed = state.totalMessagesProcessed + 1,
-        )
-    }
+val serverRoomReducer =
+    buildReducer<ServerRoomState, SharedChatAction> {
+        on<SharedChatAction.SendMessage> { state, action ->
+            state.copy(
+                messages = state.messages + ChatMessage(action.user, action.text),
+                lastEvent = ChatEvent.MessageReceived(user = action.user, text = action.text),
+                totalMessagesProcessed = state.totalMessagesProcessed + 1,
+            )
+        }
 
-    on<SharedChatAction.JoinRoom> { state, action ->
-        state.copy(
-            users = state.users + action.user,
-            lastEvent = ChatEvent.UserJoined(user = action.user),
-        )
-    }
+        on<SharedChatAction.JoinRoom> { state, action ->
+            state.copy(
+                users = state.users + action.user,
+                lastEvent = ChatEvent.UserJoined(user = action.user),
+            )
+        }
 
-    on<SharedChatAction.LeaveRoom> { state, action ->
-        state.copy(
-            users = state.users - action.user,
-            lastEvent = ChatEvent.UserLeft(user = action.user),
-        )
+        on<SharedChatAction.LeaveRoom> { state, action ->
+            state.copy(
+                users = state.users - action.user,
+                lastEvent = ChatEvent.UserLeft(user = action.user),
+            )
+        }
     }
-}

--- a/kotlin/samples/flowdux-remote/node-mediator/shared/src/main/kotlin/io/flowdux/sample/nodemediator/shared/NodeMediatorContract.kt
+++ b/kotlin/samples/flowdux-remote/node-mediator/shared/src/main/kotlin/io/flowdux/sample/nodemediator/shared/NodeMediatorContract.kt
@@ -18,17 +18,25 @@ interface ChatAction : Action
 sealed interface SharedChatAction : ChatAction {
     // Client → Server (via Node → Central)
     @Serializable
-    data class SendMessage(val user: String, val text: String) : SharedChatAction, ServerSharedAction
+    data class SendMessage(val user: String, val text: String) :
+        SharedChatAction,
+        ServerSharedAction
 
     @Serializable
-    data class JoinRoom(val user: String, val roomId: String = "lobby") : SharedChatAction, ServerSharedAction
+    data class JoinRoom(val user: String, val roomId: String = "lobby") :
+        SharedChatAction,
+        ServerSharedAction
 
     @Serializable
-    data class LeaveRoom(val user: String) : SharedChatAction, ServerSharedAction
+    data class LeaveRoom(val user: String) :
+        SharedChatAction,
+        ServerSharedAction
 
     // Server → Client (via Central → Node)
     @Serializable
-    data class SyncState(val state: RoomState) : SharedChatAction, ClientSharedAction
+    data class SyncState(val state: RoomState) :
+        SharedChatAction,
+        ClientSharedAction
 }
 
 /**
@@ -43,10 +51,7 @@ data class RoomState(
 ) : State
 
 @Serializable
-data class ChatMessage(
-    val user: String,
-    val text: String,
-)
+data class ChatMessage(val user: String, val text: String)
 
 @Serializable
 sealed interface ChatEvent {

--- a/kotlin/samples/flowdux-remote/poker/client/src/main/kotlin/io/flowdux/sample/poker/client/ClientPokerAction.kt
+++ b/kotlin/samples/flowdux-remote/poker/client/src/main/kotlin/io/flowdux/sample/poker/client/ClientPokerAction.kt
@@ -5,5 +5,6 @@ import io.flowdux.sample.poker.PokerAction
 /** Client-only actions (not sent over wire). */
 sealed interface ClientPokerAction : PokerAction {
     data object Connect : ClientPokerAction
+
     data object Disconnect : ClientPokerAction
 }

--- a/kotlin/samples/flowdux-remote/poker/client/src/main/kotlin/io/flowdux/sample/poker/client/ClientPokerReducer.kt
+++ b/kotlin/samples/flowdux-remote/poker/client/src/main/kotlin/io/flowdux/sample/poker/client/ClientPokerReducer.kt
@@ -5,22 +5,23 @@ import io.flowdux.buildReducer
 import io.flowdux.sample.poker.PokerAction
 import io.flowdux.sample.poker.SharedPokerAction
 
-val clientPokerReducer: Reducer<ClientPokerState, PokerAction> = buildReducer {
-    // Sync public table state from Room Store
-    on<SharedPokerAction.SyncTableState> { state, action ->
-        state.copy(
-            players = action.state.players,
-            communityCards = action.state.communityCards,
-            pot = action.state.pot,
-            currentTurnPlayerId = action.state.currentTurnPlayerId,
-            phase = action.state.phase,
-            minimumBet = action.state.minimumBet,
-            lastEvent = action.state.lastEvent,
-        )
-    }
+val clientPokerReducer: Reducer<ClientPokerState, PokerAction> =
+    buildReducer {
+        // Sync public table state from Room Store
+        on<SharedPokerAction.SyncTableState> { state, action ->
+            state.copy(
+                players = action.state.players,
+                communityCards = action.state.communityCards,
+                pot = action.state.pot,
+                currentTurnPlayerId = action.state.currentTurnPlayerId,
+                phase = action.state.phase,
+                minimumBet = action.state.minimumBet,
+                lastEvent = action.state.lastEvent,
+            )
+        }
 
-    // Sync private hand from Per-Client Store
-    on<SharedPokerAction.SyncHand> { state, action ->
-        state.copy(myHand = action.cards)
+        // Sync private hand from Per-Client Store
+        on<SharedPokerAction.SyncHand> { state, action ->
+            state.copy(myHand = action.cards)
+        }
     }
-}

--- a/kotlin/samples/flowdux-remote/poker/client/src/main/kotlin/io/flowdux/sample/poker/client/ClientPokerState.kt
+++ b/kotlin/samples/flowdux-remote/poker/client/src/main/kotlin/io/flowdux/sample/poker/client/ClientPokerState.kt
@@ -16,7 +16,6 @@ import io.flowdux.sample.poker.TableEvent
 data class ClientPokerState(
     // Client-local
     val playerId: String = "",
-
     // Public state (synced from Room Store)
     val players: List<PlayerInfo> = emptyList(),
     val communityCards: List<Card> = emptyList(),
@@ -25,7 +24,6 @@ data class ClientPokerState(
     val phase: GamePhase = GamePhase.WAITING,
     val minimumBet: Int = 0,
     val lastEvent: TableEvent? = null,
-
     // Private state (synced from Per-Client Store)
     val myHand: List<Card> = emptyList(),
 ) : State {

--- a/kotlin/samples/flowdux-remote/poker/client/src/main/kotlin/io/flowdux/sample/poker/client/Main.kt
+++ b/kotlin/samples/flowdux-remote/poker/client/src/main/kotlin/io/flowdux/sample/poker/client/Main.kt
@@ -4,7 +4,6 @@ import io.flowdux.Store
 import io.flowdux.remote.createClientStore
 import io.flowdux.remote.ktor.KtorWebSocketClientConnection
 import io.flowdux.remote.serialization.typedJsonAs
-import io.flowdux.sample.poker.GamePhase
 import io.flowdux.sample.poker.PokerAction
 import io.flowdux.sample.poker.SharedPokerAction
 import io.flowdux.sample.poker.TableEvent
@@ -35,33 +34,34 @@ fun main(args: Array<String>) = runBlocking {
     val store = createPokerStore(playerId)
 
     // Observe state changes
-    val collectorJob = launch {
-        var lastHandSize = 0
-        store.state.collect { state ->
-            // Display private hand when received/changed
-            if (state.myHand.size != lastHandSize && state.myHand.isNotEmpty()) {
-                lastHandSize = state.myHand.size
-                println()
-                println("  YOUR PRIVATE HAND: ${state.myHand.joinToString(" ")}")
-                println("  (Only you can see these cards!)")
-                println()
-            }
+    val collectorJob =
+        launch {
+            var lastHandSize = 0
+            store.state.collect { state ->
+                // Display private hand when received/changed
+                if (state.myHand.size != lastHandSize && state.myHand.isNotEmpty()) {
+                    lastHandSize = state.myHand.size
+                    println()
+                    println("  YOUR PRIVATE HAND: ${state.myHand.joinToString(" ")}")
+                    println("  (Only you can see these cards!)")
+                    println()
+                }
 
-            // Display public events
-            when (val event = state.lastEvent) {
-                is TableEvent.PlayerJoined -> println("  [+] ${event.name} joined the table")
-                is TableEvent.PlayerLeft -> println("  [-] ${event.playerId} left the table")
-                is TableEvent.PlayerBet -> println("  [$] ${event.playerId} bet ${event.amount}")
-                is TableEvent.PlayerFolded -> println("  [X] ${event.playerId} folded")
-                is TableEvent.PlayerChecked -> println("  [.] ${event.playerId} checked")
-                is TableEvent.PlayerCalled -> println("  [=] ${event.playerId} called ${event.amount}")
-                is TableEvent.PhaseChanged -> println("  [>] Phase: ${event.phase}")
-                is TableEvent.GameStarted -> println("  [!] ${event.message}")
-                is TableEvent.GameEnded -> println("  [*] ${event.winnerName} wins ${event.pot} chips!")
-                null -> {}
+                // Display public events
+                when (val event = state.lastEvent) {
+                    is TableEvent.PlayerJoined -> println("  [+] ${event.name} joined the table")
+                    is TableEvent.PlayerLeft -> println("  [-] ${event.playerId} left the table")
+                    is TableEvent.PlayerBet -> println("  [$] ${event.playerId} bet ${event.amount}")
+                    is TableEvent.PlayerFolded -> println("  [X] ${event.playerId} folded")
+                    is TableEvent.PlayerChecked -> println("  [.] ${event.playerId} checked")
+                    is TableEvent.PlayerCalled -> println("  [=] ${event.playerId} called ${event.amount}")
+                    is TableEvent.PhaseChanged -> println("  [>] Phase: ${event.phase}")
+                    is TableEvent.GameStarted -> println("  [!] ${event.message}")
+                    is TableEvent.GameEnded -> println("  [*] ${event.winnerName} wins ${event.pot} chips!")
+                    null -> {}
+                }
             }
         }
-    }
 
     // Connect and join
     store.dispatch(ClientPokerAction.Connect)
@@ -140,11 +140,12 @@ private fun printStatus(store: Store<ClientPokerState, PokerAction>) {
     for (player in state.players) {
         val turnMarker = if (player.id == state.currentTurnPlayerId) " <-- YOUR TURN" else ""
         val youMarker = if (player.id == state.playerId) " (you)" else ""
-        val status = when {
-            player.folded -> " [FOLDED]"
-            player.isAllIn -> " [ALL-IN]"
-            else -> ""
-        }
+        val status =
+            when {
+                player.folded -> " [FOLDED]"
+                player.isAllIn -> " [ALL-IN]"
+                else -> ""
+            }
         println("    ${player.name}$youMarker: ${player.chips} chips, bet ${player.currentBet}$status$turnMarker")
     }
     if (state.myHand.isNotEmpty()) {
@@ -155,11 +156,13 @@ private fun printStatus(store: Store<ClientPokerState, PokerAction>) {
 }
 
 private fun createPokerStore(playerId: String): Store<ClientPokerState, PokerAction> {
-    val connection = KtorWebSocketClientConnection.create(
-        host = "localhost",
-        port = 8080,
-        path = "/poker/$playerId",
-    ).typedJsonAs<SharedPokerAction, PokerAction>()
+    val connection =
+        KtorWebSocketClientConnection
+            .create(
+                host = "localhost",
+                port = 8080,
+                path = "/poker/$playerId",
+            ).typedJsonAs<SharedPokerAction, PokerAction>()
 
     return createClientStore(
         initialState = ClientPokerState(playerId = playerId),

--- a/kotlin/samples/flowdux-remote/poker/client/src/main/kotlin/io/flowdux/sample/poker/client/PokerRemoteMiddleware.kt
+++ b/kotlin/samples/flowdux-remote/poker/client/src/main/kotlin/io/flowdux/sample/poker/client/PokerRemoteMiddleware.kt
@@ -5,17 +5,17 @@ import io.flowdux.remote.SyncMiddleware
 import io.flowdux.remote.TypedClientConnection
 import io.flowdux.sample.poker.PokerAction
 
-class PokerRemoteMiddleware(
-    connection: TypedClientConnection<PokerAction>,
-) : SyncMiddleware<ClientPokerState, PokerAction>(
-    connection = connection,
-) {
-    override val processors: ActionProcessorMap<ClientPokerState, PokerAction> = buildProcessors {
-        on<ClientPokerAction.Connect> { _, _ ->
-            startConnection()
+class PokerRemoteMiddleware(connection: TypedClientConnection<PokerAction>) :
+    SyncMiddleware<ClientPokerState, PokerAction>(
+        connection = connection,
+    ) {
+    override val processors: ActionProcessorMap<ClientPokerState, PokerAction> =
+        buildProcessors {
+            on<ClientPokerAction.Connect> { _, _ ->
+                startConnection()
+            }
+            on<ClientPokerAction.Disconnect> { _, _ ->
+                stopConnection()
+            }
         }
-        on<ClientPokerAction.Disconnect> { _, _ ->
-            stopConnection()
-        }
-    }
 }

--- a/kotlin/samples/flowdux-remote/poker/server/src/main/kotlin/io/flowdux/sample/poker/server/Main.kt
+++ b/kotlin/samples/flowdux-remote/poker/server/src/main/kotlin/io/flowdux/sample/poker/server/Main.kt
@@ -54,8 +54,10 @@ fun main() {
     // Monitor table state
     applicationScope.launch {
         pokerTable.roomStore.state.collect { state ->
-            println("[Server] Phase: ${state.phase}, Players: ${state.players.size}, " +
-                "Pot: ${state.pot}, Turn: ${state.currentTurnPlayerId ?: "none"}")
+            println(
+                "[Server] Phase: ${state.phase}, Players: ${state.players.size}, " +
+                    "Pot: ${state.pot}, Turn: ${state.currentTurnPlayerId ?: "none"}",
+            )
         }
     }
 
@@ -85,8 +87,9 @@ fun main() {
                 println("[Server] Player connecting: $playerId")
 
                 // Create typed connection for this player
-                val connection = KtorWebSocketServerConnection(this)
-                    .typedJsonAs<SharedPokerAction, PokerAction>()
+                val connection =
+                    KtorWebSocketServerConnection(this)
+                        .typedJsonAs<SharedPokerAction, PokerAction>()
 
                 // Create Per-Client Store for private state
                 val playerSession = PlayerSession(playerId, connection)

--- a/kotlin/samples/flowdux-remote/poker/server/src/main/kotlin/io/flowdux/sample/poker/server/PlayerSession.kt
+++ b/kotlin/samples/flowdux-remote/poker/server/src/main/kotlin/io/flowdux/sample/poker/server/PlayerSession.kt
@@ -3,9 +3,9 @@ package io.flowdux.sample.poker.server
 import io.flowdux.State
 import io.flowdux.Store
 import io.flowdux.buildReducer
+import io.flowdux.remote.server.connection.TypedServerConnection
 import io.flowdux.remote.server.createServerStore
 import io.flowdux.remote.server.middleware.SingleClientSyncMiddleware
-import io.flowdux.remote.server.connection.TypedServerConnection
 import io.flowdux.remote.server.serve
 import io.flowdux.sample.poker.Card
 import io.flowdux.sample.poker.PokerAction
@@ -23,17 +23,15 @@ import io.flowdux.sample.poker.SharedPokerAction
  * - Room Store (PokerTable) manages shared game state
  * - Per-Client Store (PlayerSession) manages player-specific private state
  */
-class PlayerSession(
-    val playerId: String,
-    private val connection: TypedServerConnection<PokerAction>,
-) {
+class PlayerSession(val playerId: String, private val connection: TypedServerConnection<PokerAction>) {
     private val middleware = PlayerRemoteMiddleware(connection)
 
-    val store: Store<PlayerState, PokerAction> = createServerStore(
-        initialState = PlayerState(playerId = playerId),
-        syncMiddleware = middleware,
-        reducer = playerReducer,
-    )
+    val store: Store<PlayerState, PokerAction> =
+        createServerStore(
+            initialState = PlayerState(playerId = playerId),
+            syncMiddleware = middleware,
+            reducer = playerReducer,
+        )
 
     /**
      * Called by PokerTable to update this player's private hand.
@@ -59,10 +57,7 @@ class PlayerSession(
 }
 
 /** Player-local state (private hand). */
-data class PlayerState(
-    val playerId: String,
-    val hand: List<Card> = emptyList(),
-) : State
+data class PlayerState(val playerId: String, val hand: List<Card> = emptyList()) : State
 
 /** Player-local actions (not sent over wire). */
 sealed interface PlayerAction : PokerAction {
@@ -70,18 +65,18 @@ sealed interface PlayerAction : PokerAction {
 }
 
 /** Reducer for player-local state. */
-private val playerReducer = buildReducer<PlayerState, PokerAction> {
-    on<PlayerAction.SetHand> { state, action ->
-        state.copy(hand = action.cards)
+private val playerReducer =
+    buildReducer<PlayerState, PokerAction> {
+        on<PlayerAction.SetHand> { state, action ->
+            state.copy(hand = action.cards)
+        }
     }
-}
 
 /** Middleware for player session - handles private state sync. */
-private class PlayerRemoteMiddleware(
-    connection: TypedServerConnection<PokerAction>,
-) : SingleClientSyncMiddleware<PlayerState, PokerAction>(
-    connection = connection,
-) {
+private class PlayerRemoteMiddleware(connection: TypedServerConnection<PokerAction>) :
+    SingleClientSyncMiddleware<PlayerState, PokerAction>(
+        connection = connection,
+    ) {
     // No processors needed - this store only sends state, doesn't receive actions
     override val processors = buildProcessors { }
 }

--- a/kotlin/samples/flowdux-remote/poker/server/src/main/kotlin/io/flowdux/sample/poker/server/PokerTable.kt
+++ b/kotlin/samples/flowdux-remote/poker/server/src/main/kotlin/io/flowdux/sample/poker/server/PokerTable.kt
@@ -1,7 +1,6 @@
 package io.flowdux.sample.poker.server
 
 import io.flowdux.Middleware
-import io.flowdux.sequential
 import io.flowdux.remote.server.pattern.SharedStateServer
 import io.flowdux.remote.server.pattern.createSharedStateServer
 import io.flowdux.sample.poker.Card
@@ -10,6 +9,7 @@ import io.flowdux.sample.poker.PokerAction
 import io.flowdux.sample.poker.Rank
 import io.flowdux.sample.poker.SharedPokerAction
 import io.flowdux.sample.poker.Suit
+import io.flowdux.sequential
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -37,20 +37,19 @@ import java.util.concurrent.ConcurrentHashMap
  * 3. Room Store distributes private hands → each PlayerSession
  * 4. PlayerSession syncs hand → only to that specific client
  */
-class PokerTable(
-    private val applicationScope: CoroutineScope,
-) {
+class PokerTable(private val applicationScope: CoroutineScope) {
     private val players = ConcurrentHashMap<String, PlayerSession>()
 
-    val roomStore: SharedStateServer<ServerTableState, PokerAction> = createSharedStateServer(
-        initialState = ServerTableState(),
-        reducer = serverTableReducer,
-        processors = tableProcessors(),
-        stateMapper = { state ->
-            SharedPokerAction.SyncTableState(state.toPublicState())
-        },
-        scope = applicationScope,
-    )
+    val roomStore: SharedStateServer<ServerTableState, PokerAction> =
+        createSharedStateServer(
+            initialState = ServerTableState(),
+            reducer = serverTableReducer,
+            processors = tableProcessors(),
+            stateMapper = { state ->
+                SharedPokerAction.SyncTableState(state.toPublicState())
+            },
+            scope = applicationScope,
+        )
 
     init {
         // Watch for hand changes and propagate to Per-Client Stores
@@ -140,8 +139,9 @@ class PokerTable(
         roomStore.close()
     }
 
-    private fun tableProcessors() =
-        Middleware.ActionProcessorBuilder<ServerTableState, PokerAction>().apply {
+    private fun tableProcessors() = Middleware
+        .ActionProcessorBuilder<ServerTableState, PokerAction>()
+        .apply {
             // Use sequential strategy to ensure poker actions are processed in order
             // and prevent race conditions from rapid action submissions.
             // Processors validate that it's the player's turn before passing to reducer.

--- a/kotlin/samples/flowdux-remote/poker/server/src/main/kotlin/io/flowdux/sample/poker/server/ServerPokerAction.kt
+++ b/kotlin/samples/flowdux-remote/poker/server/src/main/kotlin/io/flowdux/sample/poker/server/ServerPokerAction.kt
@@ -6,7 +6,10 @@ import io.flowdux.sample.poker.PokerAction
 /** Server-only actions (not serialized, not sent over wire). */
 sealed interface ServerPokerAction : PokerAction {
     data class PlayerLeft(val playerId: String) : ServerPokerAction
+
     data class StartGame(val deck: List<Card>) : ServerPokerAction
+
     data object AdvancePhase : ServerPokerAction
+
     data class DetermineWinner(val winnerId: String) : ServerPokerAction
 }

--- a/kotlin/samples/flowdux-remote/poker/server/src/main/kotlin/io/flowdux/sample/poker/server/ServerTableReducer.kt
+++ b/kotlin/samples/flowdux-remote/poker/server/src/main/kotlin/io/flowdux/sample/poker/server/ServerTableReducer.kt
@@ -8,166 +8,173 @@ import io.flowdux.sample.poker.PokerAction
 import io.flowdux.sample.poker.SharedPokerAction
 import io.flowdux.sample.poker.TableEvent
 
-val serverTableReducer: Reducer<ServerTableState, PokerAction> = buildReducer {
-    on<SharedPokerAction.JoinTable> { state, action ->
-        val newPlayer = ServerPlayerInfo(
-            id = action.playerId,
-            name = action.playerId,
-            chips = 1000,
-        )
-        state.copy(
-            players = state.players + (action.playerId to newPlayer),
-            lastEvent = TableEvent.PlayerJoined(action.playerId, action.playerId),
-        )
-    }
-
-    on<ServerPokerAction.PlayerLeft> { state, action ->
-        state.copy(
-            players = state.players - action.playerId,
-            hands = state.hands - action.playerId,
-            lastEvent = TableEvent.PlayerLeft(action.playerId),
-        )
-    }
-
-    on<ServerPokerAction.StartGame> { state, action ->
-        if (state.players.size < 2) return@on state
-
-        val playerIds = state.players.keys.toList()
-        var remainingDeck = action.deck.toMutableList()
-        val newHands = mutableMapOf<String, List<Card>>()
-
-        // Deal 2 cards to each player
-        for (playerId in playerIds) {
-            val hand = listOf(remainingDeck.removeFirst(), remainingDeck.removeFirst())
-            newHands[playerId] = hand
+val serverTableReducer: Reducer<ServerTableState, PokerAction> =
+    buildReducer {
+        on<SharedPokerAction.JoinTable> { state, action ->
+            val newPlayer =
+                ServerPlayerInfo(
+                    id = action.playerId,
+                    name = action.playerId,
+                    chips = 1000,
+                )
+            state.copy(
+                players = state.players + (action.playerId to newPlayer),
+                lastEvent = TableEvent.PlayerJoined(action.playerId, action.playerId),
+            )
         }
 
-        // Reset player states for new round
-        val resetPlayers = state.players.mapValues { (_, player) ->
-            player.copy(currentBet = 0, folded = false, isAllIn = false)
+        on<ServerPokerAction.PlayerLeft> { state, action ->
+            state.copy(
+                players = state.players - action.playerId,
+                hands = state.hands - action.playerId,
+                lastEvent = TableEvent.PlayerLeft(action.playerId),
+            )
         }
 
-        state.copy(
-            players = resetPlayers,
-            deck = remainingDeck,
-            hands = newHands,
-            communityCards = emptyList(),
-            pot = 0,
-            phase = GamePhase.PRE_FLOP,
-            currentTurnIndex = 0,
-            lastEvent = TableEvent.GameStarted("Cards dealt! Place your bets."),
-        )
-    }
+        on<ServerPokerAction.StartGame> { state, action ->
+            if (state.players.size < 2) return@on state
 
-    on<SharedPokerAction.PlaceBet> { state, action ->
-        val player = state.players[action.playerId] ?: return@on state
-        val betAmount = action.amount.coerceAtMost(player.chips)
-        val isAllIn = betAmount >= player.chips
+            val playerIds = state.players.keys.toList()
+            var remainingDeck = action.deck.toMutableList()
+            val newHands = mutableMapOf<String, List<Card>>()
 
-        val updatedPlayer = player.copy(
-            chips = player.chips - betAmount,
-            currentBet = player.currentBet + betAmount,
-            isAllIn = isAllIn,
-        )
-
-        val newMinimumBet = maxOf(state.minimumBet, updatedPlayer.currentBet)
-
-        state.copy(
-            players = state.players + (action.playerId to updatedPlayer),
-            pot = state.pot + betAmount,
-            minimumBet = newMinimumBet,
-            currentTurnIndex = (state.currentTurnIndex + 1) % state.activePlayerIds.size.coerceAtLeast(1),
-            lastEvent = TableEvent.PlayerBet(action.playerId, betAmount),
-        )
-    }
-
-    on<SharedPokerAction.Fold> { state, action ->
-        val player = state.players[action.playerId] ?: return@on state
-        val updatedPlayer = player.copy(folded = true)
-
-        state.copy(
-            players = state.players + (action.playerId to updatedPlayer),
-            currentTurnIndex = state.currentTurnIndex % state.activePlayerIds.size.coerceAtLeast(1),
-            lastEvent = TableEvent.PlayerFolded(action.playerId),
-        )
-    }
-
-    on<SharedPokerAction.Check> { state, action ->
-        state.copy(
-            currentTurnIndex = (state.currentTurnIndex + 1) % state.activePlayerIds.size.coerceAtLeast(1),
-            lastEvent = TableEvent.PlayerChecked(action.playerId),
-        )
-    }
-
-    on<SharedPokerAction.Call> { state, action ->
-        val player = state.players[action.playerId] ?: return@on state
-        val callAmount = (state.minimumBet - player.currentBet).coerceAtMost(player.chips)
-        val isAllIn = callAmount >= player.chips
-
-        val updatedPlayer = player.copy(
-            chips = player.chips - callAmount,
-            currentBet = player.currentBet + callAmount,
-            isAllIn = isAllIn,
-        )
-
-        state.copy(
-            players = state.players + (action.playerId to updatedPlayer),
-            pot = state.pot + callAmount,
-            currentTurnIndex = (state.currentTurnIndex + 1) % state.activePlayerIds.size.coerceAtLeast(1),
-            lastEvent = TableEvent.PlayerCalled(action.playerId, callAmount),
-        )
-    }
-
-    on<ServerPokerAction.AdvancePhase> { state, _ ->
-        val (newPhase, newCommunityCards) = when (state.phase) {
-            GamePhase.PRE_FLOP -> {
-                // Reveal 3 community cards (flop)
-                val flop = state.deck.take(3)
-                GamePhase.FLOP to flop
+            // Deal 2 cards to each player
+            for (playerId in playerIds) {
+                val hand = listOf(remainingDeck.removeFirst(), remainingDeck.removeFirst())
+                newHands[playerId] = hand
             }
-            GamePhase.FLOP -> {
-                // Reveal 4th card (turn)
-                val turn = state.communityCards + state.deck.drop(3).take(1)
-                GamePhase.TURN to turn
-            }
-            GamePhase.TURN -> {
-                // Reveal 5th card (river)
-                val river = state.communityCards + state.deck.drop(4).take(1)
-                GamePhase.RIVER to river
-            }
-            GamePhase.RIVER -> {
-                GamePhase.SHOWDOWN to state.communityCards
-            }
-            else -> state.phase to state.communityCards
+
+            // Reset player states for new round
+            val resetPlayers =
+                state.players.mapValues { (_, player) ->
+                    player.copy(currentBet = 0, folded = false, isAllIn = false)
+                }
+
+            state.copy(
+                players = resetPlayers,
+                deck = remainingDeck,
+                hands = newHands,
+                communityCards = emptyList(),
+                pot = 0,
+                phase = GamePhase.PRE_FLOP,
+                currentTurnIndex = 0,
+                lastEvent = TableEvent.GameStarted("Cards dealt! Place your bets."),
+            )
         }
 
-        // Reset current bets for new betting round
-        val resetPlayers = state.players.mapValues { (_, player) ->
-            player.copy(currentBet = 0)
+        on<SharedPokerAction.PlaceBet> { state, action ->
+            val player = state.players[action.playerId] ?: return@on state
+            val betAmount = action.amount.coerceAtMost(player.chips)
+            val isAllIn = betAmount >= player.chips
+
+            val updatedPlayer =
+                player.copy(
+                    chips = player.chips - betAmount,
+                    currentBet = player.currentBet + betAmount,
+                    isAllIn = isAllIn,
+                )
+
+            val newMinimumBet = maxOf(state.minimumBet, updatedPlayer.currentBet)
+
+            state.copy(
+                players = state.players + (action.playerId to updatedPlayer),
+                pot = state.pot + betAmount,
+                minimumBet = newMinimumBet,
+                currentTurnIndex = (state.currentTurnIndex + 1) % state.activePlayerIds.size.coerceAtLeast(1),
+                lastEvent = TableEvent.PlayerBet(action.playerId, betAmount),
+            )
         }
 
-        state.copy(
-            phase = newPhase,
-            communityCards = newCommunityCards,
-            players = resetPlayers,
-            minimumBet = 10,
-            currentTurnIndex = 0,
-            lastEvent = TableEvent.PhaseChanged(newPhase),
-        )
-    }
+        on<SharedPokerAction.Fold> { state, action ->
+            val player = state.players[action.playerId] ?: return@on state
+            val updatedPlayer = player.copy(folded = true)
 
-    on<ServerPokerAction.DetermineWinner> { state, action ->
-        val winner = state.players[action.winnerId] ?: return@on state
-        val updatedWinner = winner.copy(chips = winner.chips + state.pot)
+            state.copy(
+                players = state.players + (action.playerId to updatedPlayer),
+                currentTurnIndex = state.currentTurnIndex % state.activePlayerIds.size.coerceAtLeast(1),
+                lastEvent = TableEvent.PlayerFolded(action.playerId),
+            )
+        }
 
-        state.copy(
-            players = state.players + (action.winnerId to updatedWinner),
-            pot = 0,
-            phase = GamePhase.WAITING,
-            hands = emptyMap(),
-            communityCards = emptyList(),
-            deck = emptyList(),
-            lastEvent = TableEvent.GameEnded(action.winnerId, winner.name, state.pot),
-        )
+        on<SharedPokerAction.Check> { state, action ->
+            state.copy(
+                currentTurnIndex = (state.currentTurnIndex + 1) % state.activePlayerIds.size.coerceAtLeast(1),
+                lastEvent = TableEvent.PlayerChecked(action.playerId),
+            )
+        }
+
+        on<SharedPokerAction.Call> { state, action ->
+            val player = state.players[action.playerId] ?: return@on state
+            val callAmount = (state.minimumBet - player.currentBet).coerceAtMost(player.chips)
+            val isAllIn = callAmount >= player.chips
+
+            val updatedPlayer =
+                player.copy(
+                    chips = player.chips - callAmount,
+                    currentBet = player.currentBet + callAmount,
+                    isAllIn = isAllIn,
+                )
+
+            state.copy(
+                players = state.players + (action.playerId to updatedPlayer),
+                pot = state.pot + callAmount,
+                currentTurnIndex = (state.currentTurnIndex + 1) % state.activePlayerIds.size.coerceAtLeast(1),
+                lastEvent = TableEvent.PlayerCalled(action.playerId, callAmount),
+            )
+        }
+
+        on<ServerPokerAction.AdvancePhase> { state, _ ->
+            val (newPhase, newCommunityCards) =
+                when (state.phase) {
+                    GamePhase.PRE_FLOP -> {
+                        // Reveal 3 community cards (flop)
+                        val flop = state.deck.take(3)
+                        GamePhase.FLOP to flop
+                    }
+                    GamePhase.FLOP -> {
+                        // Reveal 4th card (turn)
+                        val turn = state.communityCards + state.deck.drop(3).take(1)
+                        GamePhase.TURN to turn
+                    }
+                    GamePhase.TURN -> {
+                        // Reveal 5th card (river)
+                        val river = state.communityCards + state.deck.drop(4).take(1)
+                        GamePhase.RIVER to river
+                    }
+                    GamePhase.RIVER -> {
+                        GamePhase.SHOWDOWN to state.communityCards
+                    }
+                    else -> state.phase to state.communityCards
+                }
+
+            // Reset current bets for new betting round
+            val resetPlayers =
+                state.players.mapValues { (_, player) ->
+                    player.copy(currentBet = 0)
+                }
+
+            state.copy(
+                phase = newPhase,
+                communityCards = newCommunityCards,
+                players = resetPlayers,
+                minimumBet = 10,
+                currentTurnIndex = 0,
+                lastEvent = TableEvent.PhaseChanged(newPhase),
+            )
+        }
+
+        on<ServerPokerAction.DetermineWinner> { state, action ->
+            val winner = state.players[action.winnerId] ?: return@on state
+            val updatedWinner = winner.copy(chips = winner.chips + state.pot)
+
+            state.copy(
+                players = state.players + (action.winnerId to updatedWinner),
+                pot = 0,
+                phase = GamePhase.WAITING,
+                hands = emptyMap(),
+                communityCards = emptyList(),
+                deck = emptyList(),
+                lastEvent = TableEvent.GameEnded(action.winnerId, winner.name, state.pot),
+            )
+        }
     }
-}

--- a/kotlin/samples/flowdux-remote/poker/server/src/main/kotlin/io/flowdux/sample/poker/server/ServerTableState.kt
+++ b/kotlin/samples/flowdux-remote/poker/server/src/main/kotlin/io/flowdux/sample/poker/server/ServerTableState.kt
@@ -17,7 +17,6 @@ data class ServerTableState(
     val phase: GamePhase = GamePhase.WAITING,
     val minimumBet: Int = 10,
     val lastEvent: TableEvent? = null,
-
     // Private information (server-only)
     val deck: List<Card> = emptyList(),
     val hands: Map<String, List<Card>> = emptyMap(), // playerId -> private hand

--- a/kotlin/samples/flowdux-remote/poker/shared/src/main/kotlin/io/flowdux/sample/poker/PokerContract.kt
+++ b/kotlin/samples/flowdux-remote/poker/shared/src/main/kotlin/io/flowdux/sample/poker/PokerContract.kt
@@ -12,17 +12,35 @@ interface PokerAction : Action
 @Serializable
 sealed interface SharedPokerAction : PokerAction {
     // Client → Server (player actions include playerId for validation)
-    @Serializable data class JoinTable(val playerId: String) : SharedPokerAction, ServerSharedAction
-    @Serializable data class PlaceBet(val playerId: String, val amount: Int) : SharedPokerAction, ServerSharedAction
-    @Serializable data class Fold(val playerId: String) : SharedPokerAction, ServerSharedAction
-    @Serializable data class Check(val playerId: String) : SharedPokerAction, ServerSharedAction
-    @Serializable data class Call(val playerId: String) : SharedPokerAction, ServerSharedAction
+    @Serializable data class JoinTable(val playerId: String) :
+        SharedPokerAction,
+        ServerSharedAction
+
+    @Serializable data class PlaceBet(val playerId: String, val amount: Int) :
+        SharedPokerAction,
+        ServerSharedAction
+
+    @Serializable data class Fold(val playerId: String) :
+        SharedPokerAction,
+        ServerSharedAction
+
+    @Serializable data class Check(val playerId: String) :
+        SharedPokerAction,
+        ServerSharedAction
+
+    @Serializable data class Call(val playerId: String) :
+        SharedPokerAction,
+        ServerSharedAction
 
     // Server → Client (public information - via Room Store)
-    @Serializable data class SyncTableState(val state: PublicTableState) : SharedPokerAction, ClientSharedAction
+    @Serializable data class SyncTableState(val state: PublicTableState) :
+        SharedPokerAction,
+        ClientSharedAction
 
     // Server → Client (private information - via Per-Client Store)
-    @Serializable data class SyncHand(val cards: List<Card>) : SharedPokerAction, ClientSharedAction
+    @Serializable data class SyncHand(val cards: List<Card>) :
+        SharedPokerAction,
+        ClientSharedAction
 }
 
 // -- Card Types --
@@ -31,8 +49,20 @@ enum class Suit { HEARTS, DIAMONDS, CLUBS, SPADES }
 
 @Serializable
 enum class Rank {
-    TWO, THREE, FOUR, FIVE, SIX, SEVEN, EIGHT, NINE, TEN,
-    JACK, QUEEN, KING, ACE;
+    TWO,
+    THREE,
+    FOUR,
+    FIVE,
+    SIX,
+    SEVEN,
+    EIGHT,
+    NINE,
+    TEN,
+    JACK,
+    QUEEN,
+    KING,
+    ACE,
+    ;
 
     override fun toString(): String = when (this) {
         TWO -> "2"
@@ -54,12 +84,13 @@ enum class Rank {
 @Serializable
 data class Card(val suit: Suit, val rank: Rank) {
     override fun toString(): String {
-        val suitSymbol = when (suit) {
-            Suit.HEARTS -> "♥"
-            Suit.DIAMONDS -> "♦"
-            Suit.CLUBS -> "♣"
-            Suit.SPADES -> "♠"
-        }
+        val suitSymbol =
+            when (suit) {
+                Suit.HEARTS -> "♥"
+                Suit.DIAMONDS -> "♦"
+                Suit.CLUBS -> "♣"
+                Suit.SPADES -> "♠"
+            }
         return "$rank$suitSymbol"
     }
 }
@@ -67,12 +98,12 @@ data class Card(val suit: Suit, val rank: Rank) {
 // -- Game State Types --
 @Serializable
 enum class GamePhase {
-    WAITING,      // Waiting for players
-    PRE_FLOP,     // Cards dealt, betting before flop
-    FLOP,         // 3 community cards revealed
-    TURN,         // 4th community card revealed
-    RIVER,        // 5th community card revealed
-    SHOWDOWN,     // Reveal hands and determine winner
+    WAITING, // Waiting for players
+    PRE_FLOP, // Cards dealt, betting before flop
+    FLOP, // 3 community cards revealed
+    TURN, // 4th community card revealed
+    RIVER, // 5th community card revealed
+    SHOWDOWN, // Reveal hands and determine winner
 }
 
 @Serializable
@@ -101,12 +132,20 @@ data class PublicTableState(
 @Serializable
 sealed interface TableEvent {
     @Serializable data class PlayerJoined(val playerId: String, val name: String) : TableEvent
+
     @Serializable data class PlayerLeft(val playerId: String) : TableEvent
+
     @Serializable data class PlayerBet(val playerId: String, val amount: Int) : TableEvent
+
     @Serializable data class PlayerFolded(val playerId: String) : TableEvent
+
     @Serializable data class PlayerChecked(val playerId: String) : TableEvent
+
     @Serializable data class PlayerCalled(val playerId: String, val amount: Int) : TableEvent
+
     @Serializable data class PhaseChanged(val phase: GamePhase) : TableEvent
+
     @Serializable data class GameStarted(val message: String) : TableEvent
+
     @Serializable data class GameEnded(val winnerId: String, val winnerName: String, val pot: Int) : TableEvent
 }

--- a/kotlin/samples/flowdux-remote/scaling/server/src/main/kotlin/io/flowdux/sample/scaling/Main.kt
+++ b/kotlin/samples/flowdux-remote/scaling/server/src/main/kotlin/io/flowdux/sample/scaling/Main.kt
@@ -3,9 +3,9 @@ package io.flowdux.sample.scaling
 import io.flowdux.Middleware
 import io.flowdux.remote.ktor.KtorWebSocketServerConnection
 import io.flowdux.remote.serialization.typedJsonAs
+import io.flowdux.remote.server.pattern.createSharedStateServer
 import io.flowdux.remote.server.session.BroadcastConfig
 import io.flowdux.remote.server.session.InMemorySessionRegistry
-import io.flowdux.remote.server.pattern.createSharedStateServer
 import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.cio.*
@@ -80,7 +80,7 @@ fun main() {
                     SharedScalingAction.ServerStats(
                         connectedClients = clientCount,
                         counter = state.counter,
-                    )
+                    ),
                 )
                 println("[Stats] clients=$clientCount, counter=${state.counter}")
             }
@@ -114,7 +114,7 @@ fun main() {
                         "counter": ${state.counter},
                         "broadcastConcurrency": ${broadcastConfig.concurrency}
                     }
-                    """.trimIndent()
+                    """.trimIndent(),
                 )
             }
 
@@ -128,7 +128,7 @@ fun main() {
                     SharedScalingAction.ServerStats(
                         connectedClients = clientCount,
                         counter = state.counter,
-                    )
+                    ),
                 )
 
                 val elapsed = System.currentTimeMillis() - startTime
@@ -167,7 +167,7 @@ fun main() {
                     val state = server.currentState
                     server.sendToClient(
                         clientId,
-                        SharedScalingAction.Pong(state.counter, state.connectedClients)
+                        SharedScalingAction.Pong(state.counter, state.connectedClients),
                     )
 
                     server.handleClient(clientId, connection)
@@ -182,19 +182,18 @@ fun main() {
     server.close()
 }
 
-private fun scalingProcessors() =
-    Middleware.ActionProcessorBuilder<ScalingState, ScalingAction>().apply {
-        on<SharedScalingAction.Ping> { state, _ ->
-            // Respond with pong containing current stats
-            emit(
-                SharedScalingAction.Pong(
-                    counter = state.counter,
-                    connectedClients = state.connectedClients
-                )
-            )
-        }
-        on<SharedScalingAction.Increment> { _, action ->
-            // Pass through to reducer
-            emit(action)
-        }
-    }.build()
+private fun scalingProcessors() = Middleware.ActionProcessorBuilder<ScalingState, ScalingAction>().apply {
+    on<SharedScalingAction.Ping> { state, _ ->
+        // Respond with pong containing current stats
+        emit(
+            SharedScalingAction.Pong(
+                counter = state.counter,
+                connectedClients = state.connectedClients,
+            ),
+        )
+    }
+    on<SharedScalingAction.Increment> { _, action ->
+        // Pass through to reducer
+        emit(action)
+    }
+}.build()

--- a/kotlin/samples/flowdux-remote/scaling/server/src/main/kotlin/io/flowdux/sample/scaling/ScalingState.kt
+++ b/kotlin/samples/flowdux-remote/scaling/server/src/main/kotlin/io/flowdux/sample/scaling/ScalingState.kt
@@ -10,10 +10,7 @@ import kotlinx.serialization.Serializable
 /**
  * Server state for the scaling demo.
  */
-data class ScalingState(
-    val counter: Long = 0,
-    val connectedClients: Int = 0,
-) : State
+data class ScalingState(val counter: Long = 0, val connectedClients: Int = 0) : State
 
 /**
  * Base action interface for scaling demo.
@@ -28,23 +25,30 @@ interface ScalingAction : Action
 sealed interface SharedScalingAction : ScalingAction {
     // Client -> Server
     @Serializable
-    data class Ping(val clientId: String) : SharedScalingAction, ServerSharedAction
+    data class Ping(val clientId: String) :
+        SharedScalingAction,
+        ServerSharedAction
 
     @Serializable
-    data class Increment(val amount: Int = 1) : SharedScalingAction, ServerSharedAction
+    data class Increment(val amount: Int = 1) :
+        SharedScalingAction,
+        ServerSharedAction
 
     // Server -> Client
     @Serializable
-    data class Pong(val counter: Long, val connectedClients: Int) : SharedScalingAction, ClientSharedAction
+    data class Pong(val counter: Long, val connectedClients: Int) :
+        SharedScalingAction,
+        ClientSharedAction
 
     @Serializable
-    data class CounterUpdate(val counter: Long) : SharedScalingAction, ClientSharedAction
+    data class CounterUpdate(val counter: Long) :
+        SharedScalingAction,
+        ClientSharedAction
 
     @Serializable
-    data class ServerStats(
-        val connectedClients: Int,
-        val counter: Long,
-    ) : SharedScalingAction, ClientSharedAction
+    data class ServerStats(val connectedClients: Int, val counter: Long) :
+        SharedScalingAction,
+        ClientSharedAction
 }
 
 /**
@@ -52,24 +56,28 @@ sealed interface SharedScalingAction : ScalingAction {
  */
 sealed interface ServerScalingAction : ScalingAction {
     data class ClientConnected(val clientId: String) : ServerScalingAction
+
     data class ClientDisconnected(val clientId: String) : ServerScalingAction
 }
 
 /**
  * Reducer for the scaling demo.
  */
-val scalingReducer = Reducer<ScalingState, ScalingAction> { state, action ->
-    when (action) {
-        is SharedScalingAction.Ping -> state
-        is SharedScalingAction.Increment -> state.copy(counter = state.counter + action.amount)
-        is ServerScalingAction.ClientConnected -> state.copy(connectedClients = state.connectedClients + 1)
-        is ServerScalingAction.ClientDisconnected -> state.copy(
-            connectedClients = maxOf(0, state.connectedClients - 1)
-        )
-        // Client-side actions (never reach reducer on server)
-        is SharedScalingAction.Pong,
-        is SharedScalingAction.CounterUpdate,
-        is SharedScalingAction.ServerStats -> state
-        else -> state
+val scalingReducer =
+    Reducer<ScalingState, ScalingAction> { state, action ->
+        when (action) {
+            is SharedScalingAction.Ping -> state
+            is SharedScalingAction.Increment -> state.copy(counter = state.counter + action.amount)
+            is ServerScalingAction.ClientConnected -> state.copy(connectedClients = state.connectedClients + 1)
+            is ServerScalingAction.ClientDisconnected ->
+                state.copy(
+                    connectedClients = maxOf(0, state.connectedClients - 1),
+                )
+            // Client-side actions (never reach reducer on server)
+            is SharedScalingAction.Pong,
+            is SharedScalingAction.CounterUpdate,
+            is SharedScalingAction.ServerStats,
+            -> state
+            else -> state
+        }
     }
-}

--- a/kotlin/samples/flowdux-remote/shared/src/main/kotlin/io/flowdux/sample/chat/ChatContract.kt
+++ b/kotlin/samples/flowdux-remote/shared/src/main/kotlin/io/flowdux/sample/chat/ChatContract.kt
@@ -12,13 +12,26 @@ interface ChatAction : Action
 @Serializable
 sealed interface SharedChatAction : ChatAction {
     // Client → Server
-    @Serializable data class SendMessage(val user: String, val text: String) : SharedChatAction, ServerSharedAction
-    @Serializable data class JoinRoom(val user: String) : SharedChatAction, ServerSharedAction
-    @Serializable data class LeaveRoom(val user: String) : SharedChatAction, ServerSharedAction
+    @Serializable data class SendMessage(val user: String, val text: String) :
+        SharedChatAction,
+        ServerSharedAction
+
+    @Serializable data class JoinRoom(val user: String) :
+        SharedChatAction,
+        ServerSharedAction
+
+    @Serializable data class LeaveRoom(val user: String) :
+        SharedChatAction,
+        ServerSharedAction
 
     // Server → Client
-    @Serializable data class SyncState(val state: ChatState) : SharedChatAction, ClientSharedAction
-    @Serializable data class SystemAnnouncement(val message: String) : SharedChatAction, ClientSharedAction
+    @Serializable data class SyncState(val state: ChatState) :
+        SharedChatAction,
+        ClientSharedAction
+
+    @Serializable data class SystemAnnouncement(val message: String) :
+        SharedChatAction,
+        ClientSharedAction
 }
 
 // -- State --
@@ -35,6 +48,8 @@ data class ChatMessage(val user: String, val text: String)
 @Serializable
 sealed interface ChatEvent {
     @Serializable data class UserJoined(val user: String) : ChatEvent
+
     @Serializable data class UserLeft(val user: String) : ChatEvent
+
     @Serializable data class MessageReceived(val user: String, val text: String) : ChatEvent
 }

--- a/kotlin/samples/flowdux-remote/simple/client/src/main/kotlin/io/flowdux/sample/chat/client/ChatRemoteMiddleware.kt
+++ b/kotlin/samples/flowdux-remote/simple/client/src/main/kotlin/io/flowdux/sample/chat/client/ChatRemoteMiddleware.kt
@@ -5,17 +5,17 @@ import io.flowdux.remote.SyncMiddleware
 import io.flowdux.remote.TypedClientConnection
 import io.flowdux.sample.chat.ChatAction
 
-class ChatRemoteMiddleware(
-    connection: TypedClientConnection<ChatAction>,
-) : SyncMiddleware<ClientChatState, ChatAction>(
-    connection = connection,
-) {
-    override val processors: ActionProcessorMap<ClientChatState, ChatAction> = buildProcessors {
-        on<ClientChatAction.Connect> { _, _ ->
-            startConnection()
+class ChatRemoteMiddleware(connection: TypedClientConnection<ChatAction>) :
+    SyncMiddleware<ClientChatState, ChatAction>(
+        connection = connection,
+    ) {
+    override val processors: ActionProcessorMap<ClientChatState, ChatAction> =
+        buildProcessors {
+            on<ClientChatAction.Connect> { _, _ ->
+                startConnection()
+            }
+            on<ClientChatAction.Disconnect> { _, _ ->
+                stopConnection()
+            }
         }
-        on<ClientChatAction.Disconnect> { _, _ ->
-            stopConnection()
-        }
-    }
 }

--- a/kotlin/samples/flowdux-remote/simple/client/src/main/kotlin/io/flowdux/sample/chat/client/ClientChatAction.kt
+++ b/kotlin/samples/flowdux-remote/simple/client/src/main/kotlin/io/flowdux/sample/chat/client/ClientChatAction.kt
@@ -4,6 +4,8 @@ import io.flowdux.sample.chat.ChatAction
 
 sealed interface ClientChatAction : ChatAction {
     data object Connect : ClientChatAction
+
     data object Disconnect : ClientChatAction
+
     data class SetCurrentUser(val user: String) : ClientChatAction
 }

--- a/kotlin/samples/flowdux-remote/simple/client/src/main/kotlin/io/flowdux/sample/chat/client/ClientChatReducer.kt
+++ b/kotlin/samples/flowdux-remote/simple/client/src/main/kotlin/io/flowdux/sample/chat/client/ClientChatReducer.kt
@@ -5,15 +5,16 @@ import io.flowdux.buildReducer
 import io.flowdux.sample.chat.ChatAction
 import io.flowdux.sample.chat.SharedChatAction
 
-val clientChatReducer: Reducer<ClientChatState, ChatAction> = buildReducer {
-    on<SharedChatAction.SyncState> { state, action ->
-        state.copy(
-            messages = action.state.messages,
-            users = action.state.users,
-            lastEvent = action.state.lastEvent,
-        )
+val clientChatReducer: Reducer<ClientChatState, ChatAction> =
+    buildReducer {
+        on<SharedChatAction.SyncState> { state, action ->
+            state.copy(
+                messages = action.state.messages,
+                users = action.state.users,
+                lastEvent = action.state.lastEvent,
+            )
+        }
+        on<ClientChatAction.SetCurrentUser> { state, action ->
+            state.copy(currentUser = action.user)
+        }
     }
-    on<ClientChatAction.SetCurrentUser> { state, action ->
-        state.copy(currentUser = action.user)
-    }
-}

--- a/kotlin/samples/flowdux-remote/simple/client/src/main/kotlin/io/flowdux/sample/chat/client/ClientChatState.kt
+++ b/kotlin/samples/flowdux-remote/simple/client/src/main/kotlin/io/flowdux/sample/chat/client/ClientChatState.kt
@@ -9,7 +9,6 @@ data class ClientChatState(
     val messages: List<ChatMessage> = emptyList(),
     val users: Set<String> = emptySet(),
     val lastEvent: ChatEvent? = null,
-
     // Client-local
     val currentUser: String = "",
 ) : State

--- a/kotlin/samples/flowdux-remote/simple/client/src/main/kotlin/io/flowdux/sample/chat/client/Main.kt
+++ b/kotlin/samples/flowdux-remote/simple/client/src/main/kotlin/io/flowdux/sample/chat/client/Main.kt
@@ -18,16 +18,17 @@ fun main() = runBlocking {
     val store = createChatStore()
 
     // Observe state changes
-    val collectorJob = launch {
-        store.state.collect { state ->
-            when (val event = state.lastEvent) {
-                is ChatEvent.UserJoined -> println("[System] ${event.user} joined the room")
-                is ChatEvent.UserLeft -> println("[System] ${event.user} left the room")
-                is ChatEvent.MessageReceived -> println("[${event.user}] ${event.text}")
-                null -> {}
+    val collectorJob =
+        launch {
+            store.state.collect { state ->
+                when (val event = state.lastEvent) {
+                    is ChatEvent.UserJoined -> println("[System] ${event.user} joined the room")
+                    is ChatEvent.UserLeft -> println("[System] ${event.user} left the room")
+                    is ChatEvent.MessageReceived -> println("[${event.user}] ${event.text}")
+                    null -> {}
+                }
             }
         }
-    }
 
     // Set current user and connect
     store.dispatch(ClientChatAction.SetCurrentUser("Alice"))
@@ -77,11 +78,13 @@ fun main() = runBlocking {
 }
 
 private fun createChatStore(): Store<ClientChatState, ChatAction> {
-    val connection = KtorWebSocketClientConnection.create(
-        host = "localhost",
-        port = 8080,
-        path = "/chat",
-    ).typedJsonAs<SharedChatAction, ChatAction>()
+    val connection =
+        KtorWebSocketClientConnection
+            .create(
+                host = "localhost",
+                port = 8080,
+                path = "/chat",
+            ).typedJsonAs<SharedChatAction, ChatAction>()
     return createClientStore(
         initialState = ClientChatState(),
         syncMiddleware = ChatRemoteMiddleware(connection),

--- a/kotlin/samples/flowdux-remote/simple/server/src/main/kotlin/io/flowdux/sample/chat/server/Main.kt
+++ b/kotlin/samples/flowdux-remote/simple/server/src/main/kotlin/io/flowdux/sample/chat/server/Main.kt
@@ -38,7 +38,7 @@ fun main() {
                             messages = serverState.messages,
                             users = serverState.users,
                             lastEvent = serverState.lastEvent,
-                        )
+                        ),
                     )
                 }
             }
@@ -46,15 +46,14 @@ fun main() {
     }.start(wait = true)
 }
 
-private fun chatProcessors() =
-    Middleware.ActionProcessorBuilder<ServerChatState, ChatAction>().apply {
-        on<SharedChatAction.SendMessage> { _, action ->
-            emit(ServerChatAction.MessageReceived(user = action.user, text = action.text))
-        }
-        on<SharedChatAction.JoinRoom> { _, action ->
-            emit(ServerChatAction.UserJoined(user = action.user))
-        }
-        on<SharedChatAction.LeaveRoom> { _, action ->
-            emit(ServerChatAction.UserLeft(user = action.user))
-        }
-    }.build()
+private fun chatProcessors() = Middleware.ActionProcessorBuilder<ServerChatState, ChatAction>().apply {
+    on<SharedChatAction.SendMessage> { _, action ->
+        emit(ServerChatAction.MessageReceived(user = action.user, text = action.text))
+    }
+    on<SharedChatAction.JoinRoom> { _, action ->
+        emit(ServerChatAction.UserJoined(user = action.user))
+    }
+    on<SharedChatAction.LeaveRoom> { _, action ->
+        emit(ServerChatAction.UserLeft(user = action.user))
+    }
+}.build()

--- a/kotlin/samples/flowdux-remote/simple/server/src/main/kotlin/io/flowdux/sample/chat/server/ServerChatAction.kt
+++ b/kotlin/samples/flowdux-remote/simple/server/src/main/kotlin/io/flowdux/sample/chat/server/ServerChatAction.kt
@@ -4,6 +4,8 @@ import io.flowdux.sample.chat.ChatAction
 
 sealed interface ServerChatAction : ChatAction {
     data class MessageReceived(val user: String, val text: String) : ServerChatAction
+
     data class UserJoined(val user: String) : ServerChatAction
+
     data class UserLeft(val user: String) : ServerChatAction
 }

--- a/kotlin/samples/flowdux-remote/simple/server/src/main/kotlin/io/flowdux/sample/chat/server/ServerChatReducer.kt
+++ b/kotlin/samples/flowdux-remote/simple/server/src/main/kotlin/io/flowdux/sample/chat/server/ServerChatReducer.kt
@@ -6,24 +6,25 @@ import io.flowdux.sample.chat.ChatAction
 import io.flowdux.sample.chat.ChatEvent
 import io.flowdux.sample.chat.ChatMessage
 
-val serverChatReducer: Reducer<ServerChatState, ChatAction> = buildReducer {
-    on<ServerChatAction.MessageReceived> { state, action ->
-        state.copy(
-            messages = state.messages + ChatMessage(action.user, action.text),
-            lastEvent = ChatEvent.MessageReceived(user = action.user, text = action.text),
-            totalMessagesProcessed = state.totalMessagesProcessed + 1,
-        )
+val serverChatReducer: Reducer<ServerChatState, ChatAction> =
+    buildReducer {
+        on<ServerChatAction.MessageReceived> { state, action ->
+            state.copy(
+                messages = state.messages + ChatMessage(action.user, action.text),
+                lastEvent = ChatEvent.MessageReceived(user = action.user, text = action.text),
+                totalMessagesProcessed = state.totalMessagesProcessed + 1,
+            )
+        }
+        on<ServerChatAction.UserJoined> { state, action ->
+            state.copy(
+                users = state.users + action.user,
+                lastEvent = ChatEvent.UserJoined(user = action.user),
+            )
+        }
+        on<ServerChatAction.UserLeft> { state, action ->
+            state.copy(
+                users = state.users - action.user,
+                lastEvent = ChatEvent.UserLeft(user = action.user),
+            )
+        }
     }
-    on<ServerChatAction.UserJoined> { state, action ->
-        state.copy(
-            users = state.users + action.user,
-            lastEvent = ChatEvent.UserJoined(user = action.user),
-        )
-    }
-    on<ServerChatAction.UserLeft> { state, action ->
-        state.copy(
-            users = state.users - action.user,
-            lastEvent = ChatEvent.UserLeft(user = action.user),
-        )
-    }
-}

--- a/kotlin/samples/flowdux-remote/simple/server/src/main/kotlin/io/flowdux/sample/chat/server/ServerChatState.kt
+++ b/kotlin/samples/flowdux-remote/simple/server/src/main/kotlin/io/flowdux/sample/chat/server/ServerChatState.kt
@@ -9,7 +9,6 @@ data class ServerChatState(
     val messages: List<ChatMessage> = emptyList(),
     val users: Set<String> = emptySet(),
     val lastEvent: ChatEvent? = null,
-
     // Server-local
     val totalMessagesProcessed: Int = 0,
 ) : State

--- a/kotlin/samples/flowdux/android/src/main/java/io/flowdux/sample/android/CounterContract.kt
+++ b/kotlin/samples/flowdux/android/src/main/java/io/flowdux/sample/android/CounterContract.kt
@@ -3,9 +3,7 @@ package io.flowdux.sample.android
 import io.flowdux.*
 
 // State
-data class CounterState(
-    val count: Int = 0
-) : State
+data class CounterState(val count: Int = 0) : State
 
 // Actions
 sealed interface CounterAction : Action {

--- a/kotlin/samples/flowdux/android/src/main/java/io/flowdux/sample/android/CounterScreen.kt
+++ b/kotlin/samples/flowdux/android/src/main/java/io/flowdux/sample/android/CounterScreen.kt
@@ -13,26 +13,24 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 
 @Composable
-fun CounterScreen(
-    viewModel: CounterViewModel = viewModel()
-) {
+fun CounterScreen(viewModel: CounterViewModel = viewModel()) {
     val state by viewModel.state.collectAsState()
 
     Surface(
         modifier = Modifier.fillMaxSize(),
-        color = MaterialTheme.colorScheme.background
+        color = MaterialTheme.colorScheme.background,
     ) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(32.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center
+            verticalArrangement = Arrangement.Center,
         ) {
             Text(
                 text = "Flowdux Counter",
                 style = MaterialTheme.typography.headlineMedium,
-                fontWeight = FontWeight.Bold
+                fontWeight = FontWeight.Bold,
             )
 
             Spacer(modifier = Modifier.height(48.dp))
@@ -41,24 +39,24 @@ fun CounterScreen(
                 text = "${state.count}",
                 fontSize = 72.sp,
                 fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.primary
+                color = MaterialTheme.colorScheme.primary,
             )
 
             Spacer(modifier = Modifier.height(48.dp))
 
             Row(
-                horizontalArrangement = Arrangement.spacedBy(16.dp)
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
             ) {
                 Button(
                     onClick = { viewModel.decrement() },
-                    modifier = Modifier.size(64.dp)
+                    modifier = Modifier.size(64.dp),
                 ) {
                     Text("-", fontSize = 24.sp)
                 }
 
                 Button(
                     onClick = { viewModel.increment() },
-                    modifier = Modifier.size(64.dp)
+                    modifier = Modifier.size(64.dp),
                 ) {
                     Text("+", fontSize = 24.sp)
                 }
@@ -67,7 +65,7 @@ fun CounterScreen(
             Spacer(modifier = Modifier.height(24.dp))
 
             OutlinedButton(
-                onClick = { viewModel.reset() }
+                onClick = { viewModel.reset() },
             ) {
                 Text("Reset")
             }

--- a/kotlin/samples/flowdux/android/src/main/java/io/flowdux/sample/android/CounterViewModel.kt
+++ b/kotlin/samples/flowdux/android/src/main/java/io/flowdux/sample/android/CounterViewModel.kt
@@ -11,55 +11,56 @@ class CounterViewModel : ViewModel() {
         private const val TAG = "CounterStore"
     }
 
-    private val store = createStore(
-        initialState = CounterState(),
-        reducer = counterReducer,
-        scope = viewModelScope,
-        logger = object : StoreLogger<CounterState, CounterAction> {
-            override fun onActionDispatched(action: CounterAction) {
-                Log.d(TAG, "[DISPATCH] $action")
-            }
+    private val store =
+        createStore(
+            initialState = CounterState(),
+            reducer = counterReducer,
+            scope = viewModelScope,
+            logger =
+            object : StoreLogger<CounterState, CounterAction> {
+                override fun onActionDispatched(action: CounterAction) {
+                    Log.d(TAG, "[DISPATCH] $action")
+                }
 
-            override fun onMiddlewareProcessing(
-                middlewareName: String,
-                action: CounterAction
-            ) {
-                Log.d(TAG, "[MIDDLEWARE] $middlewareName processing $action")
-            }
+                override fun onMiddlewareProcessing(middlewareName: String, action: CounterAction) {
+                    Log.d(TAG, "[MIDDLEWARE] $middlewareName processing $action")
+                }
 
-            override fun onMiddlewaresCompleted(action: CounterAction) {
-                Log.d(TAG, "[MIDDLEWARE_CHAIN] completed with $action")
-            }
+                override fun onMiddlewaresCompleted(action: CounterAction) {
+                    Log.d(TAG, "[MIDDLEWARE_CHAIN] completed with $action")
+                }
 
-            override fun onFlowHolderActionEmitted(action: CounterAction) {
-                Log.d(TAG, "[FLOW_ACTION] emitted $action")
-            }
+                override fun onFlowHolderActionEmitted(action: CounterAction) {
+                    Log.d(TAG, "[FLOW_ACTION] emitted $action")
+                }
 
-            override fun onErrorOccurred(throwable: Throwable) {
-                Log.e(TAG, "[ERROR] ${throwable.message}", throwable)
-            }
+                override fun onErrorOccurred(throwable: Throwable) {
+                    Log.e(TAG, "[ERROR] ${throwable.message}", throwable)
+                }
 
-            override fun onErrorHandled(action: CounterAction) {
-                Log.d(TAG, "[ERROR_HANDLED] $action")
-            }
+                override fun onErrorHandled(action: CounterAction) {
+                    Log.d(TAG, "[ERROR_HANDLED] $action")
+                }
 
-            override fun onStateReduced(
-                action: CounterAction,
-                previousState: CounterState,
-                newState: CounterState
-            ) {
-                Log.d(TAG, "[REDUCE] $action: $previousState -> $newState")
-            }
+                override fun onStateReduced(
+                    action: CounterAction,
+                    previousState: CounterState,
+                    newState: CounterState,
+                ) {
+                    Log.d(TAG, "[REDUCE] $action: $previousState -> $newState")
+                }
 
-            override fun onDispatchAfterClose(action: CounterAction) {
-                Log.w(TAG, "[DISPATCH_AFTER_CLOSE] $action")
-            }
-        }
-    )
+                override fun onDispatchAfterClose(action: CounterAction) {
+                    Log.w(TAG, "[DISPATCH_AFTER_CLOSE] $action")
+                }
+            },
+        )
 
     val state = store.state
 
     fun increment() = store.dispatch(CounterAction.Increment)
+
     fun decrement() = store.dispatch(CounterAction.Decrement)
+
     fun reset() = store.dispatch(CounterAction.Reset)
 }

--- a/kotlin/samples/flowdux/jvm/src/main/kotlin/io/flowdux/sample/Main.kt
+++ b/kotlin/samples/flowdux/jvm/src/main/kotlin/io/flowdux/sample/Main.kt
@@ -4,7 +4,6 @@ import io.flowdux.*
 import io.flowdux.timetravel.createTimeTravelStore
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlin.time.Duration.Companion.milliseconds
@@ -14,15 +13,15 @@ data class CounterState(
     val count: Int = 0,
     val source: String = "",
     val searchResults: List<String> = emptyList(),
-    val isLoading: Boolean = false
+    val isLoading: Boolean = false,
 ) : State
 
 // Simulated Repository that emits cached data first, then fresh API data
 object CounterRepository {
     fun getCount(): Flow<Pair<Int, String>> = flow {
-        emit(10 to "cache")   // First: cached data
-        delay(500)            // Simulate network delay
-        emit(42 to "api")     // Then: fresh API response
+        emit(10 to "cache") // First: cached data
+        delay(500) // Simulate network delay
+        emit(42 to "api") // Then: fresh API response
     }
 }
 
@@ -36,11 +35,10 @@ sealed interface CounterAction : Action {
 
     // FlowHolderAction: holds and converts existing Flow to Flow<Action>
     // No side effects - just wraps the flow from Repository/Socket
-    data class ObserveCount(
-        private val countFlow: Flow<Pair<Int, String>>
-    ) : CounterAction, FlowHolderAction {
-        override fun toFlowAction(): Flow<Action> =
-            countFlow.map { (value, source) -> SetCount(value, source) }
+    data class ObserveCount(private val countFlow: Flow<Pair<Int, String>>) :
+        CounterAction,
+        FlowHolderAction {
+        override fun toFlowAction(): Flow<Action> = countFlow.map { (value, source) -> SetCount(value, source) }
     }
 
     // Execution Strategy Examples
@@ -150,7 +148,7 @@ fun main() {
         initialState = CounterState(),
         reducer = counterReducer,
         middlewares = listOf(ExecutionStrategyMiddleware()),
-        scope = scope
+        scope = scope,
     )
 
     // Collect state changes in background
@@ -248,7 +246,7 @@ fun main() {
         val timeTravelStore = createTimeTravelStore(
             initialState = CounterState(),
             reducer = counterReducer,
-            scope = timeTravelScope
+            scope = timeTravelScope,
         )
 
         // Collect state changes
@@ -273,7 +271,9 @@ fun main() {
         println("\n> Undo (go back one step)")
         timeTravelStore.undo()
         delay(50)
-        println("  Now at index ${timeTravelStore.currentIndex}, canUndo=${timeTravelStore.canUndo}, canRedo=${timeTravelStore.canRedo}")
+        println(
+            "  Now at index ${timeTravelStore.currentIndex}, canUndo=${timeTravelStore.canUndo}, canRedo=${timeTravelStore.canRedo}",
+        )
 
         println("\n> Undo again")
         timeTravelStore.undo()

--- a/kotlin/samples/flowdux/kmm/androidApp/src/main/java/io/flowdux/sample/shared/android/CounterScreen.kt
+++ b/kotlin/samples/flowdux/kmm/androidApp/src/main/java/io/flowdux/sample/shared/android/CounterScreen.kt
@@ -13,32 +13,30 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 
 @Composable
-fun CounterScreen(
-    viewModel: CounterViewModel = viewModel()
-) {
+fun CounterScreen(viewModel: CounterViewModel = viewModel()) {
     val state by viewModel.store.state.collectAsState()
 
     Surface(
         modifier = Modifier.fillMaxSize(),
-        color = MaterialTheme.colorScheme.background
+        color = MaterialTheme.colorScheme.background,
     ) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(32.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center
+            verticalArrangement = Arrangement.Center,
         ) {
             Text(
                 text = "Flowdux KMM",
                 style = MaterialTheme.typography.headlineMedium,
-                fontWeight = FontWeight.Bold
+                fontWeight = FontWeight.Bold,
             )
 
             Text(
                 text = "Shared Counter",
                 style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colorScheme.secondary
+                color = MaterialTheme.colorScheme.secondary,
             )
 
             Spacer(modifier = Modifier.height(48.dp))
@@ -47,24 +45,24 @@ fun CounterScreen(
                 text = "${state.count}",
                 fontSize = 72.sp,
                 fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.primary
+                color = MaterialTheme.colorScheme.primary,
             )
 
             Spacer(modifier = Modifier.height(48.dp))
 
             Row(
-                horizontalArrangement = Arrangement.spacedBy(16.dp)
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
             ) {
                 Button(
                     onClick = { viewModel.store.decrement() },
-                    modifier = Modifier.size(64.dp)
+                    modifier = Modifier.size(64.dp),
                 ) {
                     Text("-", fontSize = 24.sp)
                 }
 
                 Button(
                     onClick = { viewModel.store.increment() },
-                    modifier = Modifier.size(64.dp)
+                    modifier = Modifier.size(64.dp),
                 ) {
                     Text("+", fontSize = 24.sp)
                 }
@@ -73,7 +71,7 @@ fun CounterScreen(
             Spacer(modifier = Modifier.height(16.dp))
 
             Row(
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 OutlinedButton(onClick = { viewModel.store.add(10) }) {
                     Text("+10")
@@ -86,7 +84,7 @@ fun CounterScreen(
             Spacer(modifier = Modifier.height(24.dp))
 
             OutlinedButton(
-                onClick = { viewModel.store.reset() }
+                onClick = { viewModel.store.reset() },
             ) {
                 Text("Reset")
             }

--- a/kotlin/samples/flowdux/kmm/shared/build.gradle.kts
+++ b/kotlin/samples/flowdux/kmm/shared/build.gradle.kts
@@ -17,7 +17,7 @@ kotlin {
     listOf(
         iosX64(),
         iosArm64(),
-        iosSimulatorArm64()
+        iosSimulatorArm64(),
     ).forEach {
         it.binaries.framework {
             baseName = "shared"

--- a/kotlin/samples/flowdux/kmm/shared/src/commonMain/kotlin/io/flowdux/sample/shared/CounterStore.kt
+++ b/kotlin/samples/flowdux/kmm/shared/src/commonMain/kotlin/io/flowdux/sample/shared/CounterStore.kt
@@ -43,7 +43,7 @@ class CounterStore(private val scope: CoroutineScope) {
     private val store = createStore(
         initialState = CounterState(),
         reducer = counterReducer,
-        scope = scope
+        scope = scope,
     )
 
     val state: StateFlow<CounterState> = store.state

--- a/kotlin/samples/flowdux/wasm/src/wasmJsMain/kotlin/io/flowdux/sample/Main.kt
+++ b/kotlin/samples/flowdux/wasm/src/wasmJsMain/kotlin/io/flowdux/sample/Main.kt
@@ -9,10 +9,7 @@ import org.w3c.dom.HTMLButtonElement
 import org.w3c.dom.HTMLElement
 
 // State
-data class CounterState(
-    val count: Int = 0,
-    val isLoading: Boolean = false
-) : State
+data class CounterState(val count: Int = 0, val isLoading: Boolean = false) : State
 
 // Actions
 sealed interface CounterAction : Action {
@@ -105,7 +102,7 @@ fun main() {
         initialState = CounterState(),
         reducer = counterReducer,
         middlewares = listOf(LoggingMiddleware(), CounterMiddleware()),
-        scope = scope
+        scope = scope,
     )
 
     // DOM elements

--- a/kotlin/samples/flowdux/web/src/jsMain/kotlin/io/flowdux/sample/Main.kt
+++ b/kotlin/samples/flowdux/web/src/jsMain/kotlin/io/flowdux/sample/Main.kt
@@ -9,10 +9,7 @@ import org.w3c.dom.HTMLButtonElement
 import org.w3c.dom.HTMLElement
 
 // State
-data class CounterState(
-    val count: Int = 0,
-    val isLoading: Boolean = false
-) : State
+data class CounterState(val count: Int = 0, val isLoading: Boolean = false) : State
 
 // Actions
 sealed interface CounterAction : Action {
@@ -92,7 +89,10 @@ private fun addLogEntry(message: String) {
 
 private fun currentTime(): String {
     val date = js("new Date()")
-    return "${date.getHours()}:${date.getMinutes().toString().padStart(2, '0')}:${date.getSeconds().toString().padStart(2, '0')}"
+    return "${date.getHours()}:${date.getMinutes().toString().padStart(
+        2,
+        '0',
+    )}:${date.getSeconds().toString().padStart(2, '0')}"
 }
 
 private val scope = MainScope()
@@ -102,7 +102,7 @@ fun main() {
         initialState = CounterState(),
         reducer = counterReducer,
         middlewares = listOf(LoggingMiddleware(), CounterMiddleware()),
-        scope = scope
+        scope = scope,
     )
 
     // DOM elements

--- a/kotlin/timetravel/build.gradle.kts
+++ b/kotlin/timetravel/build.gradle.kts
@@ -12,7 +12,7 @@ mavenPublishing {
 }
 
 // JitPack only publishes JVM artifacts to avoid variant resolution issues for JVM/Android consumers
-val isJitPack = System.getenv("JITPACK") == "true"
+val isJitPack = providers.environmentVariable("JITPACK").map { it == "true" }.getOrElse(false)
 
 kotlin {
     jvm()

--- a/kotlin/timetravel/src/commonMain/kotlin/io/flowdux/timetravel/StateSnapshot.kt
+++ b/kotlin/timetravel/src/commonMain/kotlin/io/flowdux/timetravel/StateSnapshot.kt
@@ -8,5 +8,5 @@ data class StateSnapshot<S : State, A : Action>(
     val action: A?,
     val previousState: S?,
     val currentState: S,
-    val timestamp: Long
+    val timestamp: Long,
 )

--- a/kotlin/timetravel/src/commonMain/kotlin/io/flowdux/timetravel/TimeTravelStore.kt
+++ b/kotlin/timetravel/src/commonMain/kotlin/io/flowdux/timetravel/TimeTravelStore.kt
@@ -46,9 +46,11 @@ class TimeTravelStore<S : State, A : Action> internal constructor(
     init {
         when {
             !initialHistory.isNullOrEmpty() -> {
-                _history.addAll(initialHistory.mapIndexed { idx, snapshot ->
-                    snapshot.copy(index = idx)
-                })
+                _history.addAll(
+                    initialHistory.mapIndexed { idx, snapshot ->
+                        snapshot.copy(index = idx)
+                    },
+                )
                 _currentIndex = _history.size - 1
                 _state = MutableStateFlow(_history.last().currentState)
             }
@@ -59,8 +61,8 @@ class TimeTravelStore<S : State, A : Action> internal constructor(
                         action = null,
                         previousState = null,
                         currentState = initialState,
-                        timestamp = currentTimeMillis()
-                    )
+                        timestamp = currentTimeMillis(),
+                    ),
                 )
                 _state = MutableStateFlow(initialState)
             }
@@ -82,8 +84,8 @@ class TimeTravelStore<S : State, A : Action> internal constructor(
                 action = action,
                 previousState = previousState,
                 currentState = newState,
-                timestamp = currentTimeMillis()
-            )
+                timestamp = currentTimeMillis(),
+            ),
         )
 
         while (_history.size > maxHistorySize && _history.size > 1) {
@@ -135,8 +137,8 @@ class TimeTravelStore<S : State, A : Action> internal constructor(
                 action = null,
                 previousState = null,
                 currentState = currentState,
-                timestamp = currentTimeMillis()
-            )
+                timestamp = currentTimeMillis(),
+            ),
         )
         _currentIndex = 0
     }
@@ -194,33 +196,37 @@ private fun <S : State, A : Action> createTimeTravelStoreInternal(
 ): TimeTravelStore<S, A> {
     lateinit var timeTravelStore: TimeTravelStore<S, A>
 
-    val timeTravelReducer = Reducer<S, A> { _, action ->
-        reducer.reduce(timeTravelStore.currentState, action)
-    }
-
-    val historyLogger = object : NoOpStoreLogger<S, A>() {
-        override fun onStateReduced(action: A, previousState: S, newState: S) {
-            timeTravelStore.recordStateChange(action, timeTravelStore.currentState, newState)
+    val timeTravelReducer =
+        Reducer<S, A> { _, action ->
+            reducer.reduce(timeTravelStore.currentState, action)
         }
-    }
+
+    val historyLogger =
+        object : NoOpStoreLogger<S, A>() {
+            override fun onStateReduced(action: A, previousState: S, newState: S) {
+                timeTravelStore.recordStateChange(action, timeTravelStore.currentState, newState)
+            }
+        }
 
     val effectiveInitialState = initialHistory?.lastOrNull()?.currentState ?: initialState!!
 
-    val innerStore = createStore(
-        initialState = effectiveInitialState,
-        reducer = timeTravelReducer,
-        middlewares = middlewares,
-        errorProcessor = errorProcessor,
-        logger = historyLogger,
-        scope = scope,
-    )
+    val innerStore =
+        createStore(
+            initialState = effectiveInitialState,
+            reducer = timeTravelReducer,
+            middlewares = middlewares,
+            errorProcessor = errorProcessor,
+            logger = historyLogger,
+            scope = scope,
+        )
 
-    timeTravelStore = TimeTravelStore(
-        innerStore = innerStore,
-        maxHistorySize = maxHistorySize,
-        initialState = initialState,
-        initialHistory = initialHistory,
-    )
+    timeTravelStore =
+        TimeTravelStore(
+            innerStore = innerStore,
+            maxHistorySize = maxHistorySize,
+            initialState = initialState,
+            initialHistory = initialHistory,
+        )
 
     return timeTravelStore
 }

--- a/kotlin/timetravel/src/commonTest/kotlin/io/flowdux/timetravel/TestFixtures.kt
+++ b/kotlin/timetravel/src/commonTest/kotlin/io/flowdux/timetravel/TestFixtures.kt
@@ -11,18 +11,22 @@ data class CounterState(val count: Int = 0) : State
 
 sealed interface CounterAction : Action {
     object Increment : CounterAction
+
     object Decrement : CounterAction
+
     data class Add(val value: Int) : CounterAction
 }
 
-val counterReducer = Reducer<CounterState, CounterAction> { state, action ->
-    when (action) {
-        is CounterAction.Increment -> state.copy(count = state.count + 1)
-        is CounterAction.Decrement -> state.copy(count = state.count - 1)
-        is CounterAction.Add -> state.copy(count = state.count + action.value)
+val counterReducer =
+    Reducer<CounterState, CounterAction> { state, action ->
+        when (action) {
+            is CounterAction.Increment -> state.copy(count = state.count + 1)
+            is CounterAction.Decrement -> state.copy(count = state.count - 1)
+            is CounterAction.Add -> state.copy(count = state.count + action.value)
+        }
     }
-}
 
-val testErrorProcessor = object : ErrorProcessor<CounterAction> {
-    override fun process(throwable: Throwable): Flow<CounterAction> = emptyFlow()
-}
+val testErrorProcessor =
+    object : ErrorProcessor<CounterAction> {
+        override fun process(throwable: Throwable): Flow<CounterAction> = emptyFlow()
+    }

--- a/kotlin/timetravel/src/commonTest/kotlin/io/flowdux/timetravel/TimeTravelStoreTest.kt
+++ b/kotlin/timetravel/src/commonTest/kotlin/io/flowdux/timetravel/TimeTravelStoreTest.kt
@@ -3,24 +3,24 @@ package io.flowdux.timetravel
 import app.cash.turbine.test
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
-import kotlin.test.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TimeTravelStoreTest {
-
     @Test
     fun `initial state is recorded in history`() = runTest {
-        val store = createTimeTravelStore(
-            initialState = CounterState(count = 5),
-            reducer = counterReducer,
-            errorProcessor = testErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createTimeTravelStore(
+                initialState = CounterState(count = 5),
+                reducer = counterReducer,
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
 
         assertEquals(1, store.history.size)
         assertEquals(0, store.currentIndex)
@@ -31,12 +31,13 @@ class TimeTravelStoreTest {
 
     @Test
     fun `dispatch records state changes in history`() = runTest {
-        val store = createTimeTravelStore(
-            initialState = CounterState(),
-            reducer = counterReducer,
-            errorProcessor = testErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createTimeTravelStore(
+                initialState = CounterState(),
+                reducer = counterReducer,
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             assertEquals(0, awaitItem().count)
@@ -63,12 +64,13 @@ class TimeTravelStoreTest {
 
     @Test
     fun `undo moves to previous state`() = runTest {
-        val store = createTimeTravelStore(
-            initialState = CounterState(),
-            reducer = counterReducer,
-            errorProcessor = testErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createTimeTravelStore(
+                initialState = CounterState(),
+                reducer = counterReducer,
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             assertEquals(0, awaitItem().count)
@@ -97,12 +99,13 @@ class TimeTravelStoreTest {
 
     @Test
     fun `redo moves to next state`() = runTest {
-        val store = createTimeTravelStore(
-            initialState = CounterState(),
-            reducer = counterReducer,
-            errorProcessor = testErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createTimeTravelStore(
+                initialState = CounterState(),
+                reducer = counterReducer,
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             assertEquals(0, awaitItem().count)
@@ -137,12 +140,13 @@ class TimeTravelStoreTest {
 
     @Test
     fun `jumpTo moves to specific state`() = runTest {
-        val store = createTimeTravelStore(
-            initialState = CounterState(),
-            reducer = counterReducer,
-            errorProcessor = testErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createTimeTravelStore(
+                initialState = CounterState(),
+                reducer = counterReducer,
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             assertEquals(0, awaitItem().count)
@@ -177,12 +181,13 @@ class TimeTravelStoreTest {
 
     @Test
     fun `dispatch from past state truncates future history`() = runTest {
-        val store = createTimeTravelStore(
-            initialState = CounterState(),
-            reducer = counterReducer,
-            errorProcessor = testErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createTimeTravelStore(
+                initialState = CounterState(),
+                reducer = counterReducer,
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             assertEquals(0, awaitItem().count)
@@ -216,12 +221,13 @@ class TimeTravelStoreTest {
 
     @Test
     fun `reset moves to initial state`() = runTest {
-        val store = createTimeTravelStore(
-            initialState = CounterState(),
-            reducer = counterReducer,
-            errorProcessor = testErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createTimeTravelStore(
+                initialState = CounterState(),
+                reducer = counterReducer,
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             assertEquals(0, awaitItem().count)
@@ -243,12 +249,13 @@ class TimeTravelStoreTest {
 
     @Test
     fun `clear resets history with current state`() = runTest {
-        val store = createTimeTravelStore(
-            initialState = CounterState(),
-            reducer = counterReducer,
-            errorProcessor = testErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createTimeTravelStore(
+                initialState = CounterState(),
+                reducer = counterReducer,
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             assertEquals(0, awaitItem().count)
@@ -272,13 +279,14 @@ class TimeTravelStoreTest {
 
     @Test
     fun `maxHistorySize limits history`() = runTest {
-        val store = createTimeTravelStore(
-            initialState = CounterState(),
-            reducer = counterReducer,
-            errorProcessor = testErrorProcessor,
-            maxHistorySize = 3,
-            scope = backgroundScope,
-        )
+        val store =
+            createTimeTravelStore(
+                initialState = CounterState(),
+                reducer = counterReducer,
+                errorProcessor = testErrorProcessor,
+                maxHistorySize = 3,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             assertEquals(0, awaitItem().count)
@@ -315,12 +323,13 @@ class TimeTravelStoreTest {
 
     @Test
     fun `close prevents further dispatch`() = runTest {
-        val store = createTimeTravelStore(
-            initialState = CounterState(),
-            reducer = counterReducer,
-            errorProcessor = testErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createTimeTravelStore(
+                initialState = CounterState(),
+                reducer = counterReducer,
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
 
         assertFalse(store.isClosed)
 
@@ -331,20 +340,27 @@ class TimeTravelStoreTest {
 
     @Test
     fun `timestamps are recorded`() = runTest {
-        val store = createTimeTravelStore(
-            initialState = CounterState(),
-            reducer = counterReducer,
-            errorProcessor = testErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createTimeTravelStore(
+                initialState = CounterState(),
+                reducer = counterReducer,
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             assertEquals(0, awaitItem().count)
 
-            val beforeDispatch = kotlinx.datetime.Clock.System.now().toEpochMilliseconds()
+            val beforeDispatch =
+                kotlinx.datetime.Clock.System
+                    .now()
+                    .toEpochMilliseconds()
             store.dispatch(CounterAction.Increment)
             assertEquals(1, awaitItem().count)
-            val afterDispatch = kotlinx.datetime.Clock.System.now().toEpochMilliseconds()
+            val afterDispatch =
+                kotlinx.datetime.Clock.System
+                    .now()
+                    .toEpochMilliseconds()
 
             val snapshot = store.history[1]
             assertTrue(snapshot.timestamp >= beforeDispatch)
@@ -356,13 +372,14 @@ class TimeTravelStoreTest {
 
     @Test
     fun `history indices are correct after truncation`() = runTest {
-        val store = createTimeTravelStore(
-            initialState = CounterState(),
-            reducer = counterReducer,
-            errorProcessor = testErrorProcessor,
-            maxHistorySize = 5,
-            scope = backgroundScope,
-        )
+        val store =
+            createTimeTravelStore(
+                initialState = CounterState(),
+                reducer = counterReducer,
+                errorProcessor = testErrorProcessor,
+                maxHistorySize = 5,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             awaitItem()
@@ -382,36 +399,38 @@ class TimeTravelStoreTest {
 
     @Test
     fun `initialHistory restores history and state`() = runTest {
-        val savedHistory: List<StateSnapshot<CounterState, CounterAction>> = listOf(
-            StateSnapshot(
-                index = 0,
-                action = null,
-                previousState = null,
-                currentState = CounterState(0),
-                timestamp = 1000L
-            ),
-            StateSnapshot(
-                index = 1,
-                action = CounterAction.Add(10),
-                previousState = CounterState(0),
-                currentState = CounterState(10),
-                timestamp = 2000L
-            ),
-            StateSnapshot(
-                index = 2,
-                action = CounterAction.Add(20),
-                previousState = CounterState(10),
-                currentState = CounterState(30),
-                timestamp = 3000L
+        val savedHistory: List<StateSnapshot<CounterState, CounterAction>> =
+            listOf(
+                StateSnapshot(
+                    index = 0,
+                    action = null,
+                    previousState = null,
+                    currentState = CounterState(0),
+                    timestamp = 1000L,
+                ),
+                StateSnapshot(
+                    index = 1,
+                    action = CounterAction.Add(10),
+                    previousState = CounterState(0),
+                    currentState = CounterState(10),
+                    timestamp = 2000L,
+                ),
+                StateSnapshot(
+                    index = 2,
+                    action = CounterAction.Add(20),
+                    previousState = CounterState(10),
+                    currentState = CounterState(30),
+                    timestamp = 3000L,
+                ),
             )
-        )
 
-        val store = createTimeTravelStore(
-            initialHistory = savedHistory,
-            reducer = counterReducer,
-            errorProcessor = testErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createTimeTravelStore(
+                initialHistory = savedHistory,
+                reducer = counterReducer,
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
 
         assertEquals(3, store.history.size)
         assertEquals(2, store.currentIndex)
@@ -429,22 +448,24 @@ class TimeTravelStoreTest {
 
     @Test
     fun `initialHistory allows dispatch to continue from restored state`() = runTest {
-        val savedHistory: List<StateSnapshot<CounterState, CounterAction>> = listOf(
-            StateSnapshot(
-                index = 0,
-                action = null,
-                previousState = null,
-                currentState = CounterState(100),
-                timestamp = 1000L
+        val savedHistory: List<StateSnapshot<CounterState, CounterAction>> =
+            listOf(
+                StateSnapshot(
+                    index = 0,
+                    action = null,
+                    previousState = null,
+                    currentState = CounterState(100),
+                    timestamp = 1000L,
+                ),
             )
-        )
 
-        val store = createTimeTravelStore(
-            initialHistory = savedHistory,
-            reducer = counterReducer,
-            errorProcessor = testErrorProcessor,
-            scope = backgroundScope,
-        )
+        val store =
+            createTimeTravelStore(
+                initialHistory = savedHistory,
+                reducer = counterReducer,
+                errorProcessor = testErrorProcessor,
+                scope = backgroundScope,
+            )
 
         store.state.test {
             assertEquals(100, awaitItem().count)
@@ -462,14 +483,15 @@ class TimeTravelStoreTest {
 
     @Test
     fun `empty initialHistory throws exception`() = runTest {
-        val exception = assertFailsWith<IllegalArgumentException> {
-            createTimeTravelStore(
-                initialHistory = emptyList<StateSnapshot<CounterState, CounterAction>>(),
-                reducer = counterReducer,
-                errorProcessor = testErrorProcessor,
-                scope = backgroundScope,
-            )
-        }
+        val exception =
+            assertFailsWith<IllegalArgumentException> {
+                createTimeTravelStore(
+                    initialHistory = emptyList<StateSnapshot<CounterState, CounterAction>>(),
+                    reducer = counterReducer,
+                    errorProcessor = testErrorProcessor,
+                    scope = backgroundScope,
+                )
+            }
         assertEquals("initialHistory must not be empty", exception.message)
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -110,37 +110,47 @@ project(":kotlin:sample-remote-poker:client").projectDir = file("kotlin/samples/
 
 include(":kotlin:sample-remote-multiplexer:shared")
 project(":kotlin:sample-remote-multiplexer").projectDir = file("kotlin/samples/flowdux-remote/multiplexer")
-project(":kotlin:sample-remote-multiplexer:shared").projectDir = file("kotlin/samples/flowdux-remote/multiplexer/shared")
+project(":kotlin:sample-remote-multiplexer:shared").projectDir =
+    file("kotlin/samples/flowdux-remote/multiplexer/shared")
 
 include(":kotlin:sample-remote-multiplexer:server")
-project(":kotlin:sample-remote-multiplexer:server").projectDir = file("kotlin/samples/flowdux-remote/multiplexer/server")
+project(":kotlin:sample-remote-multiplexer:server").projectDir =
+    file("kotlin/samples/flowdux-remote/multiplexer/server")
 
 include(":kotlin:sample-remote-multiplexer:client")
-project(":kotlin:sample-remote-multiplexer:client").projectDir = file("kotlin/samples/flowdux-remote/multiplexer/client")
+project(":kotlin:sample-remote-multiplexer:client").projectDir =
+    file("kotlin/samples/flowdux-remote/multiplexer/client")
 
 include(":kotlin:sample-remote-node-mediator:shared")
 project(":kotlin:sample-remote-node-mediator").projectDir = file("kotlin/samples/flowdux-remote/node-mediator")
-project(":kotlin:sample-remote-node-mediator:shared").projectDir = file("kotlin/samples/flowdux-remote/node-mediator/shared")
+project(":kotlin:sample-remote-node-mediator:shared").projectDir =
+    file("kotlin/samples/flowdux-remote/node-mediator/shared")
 
 include(":kotlin:sample-remote-node-mediator:central")
-project(":kotlin:sample-remote-node-mediator:central").projectDir = file("kotlin/samples/flowdux-remote/node-mediator/central")
+project(":kotlin:sample-remote-node-mediator:central").projectDir =
+    file("kotlin/samples/flowdux-remote/node-mediator/central")
 
 include(":kotlin:sample-remote-node-mediator:node")
-project(":kotlin:sample-remote-node-mediator:node").projectDir = file("kotlin/samples/flowdux-remote/node-mediator/node")
+project(":kotlin:sample-remote-node-mediator:node").projectDir =
+    file("kotlin/samples/flowdux-remote/node-mediator/node")
 
 include(":kotlin:sample-remote-node-mediator:client")
-project(":kotlin:sample-remote-node-mediator:client").projectDir = file("kotlin/samples/flowdux-remote/node-mediator/client")
+project(":kotlin:sample-remote-node-mediator:client").projectDir =
+    file("kotlin/samples/flowdux-remote/node-mediator/client")
 
 // ── Samples: flowdux-remote (multi-device) ──
 include(":kotlin:sample-remote-multidevice:shared")
 project(":kotlin:sample-remote-multidevice").projectDir = file("kotlin/samples/flowdux-remote/multi-device")
-project(":kotlin:sample-remote-multidevice:shared").projectDir = file("kotlin/samples/flowdux-remote/multi-device/shared")
+project(":kotlin:sample-remote-multidevice:shared").projectDir =
+    file("kotlin/samples/flowdux-remote/multi-device/shared")
 
 include(":kotlin:sample-remote-multidevice:server")
-project(":kotlin:sample-remote-multidevice:server").projectDir = file("kotlin/samples/flowdux-remote/multi-device/server")
+project(":kotlin:sample-remote-multidevice:server").projectDir =
+    file("kotlin/samples/flowdux-remote/multi-device/server")
 
 include(":kotlin:sample-remote-multidevice:client")
-project(":kotlin:sample-remote-multidevice:client").projectDir = file("kotlin/samples/flowdux-remote/multi-device/client")
+project(":kotlin:sample-remote-multidevice:client").projectDir =
+    file("kotlin/samples/flowdux-remote/multi-device/client")
 
 // ── Samples: flowdux-remote (auth) ──
 include(":kotlin:sample-remote-auth:server")


### PR DESCRIPTION
## Summary
- feat(remote-client): add automatic reconnection with exponential backoff (#255)
- security(remote-ktor): add WebSocket origin validation to prevent CSWSH (#258)
- security(remote-auth): sanitize auth error messages to prevent info leakage (#259)
- fix(flowdux): make Store._isClosed atomic to prevent race condition (#224)
- fix(remote-ktor): handle incomingChannel race condition on disconnect (#248)
- fix(remote-ktor): add @Volatile to session for Native thread safety (#244)
- fix(remote-server): detect dead sessions via listener flow completion (#223)
- fix(remote-serialization): graceful handling of action type version mismatch (#253)
- fix(remote-node-mediator): prevent split-brain on node reconnection (#252)
- fix(remote-multiplexer): fix race conditions in create/destroy (#221)
- perf(remote-ktor): replace Channel.UNLIMITED with Channel.BUFFERED (#236, #242)
- perf(remote-serialization): eliminate double JSON parsing (#245)
- docs: getting-started guide, WASM notice, lifecycle docs
- chore: .editorconfig, Gradle config cache, Kover coverage, git hooks

## Test plan
- [x] 전체 모듈 테스트 통과
- [x] 샘플 앱 컴파일 및 런타임 검증 완료 (10개 JVM 샘플)

🤖 Generated with [Claude Code](https://claude.com/claude-code)