### PR TITLE
feat(flowdux): implement TimeTravelStore module for Dart

### DIFF
--- a/.claude/mistakes.md
+++ b/.claude/mistakes.md
@@ -12,4 +12,14 @@
 
 ---
 
-(아직 기록된 실수가 없습니다)
+### 1. Dart format 미실행으로 CI 실패
+
+- **상황**: Dart 소스 파일 작성 후 `dart format` 실행 없이 커밋 및 푸시
+- **원인**: Kotlin에는 `pre-commit` hook의 `spotlessCheck`가 있으나, Dart에는 동등한 로컬 검증이 없음. 포맷팅을 CI에만 의존
+- **규칙**: Dart 파일 수정 시 커밋 전 반드시 `dart format .` 실행. `.claude/rules/dart-quality.md` 참조
+
+### 2. close() 멱등성 누락
+
+- **상황**: `close()` 메서드에서 `_stateSubject.close()`를 `isClosed` 체크 없이 직접 호출하여 이중 close 시 에러 발생 가능
+- **원인**: 리소스 정리 메서드의 멱등성을 기본 패턴으로 인식하지 못함
+- **규칙**: `close()` / `dispose()` 구현 시 항상 `isClosed` 체크를 포함. `.claude/rules/dart-quality.md` 참조

--- a/.claude/rules/dart-quality.md
+++ b/.claude/rules/dart-quality.md
@@ -1,0 +1,11 @@
+---
+paths:
+  - "dart/**/*.dart"
+---
+
+# Dart Code Quality Rules
+
+- 커밋 전 `dart format .`을 실행하여 포맷 검증 — CI의 `dart format --set-exit-if-changed .` 실패 방지
+- `close()` / `dispose()` 메서드는 반드시 멱등성 보장 — `isClosed` 또는 상태 플래그 체크 후 정리 수행
+- BehaviorSubject, StreamController 등 리소스 close 시 `isClosed` 체크 필수
+- nullable 타입을 non-null로 캐스팅(`as S`) 금지 — 팩토리 또는 상위에서 미리 계산한 값을 전달

--- a/dart/flowdux/lib/flowdux.dart
+++ b/dart/flowdux/lib/flowdux.dart
@@ -24,3 +24,7 @@ export 'src/strategy/concurrent.dart';
 
 // Utilities
 export 'src/util/async_lock.dart';
+
+// Time Travel
+export 'src/timetravel/state_snapshot.dart';
+export 'src/timetravel/time_travel_store.dart';

