### PR TITLE
test(remote-ktor): audit KtorWebSocketClientConnection concurrency

### DIFF
--- a/kotlin/remote/client/src/commonMain/kotlin/io/flowdux/remote/ClientConnection.kt
+++ b/kotlin/remote/client/src/commonMain/kotlin/io/flowdux/remote/ClientConnection.kt
@@ -29,8 +29,8 @@ interface ClientConnection {
     /**
      * Establish the connection and suspend until disconnected.
      *
-     * Implementations should be safe against concurrent calls (e.g., via [Mutex]).
-     * Only one connection should be established per call.
+     * Implementations should be safe against concurrent calls (e.g., via a mutex).
+     * Even when called concurrently, at most one active connection should be established.
      */
     suspend fun connect()
 

--- a/kotlin/remote/client/src/commonMain/kotlin/io/flowdux/remote/ClientConnection.kt
+++ b/kotlin/remote/client/src/commonMain/kotlin/io/flowdux/remote/ClientConnection.kt
@@ -18,13 +18,28 @@ interface ClientConnection {
     /** Incoming raw messages from the server. */
     val incoming: Flow<String>
 
-    /** Send a raw message to the server. */
+    /**
+     * Send a raw message to the server.
+     *
+     * Implementations should be thread-safe: multiple coroutines may call this concurrently.
+     * Throws [IllegalStateException] if the connection is not active.
+     */
     suspend fun send(message: String)
 
-    /** Establish the connection and suspend until disconnected. */
+    /**
+     * Establish the connection and suspend until disconnected.
+     *
+     * Implementations should be safe against concurrent calls (e.g., via [Mutex]).
+     * Only one connection should be established per call.
+     */
     suspend fun connect()
 
-    /** Close the connection. */
+    /**
+     * Close the connection.
+     *
+     * Implementations should be idempotent: calling this multiple times or concurrently
+     * must not throw.
+     */
     suspend fun disconnect()
 }
 

--- a/kotlin/remote/ktor/src/commonMain/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnection.kt
+++ b/kotlin/remote/ktor/src/commonMain/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnection.kt
@@ -54,8 +54,11 @@ import kotlin.concurrent.Volatile
  *   and converted to [IllegalStateException].
  * - [connect] is guarded by an internal [Mutex]; concurrent calls are serialized and only
  *   the first one establishes a WebSocket session.
- * - [disconnect] is safe to call concurrently or multiple times. Channel close operations
- *   are idempotent, and `@Volatile` fields ensure visibility across threads.
+ * - [disconnect] may be called concurrently or multiple times. This is safe in practice
+ *   because close operations on the underlying Ktor channels, WebSocket session, and
+ *   [HttpClient] are idempotent by contract. The `@Volatile` fields in this class are
+ *   used to ensure visibility across threads, but they do not make compound operations
+ *   (such as checking a field and then closing) atomic or provide additional locking.
  *
  * ## Backpressure
  *

--- a/kotlin/remote/ktor/src/commonMain/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnection.kt
+++ b/kotlin/remote/ktor/src/commonMain/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnection.kt
@@ -47,6 +47,16 @@ import kotlin.concurrent.Volatile
  * conn2.connect()
  * ```
  *
+ * ## Concurrency & Thread Safety
+ *
+ * - [send] is thread-safe: multiple coroutines may call it concurrently. If the connection
+ *   closes while a send is in progress, [ClosedSendChannelException] is caught internally
+ *   and converted to [IllegalStateException].
+ * - [connect] is guarded by an internal [Mutex]; concurrent calls are serialized and only
+ *   the first one establishes a WebSocket session.
+ * - [disconnect] is safe to call concurrently or multiple times. Channel close operations
+ *   are idempotent, and `@Volatile` fields ensure visibility across threads.
+ *
  * ## Backpressure
  *
  * Both incoming and outgoing channels use [Channel.BUFFERED] (64 elements, SUSPEND overflow):
@@ -91,6 +101,9 @@ class KtorWebSocketClientConnection(private val url: String, httpClient: HttpCli
     private val connectMutex = Mutex()
 
     override suspend fun send(message: String) {
+        // Best-effort fast-fail guard. The authoritative safety net is the
+        // ClosedSendChannelException catch below, which handles the race between
+        // this check and a concurrent disconnect() closing the channel.
         if (_connectionState.value != ConnectionState.CONNECTED) {
             throw IllegalStateException("Cannot send message: WebSocket is not connected")
         }

--- a/kotlin/remote/ktor/src/jvmTest/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnectionTest.kt
+++ b/kotlin/remote/ktor/src/jvmTest/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnectionTest.kt
@@ -549,7 +549,9 @@ class KtorWebSocketClientConnectionTest {
 
                 // Wait until at least some sends are in-flight, then disconnect
                 withTimeout(5_000) {
-                    while (sendsStarted.get() == 0) { delay(1) }
+                    while (sendsStarted.get() == 0) {
+                        delay(1)
+                    }
                 }
                 connection.disconnect()
 

--- a/kotlin/remote/ktor/src/jvmTest/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnectionTest.kt
+++ b/kotlin/remote/ktor/src/jvmTest/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnectionTest.kt
@@ -507,6 +507,95 @@ class KtorWebSocketClientConnectionTest {
     }
 
     @Test
+    fun `concurrent send and disconnect completes without hanging`() = runBlocking {
+        val server = embeddedServer(CIO, port = 0) {
+            install(WebSockets)
+            routing {
+                webSocket("/test") {
+                    for (frame in incoming) {
+                        // Consume incoming frames to drain client's outgoing buffer
+                    }
+                }
+            }
+        }.start(wait = false)
+
+        try {
+            val port = server.engine.resolvedConnectors().first().port
+
+            // Repeat to increase chance of hitting race window
+            repeat(5) {
+                val connection = KtorWebSocketClientConnection("ws://localhost:$port/test")
+
+                val connectJob = launch(Dispatchers.Default) { connection.connect() }
+                withTimeout(5_000) {
+                    connection.connectionState.first { it == ConnectionState.CONNECTED }
+                }
+
+                // Launch sends from multiple coroutines
+                val sendJobs = (1..5).map { threadId ->
+                    launch(Dispatchers.Default) {
+                        for (i in 0 until 20) {
+                            try {
+                                connection.send("t$threadId-msg$i")
+                            } catch (_: IllegalStateException) {
+                                // Expected: disconnect() may close channels concurrently
+                                break
+                            }
+                        }
+                    }
+                }
+
+                // Disconnect while sends are in-flight
+                delay(5)
+                connection.disconnect()
+
+                withTimeout(10_000) {
+                    sendJobs.forEach { it.join() }
+                    connectJob.join()
+                }
+                assertEquals(ConnectionState.DISCONNECTED, connection.connectionState.value)
+            }
+        } finally {
+            server.stop(500, 1_000)
+        }
+    }
+
+    @Test
+    fun `multiple concurrent disconnect calls complete safely`() = runBlocking {
+        val server = embeddedServer(CIO, port = 0) {
+            install(WebSockets)
+            routing {
+                webSocket("/test") {
+                    for (frame in incoming) { /* keep alive */ }
+                }
+            }
+        }.start(wait = false)
+
+        try {
+            val port = server.engine.resolvedConnectors().first().port
+            val connection = KtorWebSocketClientConnection("ws://localhost:$port/test")
+
+            val connectJob = launch(Dispatchers.Default) { connection.connect() }
+            withTimeout(5_000) {
+                connection.connectionState.first { it == ConnectionState.CONNECTED }
+            }
+
+            // Launch multiple concurrent disconnect calls
+            val disconnectJobs = (1..10).map {
+                launch(Dispatchers.Default) { connection.disconnect() }
+            }
+
+            withTimeout(5_000) {
+                disconnectJobs.forEach { it.join() }
+                connectJob.join()
+            }
+            assertEquals(ConnectionState.DISCONNECTED, connection.connectionState.value)
+        } finally {
+            server.stop(500, 1_000)
+        }
+    }
+
+    @Test
     fun `slow consumer receives messages in order under sustained backpressure`() = runBlocking {
         val messageCount = 200 // Well above buffer size of 64
         val server = embeddedServer(CIO, port = 0) {

--- a/kotlin/remote/ktor/src/jvmTest/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnectionTest.kt
+++ b/kotlin/remote/ktor/src/jvmTest/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnectionTest.kt
@@ -525,6 +525,7 @@ class KtorWebSocketClientConnectionTest {
             // Repeat to increase chance of hitting race window
             repeat(5) {
                 val connection = KtorWebSocketClientConnection("ws://localhost:$port/test")
+                val sendsStarted = AtomicInteger(0)
 
                 val connectJob = launch(Dispatchers.Default) { connection.connect() }
                 withTimeout(5_000) {
@@ -537,6 +538,7 @@ class KtorWebSocketClientConnectionTest {
                         for (i in 0 until 20) {
                             try {
                                 connection.send("t$threadId-msg$i")
+                                sendsStarted.incrementAndGet()
                             } catch (_: IllegalStateException) {
                                 // Expected: disconnect() may close channels concurrently
                                 break
@@ -545,8 +547,10 @@ class KtorWebSocketClientConnectionTest {
                     }
                 }
 
-                // Disconnect while sends are in-flight
-                delay(5)
+                // Wait until at least some sends are in-flight, then disconnect
+                withTimeout(5_000) {
+                    while (sendsStarted.get() == 0) { delay(1) }
+                }
                 connection.disconnect()
 
                 withTimeout(10_000) {

--- a/kotlin/remote/ktor/src/jvmTest/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnectionTest.kt
+++ b/kotlin/remote/ktor/src/jvmTest/kotlin/io/flowdux/remote/ktor/KtorWebSocketClientConnectionTest.kt
@@ -526,40 +526,43 @@ class KtorWebSocketClientConnectionTest {
             repeat(5) {
                 val connection = KtorWebSocketClientConnection("ws://localhost:$port/test")
                 val sendsStarted = AtomicInteger(0)
+                try {
+                    val connectJob = launch(Dispatchers.Default) { connection.connect() }
+                    withTimeout(5_000) {
+                        connection.connectionState.first { it == ConnectionState.CONNECTED }
+                    }
 
-                val connectJob = launch(Dispatchers.Default) { connection.connect() }
-                withTimeout(5_000) {
-                    connection.connectionState.first { it == ConnectionState.CONNECTED }
-                }
-
-                // Launch sends from multiple coroutines
-                val sendJobs = (1..5).map { threadId ->
-                    launch(Dispatchers.Default) {
-                        for (i in 0 until 20) {
-                            try {
-                                connection.send("t$threadId-msg$i")
-                                sendsStarted.incrementAndGet()
-                            } catch (_: IllegalStateException) {
-                                // Expected: disconnect() may close channels concurrently
-                                break
+                    // Launch sends from multiple coroutines
+                    val sendJobs = (1..5).map { threadId ->
+                        launch(Dispatchers.Default) {
+                            for (i in 0 until 20) {
+                                try {
+                                    connection.send("t$threadId-msg$i")
+                                    sendsStarted.incrementAndGet()
+                                } catch (_: IllegalStateException) {
+                                    // Expected: disconnect() may close channels concurrently
+                                    break
+                                }
                             }
                         }
                     }
-                }
 
-                // Wait until at least some sends are in-flight, then disconnect
-                withTimeout(5_000) {
-                    while (sendsStarted.get() == 0) {
-                        delay(1)
+                    // Wait until at least one send has completed, then disconnect
+                    withTimeout(5_000) {
+                        while (sendsStarted.get() == 0) {
+                            delay(1)
+                        }
                     }
-                }
-                connection.disconnect()
+                    connection.disconnect()
 
-                withTimeout(10_000) {
-                    sendJobs.forEach { it.join() }
-                    connectJob.join()
+                    withTimeout(10_000) {
+                        sendJobs.forEach { it.join() }
+                        connectJob.join()
+                    }
+                    assertEquals(ConnectionState.DISCONNECTED, connection.connectionState.value)
+                } finally {
+                    connection.disconnect()
                 }
-                assertEquals(ConnectionState.DISCONNECTED, connection.connectionState.value)
             }
         } finally {
             server.stop(500, 1_000)
@@ -577,9 +580,10 @@ class KtorWebSocketClientConnectionTest {
             }
         }.start(wait = false)
 
+        var connection: KtorWebSocketClientConnection? = null
         try {
             val port = server.engine.resolvedConnectors().first().port
-            val connection = KtorWebSocketClientConnection("ws://localhost:$port/test")
+            connection = KtorWebSocketClientConnection("ws://localhost:$port/test")
 
             val connectJob = launch(Dispatchers.Default) { connection.connect() }
             withTimeout(5_000) {
@@ -597,6 +601,7 @@ class KtorWebSocketClientConnectionTest {
             }
             assertEquals(ConnectionState.DISCONNECTED, connection.connectionState.value)
         } finally {
+            connection?.disconnect()
             server.stop(500, 1_000)
         }
     }


### PR DESCRIPTION
## Summary
Closes #272

- Document `send()` TOCTOU guard as best-effort with `ClosedSendChannelException` as the authoritative safety net
- Add Concurrency & Thread Safety section to `KtorWebSocketClientConnection` KDoc
- Add concurrency contract to `ClientConnection` interface KDoc (`send`, `connect`, `disconnect`)
- Add stress test: concurrent `send()` + `disconnect()` (5 iterations, multi-coroutine)
- Add stress test: multiple concurrent `disconnect()` calls (10 coroutines)

## Test plan
- [x] `./gradlew :kotlin:flowdux-remote-ktor:jvmTest` — all 41 tests pass
- [x] `./gradlew :kotlin:flowdux-remote-client:jvmTest` — all tests pass
- [x] New stress tests use `runBlocking` + `Dispatchers.Default` for real multi-threaded concurrency

🤖 Generated with [Claude Code](https://claude.com/claude-code)