### PR TITLE
feat(flutter): add lifecycle-aware StoreScope widget #286

### DIFF
--- a/dart/flowdux_flutter/CHANGELOG.md
+++ b/dart/flowdux_flutter/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `StoreScope` widget — lifecycle-aware provider that creates a `Store` exactly
+  once via `create` and closes it on dispose. Safe to use inside `PageRoute`
+  builders and other contexts where the build function may be invoked
+  repeatedly. (#286)
+
 ## [0.2.5] - 2026-02-04
 
 ### Fixed

--- a/dart/flowdux_flutter/README.md
+++ b/dart/flowdux_flutter/README.md
@@ -8,6 +8,7 @@ Flutter bindings for [FlowDux](https://pub.dev/packages/flowdux) state managemen
 ## Features
 
 - **StoreProvider** - Provide store to widget tree via InheritedWidget
+- **StoreScope** - Lifecycle-aware provider that creates/closes a store automatically
 - **StoreBuilder** - Rebuild widgets when state changes
 - **StoreSelector** - Optimized rebuilds with selectors
 - **StoreConsumer** - Access both store and state
@@ -97,6 +98,31 @@ final store = context.store<AppState, AppAction>();
 // Safe access (returns null if not found)
 final store = StoreProvider.maybeOf<AppState, AppAction>(context);
 ```
+
+### StoreScope
+
+Owns a store's lifecycle: creates it once via `create` and closes it on dispose.
+Use this anywhere the build function may run multiple times — e.g. inside a
+`PageRoute`'s `pageBuilder`, a custom route builder, or a `NestedRoute`. Without
+it, building a fresh `Store` inline causes the store to be replaced on rebuild
+while child `State` objects keep stale references, dropping dispatched actions
+silently.
+
+```dart
+PageRouteBuilder(
+  pageBuilder: (_, __, ___) => StoreScope<AppState, AppAction>(
+    create: () => createStore<AppState, AppAction>(
+      initialState: AppState(),
+      reducer: appReducer,
+    ),
+    child: MyScreen(),
+  ),
+);
+```
+
+The created store is exposed to descendants via `StoreProvider`, so all the
+widgets below (`StoreBuilder`, `StoreSelector`, `StoreConsumer`,
+`StoreListener`, `context.store`, `context.dispatch`) work unchanged.
 
 ### StoreBuilder
 

--- a/dart/flowdux_flutter/lib/flowdux_flutter.dart
+++ b/dart/flowdux_flutter/lib/flowdux_flutter.dart
@@ -61,5 +61,6 @@ library flowdux_flutter;
 export 'package:flowdux/flowdux.dart';
 
 export 'src/store_provider.dart';
+export 'src/store_scope.dart';
 export 'src/store_builder.dart';
 export 'src/store_consumer.dart';

--- a/dart/flowdux_flutter/lib/src/store_scope.dart
+++ b/dart/flowdux_flutter/lib/src/store_scope.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/widgets.dart' hide Action;
+import 'package:flowdux/flowdux.dart';
+
+import 'store_provider.dart';
+
+/// Provides a [Store] with lifecycle ownership.
+///
+/// Unlike [StoreProvider], which expects an externally-managed [Store],
+/// [StoreScope] creates the store via [create] exactly once in [State.initState]
+/// and closes it in [State.dispose]. This makes it safe to use in places where
+/// the build function may run multiple times — e.g. inside a `PageRoute`'s
+/// `pageBuilder`, a `NestedRoute` builder, or any custom route builder that
+/// rebuilds on system events such as keyboard/theme/`MediaQuery` changes.
+///
+/// Without this widget, building a fresh [Store] inline in a route builder
+/// causes the store to be replaced on every rebuild while child [State]
+/// objects retain stale references, dropping dispatched actions and resetting
+/// derived state silently.
+///
+/// Example — store-per-screen via a route builder:
+/// ```dart
+/// PageRouteBuilder(
+///   pageBuilder: (_, __, ___) => StoreScope<AppState, AppAction>(
+///     create: () => createStore<AppState, AppAction>(
+///       initialState: AppState(),
+///       reducer: appReducer,
+///     ),
+///     child: MyScreen(),
+///   ),
+/// );
+/// ```
+///
+/// The created store is exposed to descendants via [StoreProvider], so all
+/// existing widgets ([StoreBuilder], [StoreSelector], [StoreConsumer],
+/// [StoreListener], `context.store`, `context.dispatch`) work unchanged.
+class StoreScope<S, A extends Action> extends StatefulWidget {
+  /// Factory invoked once in [State.initState] to create the store.
+  ///
+  /// Must return a fresh [Store]. The returned store will be closed
+  /// automatically when this widget is removed from the tree.
+  final Store<S, A> Function() create;
+
+  /// The widget below this one in the tree.
+  final Widget child;
+
+  /// Creates a [StoreScope] that owns the lifecycle of a [Store].
+  const StoreScope({super.key, required this.create, required this.child});
+
+  @override
+  State<StoreScope<S, A>> createState() => _StoreScopeState<S, A>();
+}
+
+class _StoreScopeState<S, A extends Action> extends State<StoreScope<S, A>> {
+  late final Store<S, A> _store;
+
+  @override
+  void initState() {
+    super.initState();
+    _store = widget.create();
+  }
+
+  @override
+  void dispose() {
+    _store.close();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return StoreProvider<S, A>(store: _store, child: widget.child);
+  }
+}

--- a/dart/flowdux_flutter/test/flowdux_flutter_test.dart
+++ b/dart/flowdux_flutter/test/flowdux_flutter_test.dart
@@ -390,6 +390,131 @@ void main() {
     });
   });
 