--- a/dart/flowdux/lib/src/timetravel/state_snapshot.dart
+++ b/dart/flowdux/lib/src/timetravel/state_snapshot.dart
@@ -1,0 +1,66 @@
+import '../action.dart';
+
+/// Represents a snapshot of state at a specific point in time.
+///
+/// Each snapshot records the state before and after an action was applied,
+/// along with the action itself and a timestamp.
+class StateSnapshot<S, A extends Action> {
+  /// The index of this snapshot in the history list.
+  final int index;
+
+  /// The action that caused this state change. Null for the initial state.
+  final A? action;
+
+  /// The state before the action was applied. Null for the initial state.
+  final S? previousState;
+
+  /// The state after the action was applied.
+  final S currentState;
+
+  /// When this state change occurred.
+  final DateTime timestamp;
+
+  /// Creates a new [StateSnapshot].
+  const StateSnapshot({
+    required this.index,
+    this.action,
+    this.previousState,
+    required this.currentState,
+    required this.timestamp,
+  });
+
+  /// Creates a copy with the given fields replaced.
+  StateSnapshot<S, A> copyWith({int? index}) {
+    return StateSnapshot(
+      index: index ?? this.index,
+      action: action,
+      previousState: previousState,
+      currentState: currentState,
+      timestamp: timestamp,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is StateSnapshot<S, A> &&
+          runtimeType == other.runtimeType &&
+          index == other.index &&
+          action == other.action &&
+          previousState == other.previousState &&
+          currentState == other.currentState &&
+          timestamp == other.timestamp;
+
+  @override
+  int get hashCode => Object.hash(
+        index,
+        action,
+        previousState,
+        currentState,
+        timestamp,
+      );
+
+  @override
+  String toString() =>
+      'StateSnapshot(index: $index, action: $action, currentState: $currentState)';
+}

--- a/dart/flowdux/lib/src/timetravel/time_travel_store.dart
+++ b/dart/flowdux/lib/src/timetravel/time_travel_store.dart
@@ -41,28 +41,21 @@ class TimeTravelStore<S, A extends Action> {
   TimeTravelStore._({
     required Store<S, A> innerStore,
     required this.maxHistorySize,
-    S? initialState,
+    required S seedState,
     List<StateSnapshot<S, A>>? initialHistory,
   })  : _innerStore = innerStore,
-        _stateSubject = BehaviorSubject.seeded(
-          initialHistory != null && initialHistory.isNotEmpty
-              ? initialHistory.last.currentState
-              : initialState as S,
-        ) {
+        _stateSubject = BehaviorSubject.seeded(seedState) {
     if (initialHistory != null && initialHistory.isNotEmpty) {
       for (var i = 0; i < initialHistory.length; i++) {
         _history.add(initialHistory[i].copyWith(index: i));
       }
       _currentIndex = _history.length - 1;
-    } else if (initialState != null) {
+    } else {
       _history.add(StateSnapshot(
         index: 0,
-        currentState: initialState,
+        currentState: seedState,
         timestamp: DateTime.now(),
       ));
-    } else {
-      throw ArgumentError(
-          'Either initialState or initialHistory must be provided');
     }
   }
 
@@ -278,10 +271,10 @@ TimeTravelStore<S, A> _createTimeTravelStoreInternal<S, A extends Action>({
     },
   );
 
-  final effectiveInitialState = initialHistory != null &&
-          initialHistory.isNotEmpty
-      ? initialHistory.last.currentState
-      : initialState!;
+  final effectiveInitialState =
+      initialHistory != null && initialHistory.isNotEmpty
+          ? initialHistory.last.currentState
+          : initialState!;
 
   final innerStore = createStore<S, A>(
     initialState: effectiveInitialState,
@@ -294,7 +287,7 @@ TimeTravelStore<S, A> _createTimeTravelStoreInternal<S, A extends Action>({
   timeTravelStore = TimeTravelStore<S, A>._(
     innerStore: innerStore,
     maxHistorySize: maxHistorySize,
-    initialState: initialState,
+    seedState: effectiveInitialState,
     initialHistory: initialHistory,
   );
 

--- a/dart/flowdux/lib/src/timetravel/time_travel_store.dart
+++ b/dart/flowdux/lib/src/timetravel/time_travel_store.dart
@@ -1,0 +1,335 @@
+import 'package:rxdart/rxdart.dart';
+
+import '../action.dart';
+import '../error_processor.dart';
+import '../middleware.dart';
+import '../reducer.dart';
+import '../store.dart';
+import '../store_logger.dart';
+import '../util/async_lock.dart';
+import 'state_snapshot.dart';
+
+/// A store wrapper that provides time travel debugging capabilities.
+///
+/// TimeTravelStore wraps a regular [Store] and tracks all state changes
+/// in a history list, enabling undo, redo, and jump-to operations.
+///
+/// Example:
+/// ```dart
+/// final store = createTimeTravelStore<CounterState, CounterAction>(
+///   initialState: CounterState(0),
+///   reducer: counterReducer,
+/// );
+///
+/// store.dispatch(IncrementAction());
+/// store.dispatch(IncrementAction());
+/// await store.undo(); // Back to count: 1
+/// await store.redo(); // Forward to count: 2
+/// await store.jumpTo(0); // Back to initial state
+/// ```
+class TimeTravelStore<S, A extends Action> {
+  final Store<S, A> _innerStore;
+
+  /// Maximum number of history entries to keep.
+  final int maxHistorySize;
+
+  final AsyncLock _lock = AsyncLock();
+  final List<StateSnapshot<S, A>> _history = [];
+  int _currentIndex = 0;
+  final BehaviorSubject<S> _stateSubject;
+
+  TimeTravelStore._({
+    required Store<S, A> innerStore,
+    required this.maxHistorySize,
+    S? initialState,
+    List<StateSnapshot<S, A>>? initialHistory,
+  })  : _innerStore = innerStore,
+        _stateSubject = BehaviorSubject.seeded(
+          initialHistory != null && initialHistory.isNotEmpty
+              ? initialHistory.last.currentState
+              : initialState as S,
+        ) {
+    if (initialHistory != null && initialHistory.isNotEmpty) {
+      for (var i = 0; i < initialHistory.length; i++) {
+        _history.add(initialHistory[i].copyWith(index: i));
+      }
+      _currentIndex = _history.length - 1;
+    } else if (initialState != null) {
+      _history.add(StateSnapshot(
+        index: 0,
+        currentState: initialState,
+        timestamp: DateTime.now(),
+      ));
+    } else {
+      throw ArgumentError(
+          'Either initialState or initialHistory must be provided');
+    }
+  }
+
+  /// Stream of state changes.
+  ///
+  /// Emits the current state immediately upon subscription,
+  /// then emits new states whenever the state changes.
+  Stream<S> get state => _stateSubject.stream;
+
+  /// Current state value (synchronous access).
+  S get currentState => _stateSubject.value;
+
+  /// A copy of the current history list.
+  List<StateSnapshot<S, A>> get history => List.unmodifiable(_history);
+
+  /// Current position in the history.
+  int get currentIndex => _currentIndex;
+
+  /// Whether undo is available (not at the beginning of history).
+  bool get canUndo => _currentIndex > 0;
+
+  /// Whether redo is available (not at the end of history).
+  bool get canRedo => _currentIndex < _history.length - 1;
+
+  /// Whether the store has been closed.
+  bool get isClosed => _innerStore.isClosed;
+
+  /// Records a state change in the history.
+  void _recordStateChange(A action, S previousState, S newState) {
+    // Truncate future history if we're not at the end
+    if (_currentIndex < _history.length - 1) {
+      while (_history.length > _currentIndex + 1) {
+        _history.removeLast();
+      }
+    }
+
+    final newIndex = _history.length;
+    _history.add(StateSnapshot(
+      index: newIndex,
+      action: action,
+      previousState: previousState,
+      currentState: newState,
+      timestamp: DateTime.now(),
+    ));
+
+    // Enforce max history size
+    while (_history.length > maxHistorySize && _history.length > 1) {
+      _history.removeAt(0);
+      for (var i = 0; i < _history.length; i++) {
+        if (_history[i].index != i) {
+          _history[i] = _history[i].copyWith(index: i);
+        }
+      }
+    }
+
+    _currentIndex = _history.length - 1;
+    if (newState != _stateSubject.value) {
+      _stateSubject.add(newState);
+    }
+  }
+
+  /// Dispatches an action to the underlying store.
+  void dispatch(A action) {
+    _innerStore.dispatch(action);
+  }
+
+  /// Moves to the previous state in history.
+  ///
+  /// Returns `true` if undo was successful, `false` if already at the beginning.
+  Future<bool> undo() => _lock.synchronized(() async {
+        if (!canUndo) return false;
+        _currentIndex--;
+        final newState = _history[_currentIndex].currentState;
+        if (newState != _stateSubject.value) {
+          _stateSubject.add(newState);
+        }
+        return true;
+      });
+
+  /// Moves to the next state in history.
+  ///
+  /// Returns `true` if redo was successful, `false` if already at the end.
+  Future<bool> redo() => _lock.synchronized(() async {
+        if (!canRedo) return false;
+        _currentIndex++;
+        final newState = _history[_currentIndex].currentState;
+        if (newState != _stateSubject.value) {
+          _stateSubject.add(newState);
+        }
+        return true;
+      });
+
+  /// Jumps to a specific index in the history.
+  ///
+  /// Returns `true` if jump was successful, `false` if the index is out of bounds.
+  Future<bool> jumpTo(int index) => _lock.synchronized(() async {
+        if (index < 0 || index >= _history.length) return false;
+        _currentIndex = index;
+        final newState = _history[_currentIndex].currentState;
+        if (newState != _stateSubject.value) {
+          _stateSubject.add(newState);
+        }
+        return true;
+      });
+
+  /// Resets to the initial state (index 0).
+  ///
+  /// History is preserved. Returns `true` if successful.
+  Future<bool> reset() => jumpTo(0);
+
+  /// Clears all history and keeps only the current state as the new initial state.
+  Future<void> clear() => _lock.synchronized(() async {
+        final current = _stateSubject.value;
+        _history.clear();
+        _history.add(StateSnapshot(
+          index: 0,
+          currentState: current,
+          timestamp: DateTime.now(),
+        ));
+        _currentIndex = 0;
+      });
+
+  /// Closes the underlying store and releases resources.
+  Future<void> close() async {
+    await _innerStore.close();
+    await _stateSubject.close();
+  }
+}
+
+/// Creates a new [TimeTravelStore] with the given configuration.
+///
+/// Example:
+/// ```dart
+/// final store = createTimeTravelStore<CounterState, CounterAction>(
+///   initialState: CounterState(0),
+///   reducer: counterReducer,
+///   maxHistorySize: 50,
+/// );
+/// ```
+TimeTravelStore<S, A> createTimeTravelStore<S, A extends Action>({
+  required S initialState,
+  required Reducer<S, A> reducer,
+  List<Middleware<S, A>> middlewares = const [],
+  ErrorProcessor<A>? errorProcessor,
+  int maxHistorySize = 100,
+}) {
+  return _createTimeTravelStoreInternal(
+    initialState: initialState,
+    initialHistory: null,
+    reducer: reducer,
+    middlewares: middlewares,
+    errorProcessor: errorProcessor,
+    maxHistorySize: maxHistorySize,
+  );
+}
+
+/// Creates a [TimeTravelStore] from a previously saved history.
+///
+/// Throws [ArgumentError] if [initialHistory] is empty.
+///
+/// Example:
+/// ```dart
+/// final store = createTimeTravelStoreFromHistory<CounterState, CounterAction>(
+///   initialHistory: savedHistory,
+///   reducer: counterReducer,
+/// );
+/// ```
+TimeTravelStore<S, A> createTimeTravelStoreFromHistory<S, A extends Action>({
+  required List<StateSnapshot<S, A>> initialHistory,
+  required Reducer<S, A> reducer,
+  List<Middleware<S, A>> middlewares = const [],
+  ErrorProcessor<A>? errorProcessor,
+  int maxHistorySize = 100,
+}) {
+  if (initialHistory.isEmpty) {
+    throw ArgumentError('initialHistory must not be empty');
+  }
+  return _createTimeTravelStoreInternal(
+    initialState: null,
+    initialHistory: initialHistory,
+    reducer: reducer,
+    middlewares: middlewares,
+    errorProcessor: errorProcessor,
+    maxHistorySize: maxHistorySize,
+  );
+}
+
+TimeTravelStore<S, A> _createTimeTravelStoreInternal<S, A extends Action>({
+  S? initialState,
+  List<StateSnapshot<S, A>>? initialHistory,
+  required Reducer<S, A> reducer,
+  required List<Middleware<S, A>> middlewares,
+  ErrorProcessor<A>? errorProcessor,
+  required int maxHistorySize,
+}) {
+  late TimeTravelStore<S, A> timeTravelStore;
+
+  S timeTravelReducer(S _, A action) {
+    return reducer(timeTravelStore.currentState, action);
+  }
+
+  final historyLogger = _TimeTravelLogger<S, A>(
+    (action, previousState, newState) {
+      timeTravelStore._recordStateChange(
+        action,
+        timeTravelStore.currentState,
+        newState,
+      );
+    },
+  );
+
+  final effectiveInitialState = initialHistory != null &&
+          initialHistory.isNotEmpty
+      ? initialHistory.last.currentState
+      : initialState!;
+
+  final innerStore = createStore<S, A>(
+    initialState: effectiveInitialState,
+    reducer: timeTravelReducer,
+    middlewares: middlewares,
+    errorProcessor: errorProcessor,
+    logger: historyLogger,
+  );
+
+  timeTravelStore = TimeTravelStore<S, A>._(
+    innerStore: innerStore,
+    maxHistorySize: maxHistorySize,
+    initialState: initialState,
+    initialHistory: initialHistory,
+  );
+
+  return timeTravelStore;
+}
+
+/// Internal logger that records state changes for time travel.
+///
+/// Implements [StoreLogger] directly (not extending [NoOpStoreLogger])
+/// so that the Store's logging pipeline is active and [onStateReduced]
+/// is called for every state transition.
+class _TimeTravelLogger<S, A extends Action> implements StoreLogger<S, A> {
+  final void Function(A action, S previousState, S newState) _onStateReduced;
+
+  _TimeTravelLogger(this._onStateReduced);
+
+  @override
+  void onStateReduced(A action, S previousState, S newState) {
+    _onStateReduced(action, previousState, newState);
+  }
+
+  @override
+  void onActionDispatched(A action) {}
+
+  @override
+  void onMiddlewareProcessing(String middlewareName, A action) {}
+
+  @override
+  void onMiddlewaresCompleted(A action) {}
+
+  @override
+  void onFlowHolderActionEmitted(A action) {}
+
+  @override
+  void onErrorOccurred(Object error, StackTrace stackTrace) {}
+
+  @override
+  void onErrorHandled(A action) {}
+
+  @override
+  void onDispatchAfterClose(A action) {}
+}

--- a/dart/flowdux/lib/src/timetravel/time_travel_store.dart
+++ b/dart/flowdux/lib/src/timetravel/time_travel_store.dart
@@ -186,9 +186,13 @@ class TimeTravelStore<S, A extends Action> {
       });
 
   /// Closes the underlying store and releases resources.
+  ///
+  /// This method is idempotent - calling it multiple times has no effect.
   Future<void> close() async {
     await _innerStore.close();
-    await _stateSubject.close();
+    if (!_stateSubject.isClosed) {
+      await _stateSubject.close();
+    }
   }
 }
 

--- a/dart/flowdux/test/timetravel/test_fixtures.dart
+++ b/dart/flowdux/test/timetravel/test_fixtures.dart
@@ -8,8 +8,7 @@ class CounterState {
 
   @override
   bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is CounterState && count == other.count;
+      identical(this, other) || other is CounterState && count == other.count;
 
   @override
   int get hashCode => count.hashCode;

--- a/dart/flowdux/test/timetravel/test_fixtures.dart
+++ b/dart/flowdux/test/timetravel/test_fixtures.dart
@@ -1,0 +1,41 @@
+import 'package:flowdux/flowdux.dart';
+
+class CounterState {
+  final int count;
+  const CounterState([this.count = 0]);
+
+  CounterState copyWith({int? count}) => CounterState(count ?? this.count);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CounterState && count == other.count;
+
+  @override
+  int get hashCode => count.hashCode;
+
+  @override
+  String toString() => 'CounterState(count: $count)';
+}
+
+abstract class CounterAction implements Action {}
+
+class IncrementAction implements CounterAction {}
+
+class DecrementAction implements CounterAction {}
+
+class AddAction implements CounterAction {
+  final int value;
+  AddAction(this.value);
+}
+
+CounterState counterReducer(CounterState state, CounterAction action) {
+  if (action is IncrementAction) {
+    return state.copyWith(count: state.count + 1);
+  } else if (action is DecrementAction) {
+    return state.copyWith(count: state.count - 1);
+  } else if (action is AddAction) {
+    return state.copyWith(count: state.count + action.value);
+  }
+  return state;
+}

--- a/dart/flowdux/test/timetravel/time_travel_store_test.dart
+++ b/dart/flowdux/test/timetravel/time_travel_store_test.dart
@@ -1,0 +1,431 @@
+import 'package:flowdux/flowdux.dart';
+import 'package:test/test.dart';
+
+import 'test_fixtures.dart';
+
+void main() {
+  group('TimeTravelStore', () {
+    test('initial state is recorded in history', () {
+      final store = createTimeTravelStore<CounterState, CounterAction>(
+        initialState: CounterState(5),
+        reducer: counterReducer,
+      );
+
+      expect(store.history.length, 1);
+      expect(store.currentIndex, 0);
+      expect(store.history[0].currentState.count, 5);
+      expect(store.history[0].action, isNull);
+      expect(store.history[0].previousState, isNull);
+
+      store.close();
+    });
+
+    test('dispatch records state changes in history', () async {
+      final store = createTimeTravelStore<CounterState, CounterAction>(
+        initialState: CounterState(),
+        reducer: counterReducer,
+      );
+
+      final states = <CounterState>[];
+      store.state.listen(states.add);
+
+      store.dispatch(IncrementAction());
+      await Future.delayed(Duration(milliseconds: 50));
+
+      store.dispatch(AddAction(10));
+      await Future.delayed(Duration(milliseconds: 50));
+
+      expect(store.history.length, 3);
+      expect(store.currentIndex, 2);
+
+      expect(store.history[0].currentState.count, 0);
+      expect(store.history[1].currentState.count, 1);
+      expect(store.history[2].currentState.count, 11);
+
+      expect(store.history[1].action, isA<IncrementAction>());
+      expect(store.history[2].action, isA<AddAction>());
+
+      await store.close();
+    });
+
+    test('undo moves to previous state', () async {
+      final store = createTimeTravelStore<CounterState, CounterAction>(
+        initialState: CounterState(),
+        reducer: counterReducer,
+      );
+
+      store.dispatch(IncrementAction());
+      await Future.delayed(Duration(milliseconds: 50));
+
+      store.dispatch(IncrementAction());
+      await Future.delayed(Duration(milliseconds: 50));
+
+      expect(store.currentState.count, 2);
+
+      expect(store.canUndo, true);
+      expect(await store.undo(), true);
+      expect(store.currentState.count, 1);
+      expect(store.currentIndex, 1);
+
+      expect(await store.undo(), true);
+      expect(store.currentState.count, 0);
+      expect(store.currentIndex, 0);
+
+      expect(store.canUndo, false);
+      expect(await store.undo(), false);
+
+      await store.close();
+    });
+
+    test('redo moves to next state', () async {
+      final store = createTimeTravelStore<CounterState, CounterAction>(
+        initialState: CounterState(),
+        reducer: counterReducer,
+      );
+
+      store.dispatch(IncrementAction());
+      await Future.delayed(Duration(milliseconds: 50));
+
+      store.dispatch(IncrementAction());
+      await Future.delayed(Duration(milliseconds: 50));
+
+      await store.undo();
+      await store.undo();
+      expect(store.currentState.count, 0);
+
+      expect(store.canRedo, true);
+      expect(await store.redo(), true);
+      expect(store.currentState.count, 1);
+      expect(store.currentIndex, 1);
+
+      expect(await store.redo(), true);
+      expect(store.currentState.count, 2);
+      expect(store.currentIndex, 2);
+
+      expect(store.canRedo, false);
+      expect(await store.redo(), false);
+
+      await store.close();
+    });
+
+    test('jumpTo moves to specific state', () async {
+      final store = createTimeTravelStore<CounterState, CounterAction>(
+        initialState: CounterState(),
+        reducer: counterReducer,
+      );
+
+      store.dispatch(AddAction(10));
+      await Future.delayed(Duration(milliseconds: 50));
+
+      store.dispatch(AddAction(20));
+      await Future.delayed(Duration(milliseconds: 50));
+
+      store.dispatch(AddAction(30));
+      await Future.delayed(Duration(milliseconds: 50));
+
+      expect(await store.jumpTo(1), true);
+      expect(store.currentState.count, 10);
+      expect(store.currentIndex, 1);
+
+      expect(await store.jumpTo(3), true);
+      expect(store.currentState.count, 60);
+      expect(store.currentIndex, 3);
+
+      expect(await store.jumpTo(0), true);
+      expect(store.currentState.count, 0);
+      expect(store.currentIndex, 0);
+
+      expect(await store.jumpTo(-1), false);
+      expect(await store.jumpTo(100), false);
+
+      await store.close();
+    });
+
+    test('dispatch from past state truncates future history', () async {
+      final store = createTimeTravelStore<CounterState, CounterAction>(
+        initialState: CounterState(),
+        reducer: counterReducer,
+      );
+
+      store.dispatch(AddAction(10));
+      await Future.delayed(Duration(milliseconds: 50));
+
+      store.dispatch(AddAction(20));
+      await Future.delayed(Duration(milliseconds: 50));
+
+      store.dispatch(AddAction(30));
+      await Future.delayed(Duration(milliseconds: 50));
+
+      expect(store.history.length, 4);
+
+      await store.jumpTo(1);
+      expect(store.currentState.count, 10);
+
+      store.dispatch(AddAction(5));
+      await Future.delayed(Duration(milliseconds: 50));
+
+      expect(store.currentState.count, 15);
+      expect(store.history.length, 3);
+      expect(store.currentIndex, 2);
+      expect(store.history[0].currentState.count, 0);
+      expect(store.history[1].currentState.count, 10);
+      expect(store.history[2].currentState.count, 15);
+
+      await store.close();
+    });
+
+    test('reset moves to initial state', () async {
+      final store = createTimeTravelStore<CounterState, CounterAction>(
+        initialState: CounterState(),
+        reducer: counterReducer,
+      );
+
+      store.dispatch(AddAction(10));
+      await Future.delayed(Duration(milliseconds: 50));
+
+      store.dispatch(AddAction(20));
+      await Future.delayed(Duration(milliseconds: 50));
+
+      expect(await store.reset(), true);
+      expect(store.currentState.count, 0);
+      expect(store.currentIndex, 0);
+      expect(store.history.length, 3);
+
+      await store.close();
+    });
+
+    test('clear resets history with current state', () async {
+      final store = createTimeTravelStore<CounterState, CounterAction>(
+        initialState: CounterState(),
+        reducer: counterReducer,
+      );
+
+      store.dispatch(AddAction(10));
+      await Future.delayed(Duration(milliseconds: 50));
+
+      store.dispatch(AddAction(20));
+      await Future.delayed(Duration(milliseconds: 50));
+
+      await store.clear();
+
+      expect(store.history.length, 1);
+      expect(store.currentIndex, 0);
+      expect(store.history[0].currentState.count, 30);
+      expect(store.currentState.count, 30);
+
+      await store.close();
+    });
+
+    test('maxHistorySize limits history', () async {
+      final store = createTimeTravelStore<CounterState, CounterAction>(
+        initialState: CounterState(),
+        reducer: counterReducer,
+        maxHistorySize: 3,
+      );
+
+      store.dispatch(AddAction(1));
+      await Future.delayed(Duration(milliseconds: 50));
+
+      store.dispatch(AddAction(2));
+      await Future.delayed(Duration(milliseconds: 50));
+
+      expect(store.history.length, 3);
+
+      store.dispatch(AddAction(3));
+      await Future.delayed(Duration(milliseconds: 50));
+
+      expect(store.history.length, 3);
+      expect(store.currentIndex, 2);
+      expect(store.history[0].currentState.count, 1);
+      expect(store.history[1].currentState.count, 3);
+      expect(store.history[2].currentState.count, 6);
+
+      store.dispatch(AddAction(4));
+      await Future.delayed(Duration(milliseconds: 50));
+
+      expect(store.history.length, 3);
+      expect(store.currentIndex, 2);
+      expect(store.history[0].currentState.count, 3);
+      expect(store.history[1].currentState.count, 6);
+      expect(store.history[2].currentState.count, 10);
+
+      await store.close();
+    });
+
+    test('close prevents further dispatch', () async {
+      final store = createTimeTravelStore<CounterState, CounterAction>(
+        initialState: CounterState(),
+        reducer: counterReducer,
+      );
+
+      expect(store.isClosed, false);
+
+      await store.close();
+
+      expect(store.isClosed, true);
+    });
+
+    test('timestamps are recorded', () async {
+      final store = createTimeTravelStore<CounterState, CounterAction>(
+        initialState: CounterState(),
+        reducer: counterReducer,
+      );
+
+      final beforeDispatch = DateTime.now();
+
+      store.dispatch(IncrementAction());
+      await Future.delayed(Duration(milliseconds: 50));
+
+      final afterDispatch = DateTime.now();
+
+      final snapshot = store.history[1];
+      expect(
+        snapshot.timestamp.isAfter(beforeDispatch) ||
+            snapshot.timestamp.isAtSameMomentAs(beforeDispatch),
+        true,
+      );
+      expect(
+        snapshot.timestamp.isBefore(afterDispatch) ||
+            snapshot.timestamp.isAtSameMomentAs(afterDispatch),
+        true,
+      );
+
+      await store.close();
+    });
+
+    test('history indices are correct after truncation', () async {
+      final store = createTimeTravelStore<CounterState, CounterAction>(
+        initialState: CounterState(),
+        reducer: counterReducer,
+        maxHistorySize: 5,
+      );
+
+      for (var i = 0; i < 10; i++) {
+        store.dispatch(AddAction(i + 1));
+        await Future.delayed(Duration(milliseconds: 50));
+      }
+
+      for (var i = 0; i < store.history.length; i++) {
+        expect(store.history[i].index, i);
+      }
+
+      await store.close();
+    });
+
+    test('initialHistory restores history and state', () async {
+      final savedHistory = <StateSnapshot<CounterState, CounterAction>>[
+        StateSnapshot(
+          index: 0,
+          currentState: CounterState(0),
+          timestamp: DateTime.fromMillisecondsSinceEpoch(1000),
+        ),
+        StateSnapshot(
+          index: 1,
+          action: AddAction(10),
+          previousState: CounterState(0),
+          currentState: CounterState(10),
+          timestamp: DateTime.fromMillisecondsSinceEpoch(2000),
+        ),
+        StateSnapshot(
+          index: 2,
+          action: AddAction(20),
+          previousState: CounterState(10),
+          currentState: CounterState(30),
+          timestamp: DateTime.fromMillisecondsSinceEpoch(3000),
+        ),
+      ];
+
+      final store =
+          createTimeTravelStoreFromHistory<CounterState, CounterAction>(
+        initialHistory: savedHistory,
+        reducer: counterReducer,
+      );
+
+      expect(store.history.length, 3);
+      expect(store.currentIndex, 2);
+      expect(store.currentState.count, 30);
+
+      expect(store.canUndo, true);
+      expect(store.canRedo, false);
+
+      await store.undo();
+      expect(store.currentState.count, 10);
+
+      await store.undo();
+      expect(store.currentState.count, 0);
+
+      await store.close();
+    });
+
+    test('initialHistory allows dispatch to continue from restored state',
+        () async {
+      final savedHistory = <StateSnapshot<CounterState, CounterAction>>[
+        StateSnapshot(
+          index: 0,
+          currentState: CounterState(100),
+          timestamp: DateTime.fromMillisecondsSinceEpoch(1000),
+        ),
+      ];
+
+      final store =
+          createTimeTravelStoreFromHistory<CounterState, CounterAction>(
+        initialHistory: savedHistory,
+        reducer: counterReducer,
+      );
+
+      expect(store.currentState.count, 100);
+
+      store.dispatch(AddAction(50));
+      await Future.delayed(Duration(milliseconds: 50));
+
+      expect(store.currentState.count, 150);
+      expect(store.history.length, 2);
+      expect(store.history[0].currentState.count, 100);
+      expect(store.history[1].currentState.count, 150);
+
+      await store.close();
+    });
+
+    test('empty initialHistory throws exception', () {
+      expect(
+        () => createTimeTravelStoreFromHistory<CounterState, CounterAction>(
+          initialHistory: [],
+          reducer: counterReducer,
+        ),
+        throwsA(isA<ArgumentError>().having(
+          (e) => e.message,
+          'message',
+          'initialHistory must not be empty',
+        )),
+      );
+    });
+
+    test('canUndo and canRedo reflect navigation state', () async {
+      final store = createTimeTravelStore<CounterState, CounterAction>(
+        initialState: CounterState(),
+        reducer: counterReducer,
+      );
+
+      expect(store.canUndo, false);
+      expect(store.canRedo, false);
+
+      store.dispatch(IncrementAction());
+      await Future.delayed(Duration(milliseconds: 50));
+
+      expect(store.canUndo, true);
+      expect(store.canRedo, false);
+
+      await store.undo();
+
+      expect(store.canUndo, false);
+      expect(store.canRedo, true);
+
+      await store.redo();
+
+      expect(store.canUndo, true);
+      expect(store.canRedo, false);
+
+      await store.close();
+    });
+  });
+}

--- a/dart/flowdux/test/timetravel/time_travel_store_test.dart
+++ b/dart/flowdux/test/timetravel/time_travel_store_test.dart
@@ -5,7 +5,7 @@ import 'test_fixtures.dart';
 
 void main() {
   group('TimeTravelStore', () {
-    test('initial state is recorded in history', () {
+    test('initial state is recorded in history', () async {
       final store = createTimeTravelStore<CounterState, CounterAction>(
         initialState: CounterState(5),
         reducer: counterReducer,
@@ -17,7 +17,7 @@ void main() {
       expect(store.history[0].action, isNull);
       expect(store.history[0].previousState, isNull);
 
-      store.close();
+      await store.close();
     });
 
     test('dispatch records state changes in history', () async {

--- a/dart/samples/timetravel/bin/main.dart
+++ b/dart/samples/timetravel/bin/main.dart
@@ -1,0 +1,148 @@
+import 'dart:io';
+
+import 'package:flowdux/flowdux.dart';
+
+// State
+class CounterState {
+  final int count;
+  const CounterState([this.count = 0]);
+
+  CounterState copyWith({int? count}) => CounterState(count ?? this.count);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CounterState && count == other.count;
+
+  @override
+  int get hashCode => count.hashCode;
+
+  @override
+  String toString() => 'CounterState(count: $count)';
+}
+
+// Actions
+abstract class CounterAction implements Action {}
+
+class IncrementAction implements CounterAction {}
+
+class DecrementAction implements CounterAction {}
+
+// Reducer
+CounterState counterReducer(CounterState state, CounterAction action) {
+  if (action is IncrementAction) {
+    return state.copyWith(count: state.count + 1);
+  } else if (action is DecrementAction) {
+    return state.copyWith(count: state.count - 1);
+  }
+  return state;
+}
+
+void main() async {
+  final store = createTimeTravelStore<CounterState, CounterAction>(
+    initialState: CounterState(),
+    reducer: counterReducer,
+  );
+
+  store.state.listen((state) {
+    // State changes are printed by the command handler
+  });
+
+  print('=== TimeTravelStore Sample ===');
+  print('Commands:');
+  print('  +       Increment counter');
+  print('  -       Decrement counter');
+  print('  u       Undo');
+  print('  r       Redo');
+  print('  j <n>   Jump to history index n');
+  print('  h       Show history');
+  print('  c       Clear history');
+  print('  q       Quit');
+  print('');
+
+  _printState(store);
+
+  while (true) {
+    stdout.write('> ');
+    final input = stdin.readLineSync()?.trim();
+    if (input == null || input == 'q') {
+      print('Goodbye!');
+      break;
+    }
+
+    if (input.isEmpty) continue;
+
+    switch (input) {
+      case '+':
+        store.dispatch(IncrementAction());
+        await Future.delayed(Duration(milliseconds: 50));
+        _printState(store);
+      case '-':
+        store.dispatch(DecrementAction());
+        await Future.delayed(Duration(milliseconds: 50));
+        _printState(store);
+      case 'u':
+        final success = await store.undo();
+        if (success) {
+          _printState(store);
+        } else {
+          print('  Cannot undo (at beginning of history)');
+        }
+      case 'r':
+        final success = await store.redo();
+        if (success) {
+          _printState(store);
+        } else {
+          print('  Cannot redo (at end of history)');
+        }
+      case 'h':
+        _printHistory(store);
+      case 'c':
+        await store.clear();
+        print('  History cleared');
+        _printState(store);
+      default:
+        if (input.startsWith('j ')) {
+          final indexStr = input.substring(2).trim();
+          final index = int.tryParse(indexStr);
+          if (index == null) {
+            print('  Invalid index: $indexStr');
+          } else {
+            final success = await store.jumpTo(index);
+            if (success) {
+              _printState(store);
+            } else {
+              print('  Invalid index: $index (valid: 0..${store.history.length - 1})');
+            }
+          }
+        } else {
+          print('  Unknown command: $input');
+        }
+    }
+  }
+
+  await store.close();
+}
+
+void _printState(TimeTravelStore<CounterState, CounterAction> store) {
+  final undo = store.canUndo ? 'Y' : 'N';
+  final redo = store.canRedo ? 'Y' : 'N';
+  print(
+    '  count: ${store.currentState.count}'
+    '  [index: ${store.currentIndex}/${store.history.length - 1}]'
+    '  undo: $undo  redo: $redo',
+  );
+}
+
+void _printHistory(TimeTravelStore<CounterState, CounterAction> store) {
+  print('  History (${store.history.length} entries):');
+  for (final snapshot in store.history) {
+    final marker = snapshot.index == store.currentIndex ? ' <<' : '';
+    final action =
+        snapshot.action != null ? snapshot.action.runtimeType.toString() : '-';
+    print(
+      '    [${snapshot.index}] count: ${snapshot.currentState.count}'
+      '  action: $action$marker',
+    );
+  }
+}

--- a/dart/samples/timetravel/bin/main.dart
+++ b/dart/samples/timetravel/bin/main.dart
@@ -44,10 +44,6 @@ void main() async {
     reducer: counterReducer,
   );
 
-  store.state.listen((state) {
-    // State changes are printed by the command handler
-  });
-
   print('=== TimeTravelStore Sample ===');
   print('Commands:');
   print('  +       Increment counter');

--- a/dart/samples/timetravel/pubspec.yaml
+++ b/dart/samples/timetravel/pubspec.yaml
@@ -1,0 +1,10 @@
+name: timetravel_sample
+description: TimeTravelStore CLI sample app — interactive counter with undo/redo
+version: 0.1.0
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  flowdux:
+    path: ../../flowdux

--- a/docs/issue/279/context.md
+++ b/docs/issue/279/context.md
@@ -1,0 +1,55 @@
+# 컨텍스트 — 이슈 #279: feat(dart): implement TimeTravelStore module
+
+## 배경
+
+Kotlin FlowDux에는 `flowdux-timetravel` 모듈이 있어 디버깅 시 상태 히스토리를 추적하고 undo/redo/jumpTo를 지원합니다. Dart 버전에는 아직 이 기능이 없으며, Kotlin 구현을 포팅하여 Dart/Flutter 개발자도 동일한 디버깅 기능을 사용할 수 있도록 합니다.
+
+## 관련 자료
+
+- GitHub 이슈: #279
+- Kotlin 구현: `kotlin/timetravel/src/commonMain/kotlin/io/flowdux/timetravel/`
+  - `TimeTravelStore.kt` — 핵심 래퍼 클래스 (235줄)
+  - `StateSnapshot.kt` — 상태 스냅샷 데이터 클래스
+- Kotlin 테스트: `kotlin/timetravel/src/commonTest/kotlin/io/flowdux/timetravel/TimeTravelStoreTest.kt` (16개 테스트)
+- Dart 기존 코어: `dart/flowdux/lib/src/` — Store, Action, Reducer, Middleware 등
+- 설계 문서: `docs/design/plan-dart-version.md`
+- 사용 가이드: `docs/guide/timetravel.md` (Kotlin 버전)
+
+## 논의 사항
+
+### 2026-03-24: 패키지 구조 결정
+
+Kotlin은 별도 모듈(`flowdux-timetravel`)로 분리되어 있으나, Dart 버전은 `dart/flowdux` 패키지 내 `lib/src/timetravel/` 서브디렉토리로 포함하기로 결정. 이유: Dart 패키지는 아직 초기 단계이고, 별도 pub.dev 패키지로 분리하기엔 이른 시점.
+
+### 2026-03-24: Kotlin ↔ Dart 매핑
+
+| Kotlin | Dart | 비고 |
+|--------|------|------|
+| `StateFlow<S>` | `BehaviorSubject<S>` (rxdart) | 동기 접근 + 스트림 |
+| `Mutex` | `AsyncLock` | 기존 구현 재사용 |
+| `suspend fun` | `Future<T>` | |
+| `Long` (epochMillis) | `DateTime` | Dart 관용적 타입 |
+| `CoroutineScope` | 불필요 | Dart 단일 스레드 |
+| Factory overloading | `createTimeTravelStore` + `createTimeTravelStoreFromHistory` | Dart는 함수 오버로딩 없음 |
+
+### 2026-03-24: 샘플 앱 추가
+
+이슈 #279에 CLI 기반 Counter 샘플 앱 포함하기로 결정. `dart/samples/timetravel/` 위치에 생성. 인터랙티브 명령으로 +/-, undo, redo, jumpTo, history, clear, quit 지원.
+
+## 결정 사항
+
+| # | 결정 | 이유 | 날짜 |
+|---|------|------|------|
+| 1 | `dart/flowdux` 패키지 내 서브디렉토리로 구현 | 별도 패키지 분리는 이른 시점 | 2026-03-24 |
+| 2 | `BehaviorSubject` 사용 (rxdart) | 기존 Store와 동일한 패턴, 동기 접근 필요 | 2026-03-24 |
+| 3 | `AsyncLock` 재사용 | 기존 `dart/flowdux/lib/src/util/async_lock.dart` 활용 | 2026-03-24 |
+| 4 | `StoreLogger` 통해 상태 변경 가로채기 | Kotlin과 동일한 패턴 | 2026-03-24 |
+| 5 | 함수 이름 분리: `createTimeTravelStore` + `createTimeTravelStoreFromHistory` | Dart 함수 오버로딩 불가 | 2026-03-24 |
+| 6 | CLI 샘플 앱 포함 | 사용법 시연 및 사용자 체험 | 2026-03-24 |
+
+## 제약 조건
+
+- Dart는 단일 스레드 (isolate 기반) — 진정한 동시성 제어 불필요, async interleaving만 방지
+- rxdart 0.28.0 의존성 (기존 flowdux 패키지에 이미 포함)
+- Dart 3.0+ 필요 (sealed class 등)
+- `freezed` 패키지 미사용 — 수동 `==`/`hashCode` 구현

--- a/docs/issue/279/plan.md
+++ b/docs/issue/279/plan.md
@@ -69,7 +69,7 @@ Kotlin의 `flowdux-timetravel` 모듈을 Dart로 포팅합니다. 디버깅 시 
   7. reset → 초기 상태로 복원
   8. clear → 히스토리 초기화, 현재 상태 유지
   9. maxHistorySize 초과 시 오래된 항목 제거
-  10. close 후 dispatch throws
+  10. close 후 isClosed 확인 (dispatch는 무시됨 — Store 동작과 일치)
   11. 타임스탬프 기록 확인
   12. 히스토리 인덱스 순차 확인
   13. fromHistory 복원

--- a/docs/issue/279/plan.md
+++ b/docs/issue/279/plan.md
@@ -1,0 +1,103 @@
+# 작업계획서 — 이슈 #279: feat(dart): implement TimeTravelStore module
+
+## 개요
+
+Kotlin의 `flowdux-timetravel` 모듈을 Dart로 포팅합니다. 디버깅 시 상태 히스토리를 추적하고 undo/redo/jumpTo를 지원하는 TimeTravelStore를 구현합니다.
+
+## 브랜치 정보
+
+- 브랜치: `feature/279-dart-timetravel`
+- 타겟: `develop`
+- 유형: `feat`
+- 스코프: `flowdux`
+
+## 수정 대상
+
+| # | 파일 | 변경 내용 | 이유 |
+|---|------|----------|------|
+| 1 | `dart/flowdux/lib/src/timetravel/state_snapshot.dart` | StateSnapshot 데이터 클래스 생성 | 히스토리 항목 표현 |
+| 2 | `dart/flowdux/lib/src/timetravel/time_travel_store.dart` | TimeTravelStore 래퍼 클래스 생성 | undo/redo/jumpTo 핵심 로직 |
+| 3 | `dart/flowdux/lib/src/timetravel/create_time_travel_store.dart` | 팩토리 함수 생성 | Store 생성 진입점 |
+| 4 | `dart/flowdux/lib/flowdux.dart` | barrel export에 timetravel 추가 | 외부에서 import 가능하도록 |
+| 5 | `dart/flowdux/test/timetravel/time_travel_store_test.dart` | 16+ 테스트 케이스 작성 | Kotlin 테스트 포팅 |
+| 6 | `dart/flowdux/test/timetravel/test_fixtures.dart` | 테스트용 Counter State/Action/Reducer | 테스트 헬퍼 |
+| 7 | `dart/samples/timetravel/bin/main.dart` | CLI 샘플 앱 | TimeTravelStore 사용법 시연 |
+| 8 | `dart/samples/timetravel/pubspec.yaml` | 샘플 앱 패키지 설정 | 의존성 관리 |
+
+## 단계별 계획
+
+### Step 1: StateSnapshot 데이터 클래스
+
+- [ ] `dart/flowdux/lib/src/timetravel/state_snapshot.dart` 생성
+  - `StateSnapshot<S, A extends Action>` — immutable 클래스
+  - 필드: `index`, `action` (nullable), `previousState` (nullable), `currentState`, `timestamp` (DateTime)
+  - `toString()`, `==`, `hashCode` 구현
+
+### Step 2: TimeTravelStore 핵심 구현
+
+- [ ] `dart/flowdux/lib/src/timetravel/time_travel_store.dart` 생성
+  - `TimeTravelStore<S, A extends Action>` 래퍼 클래스
+  - 내부 Store를 감싸고 StoreLogger를 통해 상태 변경 가로채기
+  - 프로퍼티: `state` (Stream), `currentState`, `history`, `currentIndex`, `canUndo`, `canRedo`, `isClosed`
+  - 메서드: `dispatch()`, `undo()`, `redo()`, `jumpTo()`, `reset()`, `clear()`, `close()`
+  - `AsyncLock` 사용하여 동시 접근 방지
+  - `maxHistorySize` 초과 시 오래된 항목 제거
+  - dispatch 시 현재 인덱스 이후 히스토리 truncate
+  - BehaviorSubject로 상태 스트림 관리
+
+### Step 3: createTimeTravelStore 팩토리 함수
+
+- [ ] `dart/flowdux/lib/src/timetravel/create_time_travel_store.dart` 생성
+  - `createTimeTravelStore()` — 새 Store 생성 (initialState 기반)
+  - `createTimeTravelStoreFromHistory()` — 기존 히스토리로 복원
+  - 내부적으로 Store 생성 후 TimeTravelStore로 감싸기
+
+### Step 4: Barrel export 업데이트
+
+- [ ] `dart/flowdux/lib/flowdux.dart`에 timetravel 파일 export 추가
+
+### Step 5: 테스트 작성
+
+- [ ] `dart/flowdux/test/timetravel/test_fixtures.dart` — CounterState, CounterAction, counterReducer
+- [ ] `dart/flowdux/test/timetravel/time_travel_store_test.dart` — Kotlin 16개 테스트 포팅:
+  1. 초기 상태가 history[0]에 기록
+  2. dispatch 시 히스토리에 상태 기록
+  3. undo/redo 왕복 동작
+  4. jumpTo 정상 동작
+  5. jumpTo 경계값 (0, 끝, 범위 밖)
+  6. dispatch 후 undo → dispatch → redo 불가 (히스토리 truncate)
+  7. reset → 초기 상태로 복원
+  8. clear → 히스토리 초기화, 현재 상태 유지
+  9. maxHistorySize 초과 시 오래된 항목 제거
+  10. close 후 dispatch throws
+  11. 타임스탬프 기록 확인
+  12. 히스토리 인덱스 순차 확인
+  13. fromHistory 복원
+  14. fromHistory 후 dispatch
+  15. 빈 initialHistory → ArgumentError
+  16. canUndo/canRedo 상태 확인
+
+### Step 6: CLI 샘플 앱
+
+- [ ] `dart/samples/timetravel/pubspec.yaml` 생성
+- [ ] `dart/samples/timetravel/bin/main.dart` 생성
+  - Counter 상태를 TimeTravelStore로 관리
+  - CLI 인터랙티브 명령: +/-, u(undo), r(redo), j(jumpTo), h(history), c(clear), q(quit)
+
+## 검증 방법
+
+- `cd dart/flowdux && dart test test/timetravel/` — 전체 timetravel 테스트 실행
+- `cd dart/flowdux && dart test` — 전체 패키지 테스트 (기존 테스트 깨지지 않음 확인)
+- `cd dart/samples/timetravel && dart run` — 샘플 앱 실행 확인
+- `dart analyze dart/flowdux` — 정적 분석 통과
+
+## 진행 상태
+
+| Step | 상태 | 비고 |
+|------|------|------|
+| Step 1 | ✅ 완료 | StateSnapshot |
+| Step 2 | ✅ 완료 | TimeTravelStore (factory 함수 포함) |
+| Step 3 | ✅ 완료 | Factory functions (Step 2에 통합) |
+| Step 4 | ✅ 완료 | Barrel export |
+| Step 5 | ✅ 완료 | Tests (16개) |
+| Step 6 | ✅ 완료 | CLI sample |

--- a/docs/issue/279/result.md
+++ b/docs/issue/279/result.md
@@ -1,0 +1,39 @@
+# 결과문서 — 이슈 #279: feat(dart): implement TimeTravelStore module
+
+## 초기 평가
+
+| # | 항목 | 평가 | 상세 |
+|---|------|------|------|
+| 1 | 완성도 | ✅ | plan.md 6개 Step 전부 완료 |
+| 2 | 정확성 | ✅ | 이슈 요구사항 전체 충족, Kotlin 기능 대등성 확보 |
+| 3 | 코드 품질 | ✅ | 기존 컨벤션 준수 (Store 패턴, 팩토리, import 스타일) |
+| 4 | 테스트 | ✅ | 16/16 통과, 전체 121개 회귀 없음 |
+| 5 | 문서 일관성 | ✅ | context.md 6개 결정사항 전부 반영 |
+
+## 수정 내역
+
+즉시 수정 항목 없음. 3라운드 Copilot 리뷰에서 지적된 사항은 모두 PR 과정에서 반영 완료:
+- `close()` 멱등성 보장 (`_stateSubject.isClosed` 체크)
+- `initialState as S` 안전하지 않은 cast → `seedState` 파라미터로 리팩터링
+- `await store.close()` 테스트 수정
+- plan.md 문구 수정 ("close 후 dispatch throws" → "close 후 isClosed 확인")
+
+## 등록된 이슈
+
+| # | 이슈 | 제목 | 사유 |
+|---|------|------|------|
+| 1 | #284 | feat(dart): sync middleware state with TimeTravelStore after undo/redo | undo/redo 후 내부 Store의 middleware 상태 불일치 (Kotlin 동일 제한) |
+| 2 | #285 | test(dart): add middleware integration tests for TimeTravelStore | middleware 조합 테스트 누락 (현재 Kotlin 범위와 동일하나 추후 확장 필요) |
+
+## 참고 사항
+
+- `Future.delayed(50ms)` 패턴은 기존 store_test.dart와 동일하며 현재 CI에서 안정적. 장기적으로 non-timing-dependent 방식 전환 고려
+- `_recordStateChange`의 maxHistorySize 재인덱싱은 이론적 O(n^2)이나 실질적으로 1회 실행 (기본 크기 100)
+- 팩토리 함수를 별도 파일 대신 `time_travel_store.dart`에 통합 — Dart private 접근 제한 및 Kotlin 구조와 일치
+
+## 최종 요약
+
+- **작업 범위**: 10 files, +1225 lines (소스 3, 테스트 2, 샘플 2, 문서 3)
+- **결과**: 성공
+- **후속 작업**: #284 (middleware 상태 동기화), #285 (middleware 통합 테스트)
+- **PR**: #283

--- a/docs/issue/279/review-log.md
+++ b/docs/issue/279/review-log.md
@@ -38,3 +38,27 @@
 | # | 파일 | 코멘트 | 대응 |
 |---|------|--------|------|
 | 1 | time_travel_store.dart:123 | plan.md에 "close 후 dispatch throws"라고 기술되어 있으나 실제 동작은 무시 | 수정 — plan.md 문구를 실제 동작에 맞게 수정 |
+
+## 작업 완료 리뷰 (issue-review)
+
+- **리뷰어**: Agent (general-purpose)
+- **시점**: PR 머지 전
+
+| # | 항목 | 평가 | 상세 |
+|---|------|------|------|
+| 1 | 완성도 | ✅ | plan.md 6개 Step 전부 완료 |
+| 2 | 정확성 | ✅ | 이슈 요구사항 전체 충족, Kotlin 기능 대등성 확보 |
+| 3 | 코드 품질 | ✅ | 기존 컨벤션 준수 (Store 패턴, 팩토리, import 스타일) |
+| 4 | 테스트 | ✅ | 16/16 통과, 전체 121개 회귀 없음 |
+| 5 | 문서 일관성 | ✅ | context.md 6개 결정사항 전부 반영 |
+
+### 즉시 수정
+
+없음.
+
+### 이슈 등록
+
+| # | 이슈 | 제목 |
+|---|------|------|
+| 1 | #284 | feat(dart): sync middleware state with TimeTravelStore after undo/redo |
+| 2 | #285 | test(dart): add middleware integration tests for TimeTravelStore |

--- a/docs/issue/279/review-log.md
+++ b/docs/issue/279/review-log.md
@@ -12,3 +12,15 @@
 | 3 | WARNING | time_travel_store.dart | maxHistorySize 재인덱싱 O(n^2) | 스킵 — Kotlin과 동일 패턴, 기본 크기 100에서 성능 문제 없음 |
 | 4 | WARNING | time_travel_store_test.dart | `Future.delayed(50ms)` 사용 — CI에서 flaky 가능 | 스킵 — 기존 테스트 패턴과 동일 (store_test.dart 참조) |
 | 5 | WARNING | main.dart (sample) | 미사용 stream subscription 누수 | 수정 — 불필요한 no-op listener 제거 |
+
+## Copilot 리뷰
+
+- **리뷰어**: GitHub Copilot (`copilot-pull-request-reviewer[bot]`)
+
+### Round 1 (commit: 5ab0c2c)
+
+| # | 파일 | 코멘트 | 대응 |
+|---|------|--------|------|
+| 1 | time_travel_store.dart:191 | `close()` 비멱등 — BehaviorSubject.close() 이중호출 문제 | 수정 — `_stateSubject.isClosed` 체크 추가 |
+| 2 | time_travel_store_test.dart:21 | `store.close()` await 누락 | 수정 — `await store.close()` 로 변경 |
+| 3 | review-log.md:11 | 테이블 `||` 포맷 오류 지적 | 스킵 — 실제 파일 확인 시 정상 마크다운 (`| # |` 형식). Copilot 오탐. |

--- a/docs/issue/279/review-log.md
+++ b/docs/issue/279/review-log.md
@@ -24,3 +24,11 @@
 | 1 | time_travel_store.dart:191 | `close()` 비멱등 — BehaviorSubject.close() 이중호출 문제 | 수정 — `_stateSubject.isClosed` 체크 추가 |
 | 2 | time_travel_store_test.dart:21 | `store.close()` await 누락 | 수정 — `await store.close()` 로 변경 |
 | 3 | review-log.md:11 | 테이블 `||` 포맷 오류 지적 | 스킵 — 실제 파일 확인 시 정상 마크다운 (`| # |` 형식). Copilot 오탐. |
+
+### Round 2 (commit: f822396)
+
+| # | 파일 | 코멘트 | 대응 |
+|---|------|--------|------|
+| 1 | time_travel_store.dart:66 | `initialState as S` cast — 검증 전에 TypeError 발생 가능 | 수정 — 생성자를 `seedState` 파라미터로 리팩터링. 팩토리에서 미리 계산한 seed를 전달하여 cast 제거. |
+| 2 | time_travel_store.dart:292 | undo/redo 후 내부 Store의 currentState가 middleware와 불일치 | 스킵 — Kotlin 구현과 동일한 알려진 제한. TimeTravelStore는 디버깅 도구이며, middleware 상태 동기화는 향후 개선 사항. |
+| 3 | time_travel_store_test.dart:12 | middleware 동작 테스트 누락 | 스킵 — Kotlin 테스트 스위트와 1:1 포팅 범위. middleware 테스트는 향후 이슈로 추적 가능. |

--- a/docs/issue/279/review-log.md
+++ b/docs/issue/279/review-log.md
@@ -32,3 +32,9 @@
 | 1 | time_travel_store.dart:66 | `initialState as S` cast — 검증 전에 TypeError 발생 가능 | 수정 — 생성자를 `seedState` 파라미터로 리팩터링. 팩토리에서 미리 계산한 seed를 전달하여 cast 제거. |
 | 2 | time_travel_store.dart:292 | undo/redo 후 내부 Store의 currentState가 middleware와 불일치 | 스킵 — Kotlin 구현과 동일한 알려진 제한. TimeTravelStore는 디버깅 도구이며, middleware 상태 동기화는 향후 개선 사항. |
 | 3 | time_travel_store_test.dart:12 | middleware 동작 테스트 누락 | 스킵 — Kotlin 테스트 스위트와 1:1 포팅 범위. middleware 테스트는 향후 이슈로 추적 가능. |
+
+### Round 3 (commit: 3a4014b)
+
+| # | 파일 | 코멘트 | 대응 |
+|---|------|--------|------|
+| 1 | time_travel_store.dart:123 | plan.md에 "close 후 dispatch throws"라고 기술되어 있으나 실제 동작은 무시 | 수정 — plan.md 문구를 실제 동작에 맞게 수정 |

--- a/docs/issue/279/review-log.md
+++ b/docs/issue/279/review-log.md
@@ -1,0 +1,14 @@
+# 리뷰 로그 — 이슈 #279
+
+## 로컬 코드 리뷰
+
+- **리뷰어**: Agent (general-purpose)
+- **시점**: PR 생성 전
+
+| # | 심각도 | 파일 | 내용 | 대응 |
+|---|--------|------|------|------|
+| 1 | CRITICAL | time_travel_store.dart | `_recordStateChange`에 `previousState` 대신 `timeTravelStore.currentState` 사용 | 스킵 — 의도된 설계. undo/redo 후 내부 Store의 previousState와 TTS의 currentState가 다를 수 있으며, reducer에 입력된 TTS의 currentState가 올바른 previousState. Kotlin 구현과 동일 패턴. |
+| 2 | WARNING | time_travel_store.dart | `_recordStateChange`가 AsyncLock 미사용 | 스킵 — 동기 함수이며 Dart 단일 스레드 모델에서 async interleaving 발생 없음 |
+| 3 | WARNING | time_travel_store.dart | maxHistorySize 재인덱싱 O(n^2) | 스킵 — Kotlin과 동일 패턴, 기본 크기 100에서 성능 문제 없음 |
+| 4 | WARNING | time_travel_store_test.dart | `Future.delayed(50ms)` 사용 — CI에서 flaky 가능 | 스킵 — 기존 테스트 패턴과 동일 (store_test.dart 참조) |
+| 5 | WARNING | main.dart (sample) | 미사용 stream subscription 누수 | 수정 — 불필요한 no-op listener 제거 |


### PR DESCRIPTION
## Summary

Kotlin의 `flowdux-timetravel` 모듈을 Dart로 포팅합니다.

- `StateSnapshot<S, A>` — 상태 히스토리 스냅샷 데이터 클래스
- `TimeTravelStore<S, A>` — Store 래퍼 (undo/redo/jumpTo/reset/clear)
- `createTimeTravelStore()` / `createTimeTravelStoreFromHistory()` — 팩토리 함수
- 16개 테스트 (Kotlin 테스트 포팅)
- CLI 샘플 앱 (`dart/samples/timetravel/`)

Closes #279

## Test plan

- [x] `dart test test/timetravel/` — 16/16 통과
- [x] `dart test` — 기존 테스트 포함 121/121 통과
- [x] `dart analyze` — 에러/경고 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)