### PR TITLE
chore(flutter): bump flowdux_flutter to 0.3.0

### DIFF
--- a/dart/flowdux_flutter/CHANGELOG.md
+++ b/dart/flowdux_flutter/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.0] - 2026-04-28
 
 ### Added
 

--- a/dart/flowdux_flutter/README.md
+++ b/dart/flowdux_flutter/README.md
@@ -18,8 +18,8 @@ Flutter bindings for [FlowDux](https://pub.dev/packages/flowdux) state managemen
 
 ```yaml
 dependencies:
-  flowdux: ^0.2.4
-  flowdux_flutter: ^0.2.4
+  flowdux: ^0.3.2
+  flowdux_flutter: ^0.3.0
 ```
 
 ## Quick Start

--- a/dart/flowdux_flutter/pubspec.yaml
+++ b/dart/flowdux_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flowdux_flutter
 description: >
   Flutter bindings for FlowDux state management library.
-  Provides StoreProvider, StoreBuilder, and StoreConsumer widgets.
+  Provides StoreScope, StoreProvider, StoreBuilder, and StoreConsumer widgets.
 version: 0.3.0
 homepage: https://github.com/chibimoons/flowdux
 repository: https://github.com/chibimoons/flowdux

--- a/dart/flowdux_flutter/pubspec.yaml
+++ b/dart/flowdux_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: flowdux_flutter
 description: >
   Flutter bindings for FlowDux state management library.
   Provides StoreProvider, StoreBuilder, and StoreConsumer widgets.
-version: 0.2.5
+version: 0.3.0
 homepage: https://github.com/chibimoons/flowdux
 repository: https://github.com/chibimoons/flowdux
 issue_tracker: https://github.com/chibimoons/flowdux/issues


### PR DESCRIPTION
## Summary

- Bump `flowdux_flutter` to **0.3.0** for the StoreScope release (#286, merged via #287).
- Promote the `[Unreleased]` CHANGELOG entry to `[0.3.0] - 2026-04-28`.

## Note

Manual `flutter pub publish` from `dart/flowdux_flutter/` will be run after merge — the existing `publish-dart.yml` workflow couples both packages into one tag, but `flowdux` itself has no changes since 0.3.2 so the workflow is unsuitable for a flutter-only release. A follow-up PR will adjust the workflow to handle this case.

## Test plan

- [x] `flutter pub publish --dry-run` — 0 warnings
- [ ] After merge: `flutter pub publish` from `dart/flowdux_flutter/`
- [ ] Verify pub.dev shows 0.3.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)