+  group('StoreScope', () {
+    testWidgets('creates store and provides it to descendants', (tester) async {
+      var createCalls = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: StoreScope<CounterState, Action>(
+            create: () {
+              createCalls++;
+              return createStore<CounterState, Action>(
+                initialState: CounterState(),
+                reducer: reducer,
+              );
+            },
+            child: Builder(
+              builder: (context) {
+                final providedStore =
+                    StoreProvider.of<CounterState, Action>(context);
+                return Text('Count: ${providedStore.currentState.count}');
+              },
+            ),
+          ),
+        ),
+      );
+
+      expect(createCalls, 1);
+      expect(find.text('Count: 0'), findsOneWidget);
+    });
+
+    testWidgets('does not recreate store across rebuilds', (tester) async {
+      var createCalls = 0;
+
+      Widget buildTree(String label) => MaterialApp(
+            home: StoreScope<CounterState, Action>(
+              create: () {
+                createCalls++;
+                return createStore<CounterState, Action>(
+                  initialState: CounterState(),
+                  reducer: reducer,
+                );
+              },
+              child: Text(label),
+            ),
+          );
+
+      await tester.pumpWidget(buildTree('first'));
+      expect(createCalls, 1);
+
+      // Rebuild parent — `create` must not run again because the State is reused.
+      await tester.pumpWidget(buildTree('second'));
+      await tester.pumpWidget(buildTree('third'));
+
+      expect(createCalls, 1);
+    });
+
+    testWidgets('closes store on dispose', (tester) async {
+      late Store<CounterState, Action> created;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: StoreScope<CounterState, Action>(
+            create: () {
+              created = createStore<CounterState, Action>(
+                initialState: CounterState(),
+                reducer: reducer,
+              );
+              return created;
+            },
+            child: const SizedBox(),
+          ),
+        ),
+      );
+
+      // Replace the tree so the StoreScope is removed and disposed.
+      await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+      await tester.pumpAndSettle();
+
+      // Dispatching after close is logged and ignored — state stays put.
+      created.dispatch(IncrementAction());
+      await tester.runAsync(() async {
+        await Future.delayed(const Duration(milliseconds: 50));
+      });
+
+      expect(created.currentState.count, 0);
+    });
+
+    testWidgets('descendants can dispatch actions through the scoped store',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: StoreScope<CounterState, Action>(
+            create: () => createStore<CounterState, Action>(
+              initialState: CounterState(),
+              reducer: reducer,
+            ),
+            child: StoreConsumer<CounterState, Action>(
+              builder: (context, store, state) {
+                return Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text('Count: ${state.count}'),
+                    ElevatedButton(
+                      onPressed: () => store.dispatch(IncrementAction()),
+                      child: const Text('Increment'),
+                    ),
+                  ],
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Count: 0'), findsOneWidget);
+
+      await tester.tap(find.text('Increment'));
+      await tester.runAsync(() async {
+        await Future.delayed(const Duration(milliseconds: 50));
+      });
+      await tester.pumpAndSettle();
+
+      expect(find.text('Count: 1'), findsOneWidget);
+    });
+  });
+
   group('StoreListener', () {
     testWidgets('calls listener on state change', (tester) async {
       final listenerCalls = <int>[];


### PR DESCRIPTION
## Summary

- Add `StoreScope` widget to `flowdux_flutter` — a lifecycle-aware provider that creates a `Store` via `create` in `initState` and closes it in `dispose`.
- Safe to use inside `PageRoute.pageBuilder` and other contexts where the build function may be invoked repeatedly (theme/`MediaQuery` changes, keyboard animations, etc.) — the existing `StoreProvider` would otherwise replace the store on every rebuild while child `State` objects keep stale references and silently drop dispatched actions.
- Backward-compatible additive change: descendants are wrapped in the existing `StoreProvider`, so `StoreBuilder` / `StoreSelector` / `StoreConsumer` / `StoreListener` / `context.store` / `context.dispatch` all work unchanged.

## Changes

| File | Change |
|------|--------|
| `dart/flowdux_flutter/lib/src/store_scope.dart` | New `StoreScope<S, A>` `StatefulWidget` |
| `dart/flowdux_flutter/lib/flowdux_flutter.dart` | Export new widget |
| `dart/flowdux_flutter/test/flowdux_flutter_test.dart` | 4 new tests: create-once, no-recreate-on-rebuild, close-on-dispose, descendants-can-dispatch |
| `dart/flowdux_flutter/CHANGELOG.md` | Unreleased entry |
| `dart/flowdux_flutter/README.md` | Document `StoreScope` usage |

## Test plan

- [x] `flutter test` — 17/17 passing (4 new `StoreScope` tests)
- [x] `dart format --set-exit-if-changed .` — clean
- [x] `flutter analyze --no-fatal-warnings` — no new issues
- [ ] CI: Dart Flutter job on PR

Closes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)